### PR TITLE
reconile storage-class in system reconcile + other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build-releases/
 
 # the output of `go build`
 /noobaa-operator
+
+# visual studio code intellisense configuration
+.vscode/

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -33,6 +33,7 @@ rules:
       - get
       - list
       - watch
+      - create
   - apiGroups:
       - objectbucket.io
     resources:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -11,7 +11,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
@@ -91,7 +90,6 @@ func RunInstall(cmd *cobra.Command, args []string) {
 	util.KubeCreateSkipExisting(c.RoleBinding)
 	util.KubeCreateSkipExisting(c.ClusterRole)
 	util.KubeCreateSkipExisting(c.ClusterRoleBinding)
-	util.KubeCreateSkipExisting(c.StorageClass)
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
 		util.KubeCreateSkipExisting(c.Deployment)
@@ -110,7 +108,6 @@ func RunUninstall(cmd *cobra.Command, args []string) {
 	util.KubeDelete(c.RoleBinding)
 	util.KubeDelete(c.Role)
 	util.KubeDelete(c.SA)
-	util.KubeDelete(c.StorageClass)
 	util.KubeDelete(c.NS)
 }
 
@@ -123,7 +120,6 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	util.KubeCheck(c.RoleBinding)
 	util.KubeCheck(c.ClusterRole)
 	util.KubeCheck(c.ClusterRoleBinding)
-	util.KubeCheck(c.StorageClass)
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
 		util.KubeCheck(c.Deployment)
@@ -140,7 +136,6 @@ func RunYaml(cmd *cobra.Command, args []string) {
 	p.PrintObj(c.RoleBinding, os.Stdout)
 	p.PrintObj(c.ClusterRole, os.Stdout)
 	p.PrintObj(c.ClusterRoleBinding, os.Stdout)
-	p.PrintObj(c.StorageClass, os.Stdout)
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
 		p.PrintObj(c.Deployment, os.Stdout)
@@ -155,7 +150,6 @@ type Conf struct {
 	RoleBinding        *rbacv1.RoleBinding
 	ClusterRole        *rbacv1.ClusterRole
 	ClusterRoleBinding *rbacv1.ClusterRoleBinding
-	StorageClass       *storagev1.StorageClass
 	Deployment         *appsv1.Deployment
 }
 
@@ -169,11 +163,8 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.RoleBinding = util.KubeObject(bundle.File_deploy_role_binding_yaml).(*rbacv1.RoleBinding)
 	c.ClusterRole = util.KubeObject(bundle.File_deploy_cluster_role_yaml).(*rbacv1.ClusterRole)
 	c.ClusterRoleBinding = util.KubeObject(bundle.File_deploy_cluster_role_binding_yaml).(*rbacv1.ClusterRoleBinding)
-	c.StorageClass = util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass)
 	c.Deployment = util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
 
-	c.StorageClass.Provisioner = options.ObjectBucketProvisionerName()
-	c.StorageClass.Name = options.Namespace + "-storage-class"
 	c.NS.Name = options.Namespace
 	c.SA.Namespace = options.Namespace
 	c.Role.Namespace = options.Namespace

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -35,6 +35,28 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 	if err := r.ReconcileDefaultBackingStore(); err != nil {
 		return err
 	}
+	if err := r.ReconcileStorageClass(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ReconcileStorageClass reconciles default storage class for the system
+func (r *Reconciler) ReconcileStorageClass() error {
+	util.KubeCheck(r.StorageClass)
+
+	if r.StorageClass.UID != "" {
+		return nil
+	}
+
+	// getting error when trying to own storage class: 
+	// 		"cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on"
+	// r.Own(r.StorageClass)
+	err := r.Client.Create(r.Ctx, r.StorageClass)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -119,6 +119,10 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 		image := options.NooBaaImage
 		sys.Spec.Image = &image
 	}
+	if options.MongoImage != "" {
+		mongoImage := options.MongoImage
+		sys.Spec.MongoImage = &mongoImage
+	}
 	if options.ImagePullSecret != "" {
 		sys.Spec.ImagePullSecret = &corev1.LocalObjectReference{Name: options.ImagePullSecret}
 	}


### PR DESCRIPTION
* creating default storage class for a system when reconciling the system 
   * removed storage-class creation on operator installation from the CLI
* fixed `mongo-image` flag that was ignored by `noobaa` CLI
* gitignore additions
