### PR TITLE
adds noobaa-mixins as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor
 /build/_output
 /build/_test
+/jsonnet/vendor/
+/jsonnet/tmp/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VENV = $(OUTPUT)/venv
 
 # Default tasks:
 
-all: build
+all: mixins build
 	@echo "@@@ All Done."
 .PHONY: all
 
@@ -93,5 +93,32 @@ install-sdk:
 	curl https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VERSION}/operator-sdk-${SDK_VERSION}-x86_64-linux-gnu -sLo ${GOPATH}/bin/operator-sdk
 	chmod +x ${GOPATH}/bin/operator-sdk
 .PHONY: install-sdk
+
+mixins: dependencies
+	cd jsonnet && \
+	jb update && \
+	./build-jsonnet.sh make.jsonnet
+.PHONY: mixins
+
+dependencies: jb jsonnet gojsontoyaml jq
+.PHONY: dependencies
+
+jb:
+	go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+.PHONY: jb
+
+jsonnet:
+	go get -u github.com/google/go-jsonnet/cmd/jsonnet
+.PHONY: jsonnet
+
+gojsontoyaml:
+	go get -u github.com/brancz/gojsontoyaml
+.PHONY: gojsontoyaml
+
+jq:
+	wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O jq && \
+	chmod +x jq && \
+	mv jq $(GOPATH)/bin
+.PHONY: jq
 
 #TODO scorecard 

--- a/jsonnet/build-jsonnet.sh
+++ b/jsonnet/build-jsonnet.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+set -x
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+
+prefix="manifests"
+rm -rf $prefix
+mkdir $prefix
+
+rm -rf tmp
+mkdir tmp
+
+jsonnet -J vendor main.jsonnet > tmp/main.json
+
+mapfile -t files < <(jq -r 'keys[]' tmp/main.json)
+
+for file in "${files[@]}"
+do
+	dir=$(dirname "${file}")
+	path="${prefix}/${dir}"
+	mkdir -p ${path}
+    # convert file name from camelCase to snake-case
+    fullfile=$(echo "${file}" | awk '{
+
+  while ( match($0, /(.*)([a-z0-9])([A-Z])(.*)/, cap))
+      $0 = cap[1] cap[2] "-" tolower(cap[3]) cap[4];
+
+    print
+
+}')
+    jq -r ".[\"${file}\"]" tmp/main.json | gojsontoyaml > "${prefix}/${fullfile}.yaml"
+done

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "name": "noobaa-mixins",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/noobaa/noobaa-mixins",
+                    "subdir": ""
+                }
+            },
+            "version": "master"
+        }
+    ]
+}

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "name": "noobaa-mixins",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/noobaa/noobaa-mixins",
+                    "subdir": ""
+                }
+            },
+            "version": "c640daf2fc2aa88746d5187893c092e198c39cfa"
+        }
+    ]
+}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -1,0 +1,18 @@
+local noobaa = (import 'noobaa-mixins/mixin.libsonnet');
+local prometheusRule(storageNamespace, storageName, alertType, prometheusLabel) = {
+  apiVersion: 'monitoring.coreos.com/v1',
+  kind: 'PrometheusRule',
+  metadata: {
+    labels: {
+      prometheus: prometheusLabel,
+      role: 'alert-rules',
+    },
+    name: 'prometheus-' + storageName + '-rules',
+    namespace: storageNamespace,
+  },
+  spec: alertType,
+};
+
+{
+  'noobaa-prometheus-rules': prometheusRule('default', 'noobaa', noobaa.prometheusAlerts+noobaa.prometheusRules, 'k8s'),
+}

--- a/jsonnet/manifests/noobaa-prometheus-rules.yaml
+++ b/jsonnet/manifests/noobaa-prometheus-rules.yaml
@@ -1,0 +1,55 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-noobaa-rules
+  namespace: default
+spec:
+  groups:
+  - name: system-capacity-alert.rules
+    rules:
+    - alert: NooBaaSystemCapacityWarning85
+      annotations:
+        description: A NooBaa system is approaching its capacity, usage is more than
+          85%
+        message: A NooBaa System Is Approaching Its Capacity
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        NooBaa_system_capacity > 85
+      labels:
+        severity: warning
+    - alert: NooBaaSystemCapacityWarning95
+      annotations:
+        description: A NooBaa system is approaching its capacity, usage is more than
+          95%
+        message: A NooBaa System Is Approaching Its Capacity
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        NooBaa_system_capacity > 95
+      labels:
+        severity: warning
+    - alert: NooBaaSystemCapacityWarning100
+      annotations:
+        description: A NooBaa system approached its capacity, usage is at 100%
+        message: A NooBaa System Approached Its Capacity
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        NooBaa_system_capacity == 100
+      labels:
+        severity: warning
+  - name: noobaa-telemeter.rules
+    rules:
+    - expr: |
+        sum(NooBaa_num_unhealthy_buckets + NooBaa_num_unhealthy_bucket_claims)
+      record: job:NooBaa_buckets_health:sum
+    - expr: |
+        sum(NooBaa_num_buckets + NooBaa_num_buckets_claims)
+      record: job:NooBaa_bucket_count:sum
+    - expr: |
+        sum(NooBaa_num_objects + NooBaa_num_objects_buckets_claims)
+      record: job:NooBaa_total_object_count:sum


### PR DESCRIPTION
adding `jsonnet/` to pull noobaa-mixins for build and integration into noobaa-operator

`make mixins` will fetch the updated resources from noobaa-mixins and create a `noobaa-prometheus-rules.yaml` which can be used for deploying alerts. 

`kubectl create -f noobaa-prometheus-rules.yaml` or,
`oc create -f noobaa-prometheus-rules.yaml`

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>