### PR TITLE
use RGW as default backing store when not in AWS (disabled)

### DIFF
--- a/deploy/internal/ceph-objectstore-user.yaml
+++ b/deploy/internal/ceph-objectstore-user.yaml
@@ -1,0 +1,7 @@
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: CEPH_OBJ_USER_NAME
+spec:
+  store: STORE_NAME
+  displayName: my display name

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -71,3 +71,21 @@ rules:
   - update
   - list
   - watch
+- apiGroups:
+  - ceph.rook.io
+  resources:
+  - cephobjectstores
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ceph.rook.io
+  resources:
+  - cephobjectstoreusers
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/openshift/custom-resource-status v0.0.0-20190801200128-4c95b3a336cd
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36 // 0.11.0
 	github.com/operator-framework/operator-sdk v0.10.0
+	github.com/rook/rook v1.1.2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rook/rook v1.1.2 h1:I5VYFIR+LpxULZWY2VHwZ3s5LcXc1IYJnNTAGDh7C3I=
+github.com/rook/rook v1.1.2/go.mod h1:r2r56HUT9OJw4APhDhfOfqnzrCgl+YB1i+gfHb+gr64=
 github.com/russross/blackfriday v0.0.0-20151117072312-300106c228d5/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -728,6 +728,17 @@ spec:
     storage: true
 `
 
+const Sha256_deploy_internal_ceph_objectstore_user_yaml = "9b60853f585d771e484854e34fc59adf56a6edb6acb1315eb2ea02b59d213755"
+
+const File_deploy_internal_ceph_objectstore_user_yaml = `apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: CEPH_OBJ_USER_NAME
+spec:
+  store: STORE_NAME
+  displayName: my display name
+`
+
 const Sha256_deploy_internal_cloud_creds_aws_cr_yaml = "8e4159bc3470c135b611b6d9f4338612be0e6ea381d5061cc79e84a7eec0ab6a"
 
 const File_deploy_internal_cloud_creds_aws_cr_yaml = `apiVersion: cloudcredential.openshift.io/v1
@@ -1119,7 +1130,7 @@ spec:
           mountPath: /data
 `
 
-const Sha256_deploy_internal_text_system_status_readme_progress_tmpl = "57be05bce16a38083799e1d559b4a418ea61148e98248deecea891459b8fdb7d"
+const Sha256_deploy_internal_text_system_status_readme_progress_tmpl = "d26aa1028e4a235018cc46e00392d3209d3e09e8320f3692be6346a9cfdf289a"
 
 const File_deploy_internal_text_system_status_readme_progress_tmpl = `
 
@@ -1133,14 +1144,19 @@ const File_deploy_internal_text_system_status_readme_progress_tmpl = `
 	You can wait for a specific condition with:
 
 		kubectl -n {{.NooBaa.Namespace}} wait noobaa/noobaa --for condition=available --timeout -1s
+
+	NooBaa Core Version:     {{.CoreVersion}}
+	NooBaa Operator Version: {{.OperatorVersion}}
 `
 
-const Sha256_deploy_internal_text_system_status_readme_ready_tmpl = "1c28f7e0548ab5f128b514738d049061e26aded743194297457a356b5a611cd9"
+const Sha256_deploy_internal_text_system_status_readme_ready_tmpl = "d2d8a51e85e4d75ee15f70b4e0baaf514149ae1a3678475a057a5ce04c6a0157"
 
 const File_deploy_internal_text_system_status_readme_ready_tmpl = `
 
 	Welcome to NooBaa!
 	-----------------
+	NooBaa Core Version:     {{.CoreVersion}}
+	NooBaa Operator Version: {{.OperatorVersion}}
 
 	Lets get started:
 
@@ -1165,7 +1181,7 @@ const File_deploy_internal_text_system_status_readme_ready_tmpl = `
 
 `
 
-const Sha256_deploy_internal_text_system_status_readme_rejected_tmpl = "2f1f771446dab18d71c23e79baeb6ab02cf1773f6881c6d1ab8797d434b78044"
+const Sha256_deploy_internal_text_system_status_readme_rejected_tmpl = "32d46b0a1eadbe10501b2b3a6529503c76c0c77e25464f56f4ee9fd9115100c4"
 
 const File_deploy_internal_text_system_status_readme_rejected_tmpl = `
 	ERROR: NooBaa operator cannot reconcile this system spec.
@@ -1177,6 +1193,9 @@ const File_deploy_internal_text_system_status_readme_rejected_tmpl = `
 		kubectl -n {{.NooBaa.Namespace}} get events --sort-by=metadata.creationTimestamp
 
 	In order to retry, edit the system spec and the operator is watching and will be notified.
+
+	NooBaa Core Version:     {{.CoreVersion}}
+	NooBaa Operator Version: {{.OperatorVersion}}
 `
 
 const Sha256_deploy_namespace_yaml = "303398323535d7f8229cb1a5378ad019cf4fa7930891688e3eea55c77e7bf69a"
@@ -1761,7 +1780,7 @@ spec:
                   fieldPath: metadata.namespace
 `
 
-const Sha256_deploy_role_yaml = "363502fb9e7745c5568256ee6ab8e02441232deed40ed73753a529fd66338cd9"
+const Sha256_deploy_role_yaml = "11b92df609b86787c9fea9d6c4fb37e3d2a71295c2bb4f669dfdd3d9a8634508"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -1830,6 +1849,24 @@ rules:
   - cloudcredential.openshift.io
   resources:
   - credentialsrequests
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+- apiGroups:
+  - ceph.rook.io
+  resources:
+  - cephobjectstores
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ceph.rook.io
+  resources:
+  - cephobjectstoreusers
   verbs:
   - get
   - create

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -17,6 +17,7 @@ import (
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	semver "github.com/hashicorp/go-version"
 	cloudcredsv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -74,6 +75,7 @@ type Reconciler struct {
 	PrometheusRule      *monitoringv1.PrometheusRule
 	ServiceMonitor      *monitoringv1.ServiceMonitor
 	SystemInfo          *nb.SystemInfo
+	CephObjectstoreUser *cephv1.CephObjectStoreUser
 }
 
 // NewReconciler initializes a reconciler to be used for loading or reconciling a noobaa system
@@ -106,6 +108,7 @@ func NewReconciler(
 		OBCStorageClass:     util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass),
 		PrometheusRule:      util.KubeObject(bundle.File_deploy_internal_prometheus_rules_yaml).(*monitoringv1.PrometheusRule),
 		ServiceMonitor:      util.KubeObject(bundle.File_deploy_internal_service_monitor_yaml).(*monitoringv1.ServiceMonitor),
+		CephObjectstoreUser: util.KubeObject(bundle.File_deploy_internal_ceph_objectstore_user_yaml).(*cephv1.CephObjectStoreUser),
 	}
 
 	// Set Namespace
@@ -122,6 +125,7 @@ func NewReconciler(
 	r.DefaultBucketClass.Namespace = r.Request.Namespace
 	r.PrometheusRule.Namespace = r.Request.Namespace
 	r.ServiceMonitor.Namespace = r.Request.Namespace
+	r.CephObjectstoreUser.Namespace = r.Request.Namespace
 
 	// Set Names
 	r.NooBaa.Name = r.Request.Name
@@ -133,6 +137,7 @@ func NewReconciler(
 	r.SecretAdmin.Name = r.Request.Name + "-admin"
 	r.CloudCreds.Name = r.Request.Name + "-cloud-creds"
 	r.CloudCreds.Spec.SecretRef.Name = r.Request.Name + "-cloud-creds-secret"
+	r.CephObjectstoreUser.Name = r.Request.Name + "-ceph-objectstore-user"
 	r.DefaultBackingStore.Name = r.Request.Name + "-default-backing-store"
 	r.DefaultBucketClass.Name = r.Request.Name + "-default-bucket-class"
 	r.PrometheusRule.Name = r.Request.Name + "-prometheus-rules"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,6 +18,7 @@ import (
 	cloudcredsv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	operv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +51,7 @@ func init() {
 	Panic(monitoringv1.AddToScheme(scheme.Scheme))
 	Panic(cloudcredsv1.AddToScheme(scheme.Scheme))
 	Panic(operv1.AddToScheme(scheme.Scheme))
+	Panic(cephv1.AddToScheme(scheme.Scheme))
 }
 
 // KubeConfig loads kubernetes client config from default locations (flags, user dir, etc)
@@ -77,6 +79,7 @@ func MapperProvider(config *rest.Config) (meta.RESTMapper, error) {
 				g.Name == "operator.openshift.io" ||
 				g.Name == "cloudcredential.openshift.io" ||
 				g.Name == "monitoring.coreos.com" ||
+				g.Name == "ceph.rook.io" ||
 				strings.HasSuffix(g.Name, ".k8s.io") {
 				return true
 			}


### PR DESCRIPTION
* When not in AWS try to create a `CephObjectstoreUser` to use as a default backing store
* This is still commented out until OCS issue is resolved (https://github.com/openshift/ocs-operator/issues/191)