### PR TITLE
fixing most gosec issues

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -8,8 +8,9 @@ package main
 
 import (
 	"github.com/noobaa/noobaa-operator/pkg/cli"
+	"github.com/noobaa/noobaa-operator/pkg/util"
 )
 
 func main() {
-	cli.Cmd().Execute()
+	util.IgnoreError(cli.Cmd().Execute())
 }

--- a/main.go
+++ b/main.go
@@ -7,8 +7,9 @@ package main
 
 import (
 	"github.com/noobaa/noobaa-operator/pkg/cli"
+	"github.com/noobaa/noobaa-operator/pkg/util"
 )
 
 func main() {
-	cli.Cmd().Execute()
+	util.IgnoreError(cli.Cmd().Execute())
 }

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -44,7 +44,7 @@ func main() {
 				return nil
 			}
 			name := compiledNameRE.ReplaceAllString(path, "_")
-			bytes, err := ioutil.ReadFile(path)
+			bytes, err := ioutil.ReadFile(filepath.Clean(path))
 			fatal(err)
 			sha256Bytes := sha256.Sum256(bytes)
 			sha256Hex := hex.EncodeToString(sha256Bytes[:])

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -119,7 +119,7 @@ func RunWait(cmd *cobra.Command, args []string) {
 // RunYaml dumps a combined yaml of all the CRDs from the bundled yamls
 func RunYaml(cmd *cobra.Command, args []string) {
 	p := printers.YAMLPrinter{}
-	ForEachCRD(func(c *CRD) { p.PrintObj(c, os.Stdout) })
+	ForEachCRD(func(c *CRD) { util.Panic(p.PrintObj(c, os.Stdout)) })
 }
 
 // LoadCrds loads the CRDs structures from the bundled yamls

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -67,7 +67,7 @@ func RunProvisioner(client client.Client, scheme *runtime.Scheme, recorder recor
 	log.Info("running noobaa provisioner ", provisionerName)
 	stopChan := make(chan struct{})
 	go func() {
-		libProv.Run(stopChan)
+		util.Panic(libProv.Run(stopChan))
 	}()
 
 	return nil

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -207,7 +207,7 @@ func RunCSV(cmd *cobra.Command, args []string) {
 	})
 
 	p := printers.YAMLPrinter{}
-	p.PrintObj(csv, os.Stdout)
+	util.Panic(p.PrintObj(csv, os.Stdout))
 }
 
 // RunPackage runs a CLI command

--- a/pkg/operator/manager.go
+++ b/pkg/operator/manager.go
@@ -63,11 +63,11 @@ func RunOperator(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed AddToManager: %s", err)
 	}
 
-	mgr.Add(manager.RunnableFunc(func(stopChan <-chan struct{}) error {
+	util.Panic(mgr.Add(manager.RunnableFunc(func(stopChan <-chan struct{}) error {
 		system.RunOperatorCreate(cmd, args)
 		<-stopChan
 		return nil
-	}))
+	})))
 
 	// // Create Service object to expose the metrics port.
 	// _, err = metrics.CreateMetricsService(util.Context(), config, metricsPort)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -130,15 +130,15 @@ func RunStatus(cmd *cobra.Command, args []string) {
 func RunYaml(cmd *cobra.Command, args []string) {
 	c := LoadOperatorConf(cmd)
 	p := printers.YAMLPrinter{}
-	p.PrintObj(c.NS, os.Stdout)
-	p.PrintObj(c.SA, os.Stdout)
-	p.PrintObj(c.Role, os.Stdout)
-	p.PrintObj(c.RoleBinding, os.Stdout)
-	p.PrintObj(c.ClusterRole, os.Stdout)
-	p.PrintObj(c.ClusterRoleBinding, os.Stdout)
+	util.Panic(p.PrintObj(c.NS, os.Stdout))
+	util.Panic(p.PrintObj(c.SA, os.Stdout))
+	util.Panic(p.PrintObj(c.Role, os.Stdout))
+	util.Panic(p.PrintObj(c.RoleBinding, os.Stdout))
+	util.Panic(p.PrintObj(c.ClusterRole, os.Stdout))
+	util.Panic(p.PrintObj(c.ClusterRoleBinding, os.Stdout))
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
-		p.PrintObj(c.Deployment, os.Stdout)
+		util.Panic(p.PrintObj(c.Deployment, os.Stdout))
 	}
 }
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -21,7 +21,7 @@ func Cmd() *cobra.Command {
 
 // RunOptions runs a CLI command
 func RunOptions(cmd *cobra.Command, args []string) {
-	cmd.Usage()
+	util.IgnoreError(cmd.Usage())
 }
 
 const (

--- a/pkg/util/fastmapper.go
+++ b/pkg/util/fastmapper.go
@@ -55,7 +55,7 @@ func (m *FastRESTMapper) Discover() error {
 			VersionedResources: make(map[string][]metav1.APIResource),
 		}
 		grs = append(grs, gr)
-		wg.Start(func() { m.DiscoverGroup(gr) })
+		wg.Start(func() { LogError(m.DiscoverGroup(gr)) })
 	}
 	wg.Wait()
 	logrus.Tracef("Filtered %d/%d", filterCount, totalCount)
@@ -80,7 +80,7 @@ func (m *FastRESTMapper) DiscoverGroup(gr *restmapper.APIGroupResources) error {
 // DiscoverOnError check if the error is NoMatchError and calls discover
 func (m *FastRESTMapper) DiscoverOnError(err error) bool {
 	if meta.IsNoMatchError(err) {
-		m.Discover()
+		LogError(m.Discover())
 		return true
 	}
 	return false

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -370,6 +370,19 @@ func Panic(err error) {
 	}
 }
 
+// LogError prints the error to the log and continue
+func LogError(err error) {
+	if err != nil {
+		log.Errorf("Error dicovered: %s", err)
+	}
+}
+
+// IgnoreError do nothing if err is not nil
+func IgnoreError(err error) {
+	if err != nil {
+	}
+}
+
 // InitLogger initializes the logrus logger with defaults
 func InitLogger() {
 	logrus.SetLevel(logrus.DebugLevel)

--- a/test/cli/cli_test.go
+++ b/test/cli/cli_test.go
@@ -38,7 +38,7 @@ func TestOptions(t *testing.T) {
 }
 
 func RunCLI(t *testing.T, args ...string) string {
-	cmd := exec.Command(CLIPath, args...)
+	cmd := exec.Command(CLIPath, args...) // #nosec
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
1. fixing error handling issues, if by panic or by ignore
2. fixing G304: Potential file inclusion via variable by using filepath.Clean in bundle.go
3. NOSEC in cli-test file so gosec will disregard it

still fails on two types of errors:
1. not verifying certificate: G402: TLS InsecureSkipVerify set true - need to be fixed with a valid certificate
2. G101: Potential hardcoded credentials -  in the build output - seems like we need gosec to skip the build/_output directory when running