### PR TITLE
use us-east-1 as the default aws region when failing to parse from node name

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -205,7 +205,12 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 	log.Infof("Secret %s was created succesfully by cloud-credentials operator", r.CloudCreds.Spec.SecretRef.Name)
 
 	// create the acutual S3 bucket
-	region := util.GetAWSRegion()
+	region, err := util.GetAWSRegion()
+	if err != nil {
+		r.Recorder.Eventf(r.NooBaa, corev1.EventTypeWarning, "DefaultBackingStoreFailure",
+			"Failed to get AWSRegion. using	 us-east-1 as the default region. %q", err)
+		region = "us-east-1"
+	}
 	r.Logger.Infof("identified aws region %s", region)
 	s3Config := &aws.Config{
 		Credentials: credentials.NewStaticCredentials(


### PR DESCRIPTION
* removed calls to `panic` from `GetAWSRegion` in `util.go`. returns error instead
* on errors - generate an event and use `us-east-1` as default 
* Fixes #90 