### PR TITLE
deploy a default storage class when deploying a system

### DIFF
--- a/deploy/obc/storage_class.yaml
+++ b/deploy/obc/storage_class.yaml
@@ -1,5 +1,6 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: noobaa
+  name: noobaa-storage-class
 provisioner: noobaa.io/noobaa.bucket
+reclaimPolicy: Delete

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -129,13 +129,9 @@ func RunYaml(cmd *cobra.Command, args []string) {
 	crds := LoadCrds()
 	p := printers.YAMLPrinter{}
 	p.PrintObj(crds.NooBaa, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(crds.BackingStore, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(crds.BucketClass, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(crds.ObjectBucket, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(crds.ObjectBucketClaim, os.Stdout)
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/noobaa/noobaa-operator/build/_output/bundle"
@@ -13,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
@@ -94,6 +94,7 @@ func RunInstall(cmd *cobra.Command, args []string) {
 	util.KubeCreateSkipExisting(c.RoleBinding)
 	util.KubeCreateSkipExisting(c.ClusterRole)
 	util.KubeCreateSkipExisting(c.ClusterRoleBinding)
+	util.KubeCreateSkipExisting(c.StorageClass)
 	rbacOnly, _ := cmd.Flags().GetBool("rbac-only")
 	if !rbacOnly {
 		util.KubeCreateSkipExisting(c.Deployment)
@@ -109,6 +110,7 @@ func RunUninstall(cmd *cobra.Command, args []string) {
 	util.KubeDelete(c.RoleBinding)
 	util.KubeDelete(c.ClusterRole)
 	util.KubeDelete(c.ClusterRoleBinding)
+	util.KubeDelete(c.StorageClass)
 	util.KubeDelete(c.Deployment)
 }
 
@@ -121,6 +123,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	util.KubeCheck(c.RoleBinding)
 	util.KubeCheck(c.ClusterRole)
 	util.KubeCheck(c.ClusterRoleBinding)
+	util.KubeCheck(c.StorageClass)
 	util.KubeCheck(c.Deployment)
 }
 
@@ -129,34 +132,30 @@ func RunYaml(cmd *cobra.Command, args []string) {
 	c := LoadOperatorConf(cmd)
 	p := printers.YAMLPrinter{}
 	p.PrintObj(c.NS, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(c.SA, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(c.Role, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(c.RoleBinding, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(c.ClusterRole, os.Stdout)
-	fmt.Println("---")
 	p.PrintObj(c.ClusterRoleBinding, os.Stdout)
-	fmt.Println("---")
+	p.PrintObj(c.StorageClass, os.Stdout)
 	p.PrintObj(c.Deployment, os.Stdout)
 }
 
-// OperatorConf struct holds all the objects needed to install the operator
-type OperatorConf struct {
+// Conf struct holds all the objects needed to install the operator
+type Conf struct {
 	NS                 *corev1.Namespace
 	SA                 *corev1.ServiceAccount
 	Role               *rbacv1.Role
 	RoleBinding        *rbacv1.RoleBinding
 	ClusterRole        *rbacv1.ClusterRole
 	ClusterRoleBinding *rbacv1.ClusterRoleBinding
+	StorageClass       *storagev1.StorageClass
 	Deployment         *appsv1.Deployment
 }
 
 // LoadOperatorConf loads and initializes all the objects needed to install the operator
-func LoadOperatorConf(cmd *cobra.Command) *OperatorConf {
-	c := &OperatorConf{}
+func LoadOperatorConf(cmd *cobra.Command) *Conf {
+	c := &Conf{}
 
 	c.NS = util.KubeObject(bundle.File_deploy_namespace_yaml).(*corev1.Namespace)
 	c.SA = util.KubeObject(bundle.File_deploy_service_account_yaml).(*corev1.ServiceAccount)
@@ -164,8 +163,11 @@ func LoadOperatorConf(cmd *cobra.Command) *OperatorConf {
 	c.RoleBinding = util.KubeObject(bundle.File_deploy_role_binding_yaml).(*rbacv1.RoleBinding)
 	c.ClusterRole = util.KubeObject(bundle.File_deploy_cluster_role_yaml).(*rbacv1.ClusterRole)
 	c.ClusterRoleBinding = util.KubeObject(bundle.File_deploy_cluster_role_binding_yaml).(*rbacv1.ClusterRoleBinding)
+	c.StorageClass = util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass)
 	c.Deployment = util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
 
+	c.StorageClass.Provisioner = "noobaa.io/" + options.Namespace + ".bucket"
+	c.StorageClass.Name = options.Namespace + "-storage-class"
 	c.NS.Name = options.Namespace
 	c.SA.Namespace = options.Namespace
 	c.Role.Namespace = options.Namespace


### PR DESCRIPTION
* added storage class creation on operator installation
* storage-class name is in the format `NAMESPACE-storage-class`
* provisioner name is aligned with the name in `provisioner.go` - `noobaa.io/NAMESPACE.bucket`