### PR TITLE
Add csv templates to operator image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,15 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/noobaa-operator \
+    CSV_TEMPLATES=/etc/noobaa-csv-templates \
     USER_UID=1001 \
     USER_NAME=noobaa-operator
 
 # install operator binary
 COPY build/_output/bin/noobaa-operator ${OPERATOR}
+
+# copy csv template files
+COPY build/_output/templates ${CSV_TEMPLATES}
 
 # copy scripts
 COPY build/bin /usr/local/bin

--- a/hack/gen-csv-template.sh
+++ b/hack/gen-csv-template.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+TMP_VERSION="9999.9999.9999"
+CSV_DIR="deploy/olm-catalog/noobaa-operator/$TMP_VERSION"
+CSV_FILE="$CSV_DIR/noobaa-operator.v9999.9999.9999.clusterserviceversion.yaml"
+CRD_DIR="deploy/crds"
+OUT_DIR=build/_output/templates
+CSV_OUT_FILE="$OUT_DIR/noobaa-operator.vVERSION.clusterserviceversion.yaml.in"
+
+mkdir -p $OUT_DIR
+operator-sdk olm-catalog gen-csv --csv-version=$TMP_VERSION
+
+mv $CSV_FILE $CSV_OUT_FILE
+cp -R $CRD_DIR $OUT_DIR/
+rm -rf $CSV_DIR
+# Make csv-version and image variables
+
+sed -i "s/${TMP_VERSION}/{{.NoobaaOperatorCsvVersion}}/g" $CSV_OUT_FILE
+sed -i "s/image\:.*/image: {{.NoobaaOperatorImage}}/g" $CSV_OUT_FILE


### PR DESCRIPTION
The ocs-operator would like to consume a CSV template from the noobaa operator's container image. This template is used to merge the noobaa operator into the ocs-operators unified CSV file.

In addition to the CSV templates, I've also included the rook related CRDs in the container image for extraction.

This is a similar change to [this](https://github.com/rook/rook/pull/3634) rook pr.

**Usage Example** extracting CSV template for OCP from the noobaa container image. 

```
$ export IMAGE=<some-image>
$ docker run --rm -it --entrypoint=cat $IMAGE /etc/noobaa-csv-templates/noobaa-operator.vVERSION.clusterserviceversion.yaml.in
```

**Usage Example** list CRDs 
```
$ export IMAGE=<some-image>
$ docker run --rm -it --entrypoint=ls $IMAGE /etc/noobaa-csv-templates/crds
noobaa_v1alpha1_backingstore_cr.yaml   noobaa_v1alpha1_bucketclass_crd.yaml
noobaa_v1alpha1_backingstore_crd.yaml  noobaa_v1alpha1_noobaa_cr.yaml
noobaa_v1alpha1_bucketclass_cr.yaml    noobaa_v1alpha1_noobaa_crd.yaml

```
