### PR TITLE
Create of secure OpenShift routes for NooBaa services (mgmt/s3)- OpenShift only

### DIFF
--- a/deploy/internal/route-mgmt.yaml
+++ b/deploy/internal/route-mgmt.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: noobaa
+  name: noobaa-mgmt
+spec:
+  port:
+    targetPort: mgmt-https
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: noobaa-mgmt
+    weight: 100
+  wildcardPolicy: None

--- a/deploy/internal/route-s3.yaml
+++ b/deploy/internal/route-s3.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: noobaa
+  name: s3
+spec:
+  port:
+    targetPort: s3-https
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: s3
+    weight: 100
+  wildcardPolicy: None

--- a/deploy/internal/service-mgmt.yaml
+++ b/deploy/internal/service-mgmt.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/scheme: http
     prometheus.io/port: "8080"
+    service.beta.openshift.io/serving-cert-secret-name: noobaa-mgmt-serving-cert
 spec:
   type: LoadBalancer
   selector:

--- a/deploy/internal/service-s3.yaml
+++ b/deploy/internal/service-s3.yaml
@@ -4,6 +4,8 @@ metadata:
   name: s3
   labels:
     app: noobaa
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
 spec:
   type: LoadBalancer
   selector:

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -35,6 +35,14 @@ spec:
       volumes:
       - name: logs
         emptyDir: {}
+      - name: mgmt-secret
+        secret:
+          secretName: noobaa-mgmt-serving-cert
+          optional: true
+      - name: s3-secret
+        secret:
+          secretName: noobaa-s3-serving-cert
+          optional: true
       initContainers:
 #----------------#
 # INIT CONTAINER #
@@ -58,6 +66,12 @@ spec:
         volumeMounts:
         - name: logs
           mountPath: /log
+        - name: mgmt-secret
+          mountPath: /etc/mgmt-secret
+          readOnly: true
+        - name: s3-secret
+          mountPath: /etc/s3-secret
+          readOnly: true
         readinessProbe:
           tcpSocket:
             port: 6001 # ready when s3 port is open

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -97,3 +97,14 @@ rules:
   - update
   - list
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20190924175516-f3ba69cc601e
+	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190614194054-1ccced634f6c
 	github.com/openshift/custom-resource-status v0.0.0-20190801200128-4c95b3a336cd
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36 // 0.11.0

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,7 @@ github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible h1:q2JBuObKafI7B4Eli6eLd+2T5JsU9ioWZ82zQwyjJPg=
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/cloud-credential-operator v0.0.0-20190614194054-1ccced634f6c h1:0WFbd1aDMdmpfpcdBOn5Ps5WSzYAJKRS95Iqum9DcJc=

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -905,6 +905,46 @@ spec:
         severity: critical
 `
 
+const Sha256_deploy_internal_route_mgmt_yaml = "009b63d885a54d3d17f3fa5c8e52ec1de91f4a07463f59a2901757d8a2af414d"
+
+const File_deploy_internal_route_mgmt_yaml = `apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: noobaa
+  name: SYSNAME-mgmt
+spec:
+  port:
+    targetPort: mgmt-https
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: SYSNAME-mgmt
+    weight: 100
+  wildcardPolicy: None
+`
+
+const Sha256_deploy_internal_route_s3_yaml = "16789c6b4fa6e6e05661488eb1312fd9ca0d161c3dfc19433515025303bd398a"
+
+const File_deploy_internal_route_s3_yaml = `apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: noobaa
+  name: SYSNAME-s3
+spec:
+  port:
+    targetPort: s3-https
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: SYSNAME-s3
+    weight: 100
+  wildcardPolicy: None
+`
+
 const Sha256_deploy_internal_secret_empty_yaml = "d63aaeaf7f9c7c1421fcc138ee2f31d2461de0dec2f68120bc9cce367d4d4186"
 
 const File_deploy_internal_secret_empty_yaml = `apiVersion: v1
@@ -916,7 +956,7 @@ type: Opaque
 data: {}
 `
 
-const Sha256_deploy_internal_service_mgmt_yaml = "14afee25800613df32344779addc74507951fbc2a31f639cfc190a0e56a5f29e"
+const Sha256_deploy_internal_service_mgmt_yaml = "332658e2a61828d7dfa406ebc1a65b4bc1e5dcec3c27a6f476f10b53f41d7107"
 
 const File_deploy_internal_service_mgmt_yaml = `apiVersion: v1
 kind: Service
@@ -928,6 +968,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/scheme: http
     prometheus.io/port: "8080"
+    service.beta.openshift.io/serving-cert-secret-name: "noobaa-mgmt-serving-cert"
 spec:
   type: LoadBalancer
   selector:
@@ -964,7 +1005,7 @@ spec:
       app: noobaa
 `
 
-const Sha256_deploy_internal_service_s3_yaml = "bfd8c420ca27482a996a9adfa0c8890fdd596850a3dbfd8c10d3ebaae1b5cc89"
+const Sha256_deploy_internal_service_s3_yaml = "220a8196a5937ca7763bcedf3ea42e9ed6dd99cbfc38dd428a884d2712a7a3bd"
 
 const File_deploy_internal_service_s3_yaml = `apiVersion: v1
 kind: Service
@@ -972,6 +1013,8 @@ metadata:
   name: s3
   labels:
     app: noobaa
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
 spec:
   type: LoadBalancer
   selector:
@@ -985,7 +1028,7 @@ spec:
       name: s3-https
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "1f9a19c4b334c3ef2854c8317d62ebbf49aba52f8221c8a434c5b1d808c9be2e"
+const Sha256_deploy_internal_statefulset_core_yaml = "660d5e608ea94afe048dfbdcf8b9cf705d40b42e2172287f02f989bb8273f8e8"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -1024,6 +1067,12 @@ spec:
       volumes:
       - name: logs
         emptyDir: {}
+      - name: mgmt-secret
+        secret:
+          secretName: noobaa-mgmt-serving-cert
+      - name: s3-secret
+        secret:
+          secretName: noobaa-s3-serving-cert
       initContainers:
 #----------------#
 # INIT CONTAINER #
@@ -1047,6 +1096,12 @@ spec:
         volumeMounts:
         - name: logs
           mountPath: /log
+        - name: mgmt-secret
+          mountPath: /etc/mgmt-secret
+          readOnly: true
+        - name: s3-secret
+          mountPath: /etc/s3-secret
+          readOnly: true
         readinessProbe:
           tcpSocket:
             port: 6001 # ready when s3 port is open
@@ -1780,7 +1835,7 @@ spec:
                   fieldPath: metadata.namespace
 `
 
-const Sha256_deploy_role_yaml = "c505b808b24f44248bb52f96464e89ac839ee2968daa84167155091206e4ce97"
+const Sha256_deploy_role_yaml = "26c988090a0b9e2b50e2ffc225476534c3916d75ecb4d67e434a514eab52824c"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -1881,6 +1936,17 @@ rules:
   - update
   - list
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+
 `
 
 const Sha256_deploy_role_binding_yaml = "59a2627156ed3db9cd1a4d9c47e8c1044279c65e84d79c525e51274329cb16ff"

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -46,6 +46,12 @@ func (r *Reconciler) ReconcilePhaseCreating() error {
 	if err := r.ReconcileObject(r.ServiceS3, r.SetDesiredServiceS3); err != nil {
 		return err
 	}
+	if err := r.ReconcileObjectOptional(r.RouteMgmt, nil); err != nil {
+		return err
+	}
+	if err := r.ReconcileObjectOptional(r.RouteS3, nil); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	routev1 "github.com/openshift/api/route/v1"
 )
 
 var (
@@ -52,6 +53,7 @@ func init() {
 	Panic(cloudcredsv1.AddToScheme(scheme.Scheme))
 	Panic(operv1.AddToScheme(scheme.Scheme))
 	Panic(cephv1.AddToScheme(scheme.Scheme))
+	Panic(routev1.AddToScheme(scheme.Scheme))
 }
 
 // KubeConfig loads kubernetes client config from default locations (flags, user dir, etc)
@@ -77,6 +79,7 @@ func MapperProvider(config *rest.Config) (meta.RESTMapper, error) {
 				g.Name == "noobaa.io" ||
 				g.Name == "objectbucket.io" ||
 				g.Name == "operator.openshift.io" ||
+				g.Name == "route.openshift.io" ||
 				g.Name == "cloudcredential.openshift.io" ||
 				g.Name == "monitoring.coreos.com" ||
 				g.Name == "ceph.rook.io" ||
@@ -639,7 +642,7 @@ func IsAWSPlatform() bool {
 
 // GetAWSRegion parses the region from a node's name
 func GetAWSRegion() (string, error) {
-	// parse the node name to get AWS region according to this: 
+	// parse the node name to get AWS region according to this:
 	// https://docs.aws.amazon.com/en_pv/vpc/latest/userguide/vpc-dns.html#vpc-dns-hostnames
 	var mapValidAWSRegions = map[string]string{
 		"compute-1":      "us-east-1",


### PR DESCRIPTION
- Generate a secret holding a certificate for each service (using OpenShift serving cert mechanism)
- Mount the secrets as folders in the noobaa-core pod (to be used by the core  for TLS communication)
- Create a secure route for each service the serve using the ingress operator cert and re-encrypt using the cert generated for each service.