### PR TITLE
Add OAuth2 support

### DIFF
--- a/deploy/auth_delegator_cluster_role_binding.yaml
+++ b/deploy/auth_delegator_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: noobaa.noobaa.io:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: noobaa
+    namespace: noobaa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -113,6 +113,10 @@ spec:
           value: ""
         - name: OAUTH_TOKEN_ENDPOINT
           value: ""
+        - name: NOOBAA_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: container_dbg
           value: "" # any non-empty value will set the container to dbg mode
         - name: CONTAINER_CPU_REQUEST

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: noobaa
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.noobaa-mgmt: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"noobaa-mgmt"}}'

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2,6 +2,22 @@ package bundle
 
 const Version = "2.0.6-wip"
 
+const Sha256_deploy_auth_delegator_cluster_role_binding_yaml = "7fd16a58f7ae0b9ecf8043536ce37a83673ab7e2c2df8f5a1690f919e81ae186"
+
+const File_deploy_auth_delegator_cluster_role_binding_yaml = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: noobaa.noobaa.io:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: noobaa
+    namespace: noobaa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+`
+
 const Sha256_deploy_cluster_role_yaml = "f719ff8e0015a73d4e6ff322d2b30efa1cc89fcb3f856c06a5910785cb9e8dd8"
 
 const File_deploy_cluster_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
@@ -1031,7 +1047,7 @@ spec:
       name: s3-https
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "97cb70ec5b66a8fec8225a441a84948368513e5db515320f8f3fcf8ed0bd01b1"
+const Sha256_deploy_internal_statefulset_core_yaml = "effdb488acaf67b4cfbb2e1120f17a9d7283206f4a65f1cc1e687473d2bd96fd"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -1148,6 +1164,10 @@ spec:
           value: ""
         - name: OAUTH_TOKEN_ENDPOINT
           value: ""
+        - name: NOOBAA_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: container_dbg
           value: "" # any non-empty value will set the container to dbg mode
         - name: CONTAINER_CPU_REQUEST
@@ -1969,11 +1989,13 @@ roleRef:
   name: noobaa
 `
 
-const Sha256_deploy_service_account_yaml = "51241cd291100562ccd8bec1625c3779e212a58a0a21d4042937a98c73245d66"
+const Sha256_deploy_service_account_yaml = "7c68e5bd65c614787d7d4cdf80db8c14d9159ce8e940c5134d33d21dbe66893f"
 
 const File_deploy_service_account_yaml = `apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: noobaa
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.noobaa-mgmt: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"noobaa-mgmt"}}'
 `
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -92,6 +92,7 @@ func RunInstall(cmd *cobra.Command, args []string) {
 	util.KubeCreateSkipExisting(c.RoleBinding)
 	util.KubeCreateSkipExisting(c.ClusterRole)
 	util.KubeCreateSkipExisting(c.ClusterRoleBinding)
+	util.KubeCreateSkipExisting(c.AuthDelegatorClusterRoleBinding)
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
 		util.KubeCreateSkipExisting(c.Deployment)
@@ -106,6 +107,7 @@ func RunUninstall(cmd *cobra.Command, args []string) {
 		util.KubeDelete(c.Deployment)
 	}
 	util.KubeDelete(c.ClusterRoleBinding)
+	util.KubeDelete(c.AuthDelegatorClusterRoleBinding)
 	util.KubeDelete(c.ClusterRole)
 	util.KubeDelete(c.RoleBinding)
 	util.KubeDelete(c.Role)
@@ -139,6 +141,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	util.KubeCheck(c.RoleBinding)
 	util.KubeCheck(c.ClusterRole)
 	util.KubeCheck(c.ClusterRoleBinding)
+	util.KubeCheck(c.AuthDelegatorClusterRoleBinding)
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
 		util.KubeCheck(c.Deployment)
@@ -155,6 +158,7 @@ func RunYaml(cmd *cobra.Command, args []string) {
 	util.Panic(p.PrintObj(c.RoleBinding, os.Stdout))
 	util.Panic(p.PrintObj(c.ClusterRole, os.Stdout))
 	util.Panic(p.PrintObj(c.ClusterRoleBinding, os.Stdout))
+	util.Panic(p.PrintObj(c.AuthDelegatorClusterRoleBinding, os.Stdout))
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
 		util.Panic(p.PrintObj(c.Deployment, os.Stdout))
@@ -163,13 +167,14 @@ func RunYaml(cmd *cobra.Command, args []string) {
 
 // Conf struct holds all the objects needed to install the operator
 type Conf struct {
-	NS                 *corev1.Namespace
-	SA                 *corev1.ServiceAccount
-	Role               *rbacv1.Role
-	RoleBinding        *rbacv1.RoleBinding
-	ClusterRole        *rbacv1.ClusterRole
-	ClusterRoleBinding *rbacv1.ClusterRoleBinding
-	Deployment         *appsv1.Deployment
+	NS                              *corev1.Namespace
+	SA                              *corev1.ServiceAccount
+	Role                            *rbacv1.Role
+	RoleBinding                     *rbacv1.RoleBinding
+	ClusterRole                     *rbacv1.ClusterRole
+	ClusterRoleBinding              *rbacv1.ClusterRoleBinding
+	AuthDelegatorClusterRoleBinding *rbacv1.ClusterRoleBinding
+	Deployment                      *appsv1.Deployment
 }
 
 // LoadOperatorConf loads and initializes all the objects needed to install the operator
@@ -182,6 +187,7 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.RoleBinding = util.KubeObject(bundle.File_deploy_role_binding_yaml).(*rbacv1.RoleBinding)
 	c.ClusterRole = util.KubeObject(bundle.File_deploy_cluster_role_yaml).(*rbacv1.ClusterRole)
 	c.ClusterRoleBinding = util.KubeObject(bundle.File_deploy_cluster_role_binding_yaml).(*rbacv1.ClusterRoleBinding)
+	c.AuthDelegatorClusterRoleBinding = util.KubeObject(bundle.File_deploy_auth_delegator_cluster_role_binding_yaml).(*rbacv1.ClusterRoleBinding)
 	c.Deployment = util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
 
 	c.NS.Name = options.Namespace
@@ -189,6 +195,7 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.Role.Namespace = options.Namespace
 	c.RoleBinding.Namespace = options.Namespace
 	c.ClusterRole.Namespace = options.Namespace
+	c.AuthDelegatorClusterRoleBinding.Namespace = options.Namespace
 	c.Deployment.Namespace = options.Namespace
 
 	c.ClusterRole.Name = options.SubDomainNS()
@@ -196,6 +203,11 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.ClusterRoleBinding.RoleRef.Name = c.ClusterRole.Name
 	for i := range c.ClusterRoleBinding.Subjects {
 		c.ClusterRoleBinding.Subjects[i].Namespace = options.Namespace
+	}
+
+	c.AuthDelegatorClusterRoleBinding.Name = options.SubDomainNS() + ":auth-delegator"
+	for i := range c.AuthDelegatorClusterRoleBinding.Subjects {
+		c.AuthDelegatorClusterRoleBinding.Subjects[i].Namespace = options.Namespace
 	}
 
 	c.Deployment.Spec.Template.Spec.Containers[0].Image = options.OperatorImage

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -61,6 +61,7 @@ type Reconciler struct {
 	NBClient        nb.Client
 	CoreVersion     string
 	OperatorVersion string
+	OAuthEndpoints  *util.OAuth2Endpoints
 
 	NooBaa              *nbv1.NooBaa
 	CoreApp             *appsv1.StatefulSet

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,9 +3,13 @@ package util
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"strings"
 	"time"
 
@@ -15,6 +19,7 @@ import (
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	obv1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	nbapis "github.com/noobaa/noobaa-operator/v2/pkg/apis"
+	routev1 "github.com/openshift/api/route/v1"
 	cloudcredsv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	operv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -34,8 +39,15 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	routev1 "github.com/openshift/api/route/v1"
 )
+
+const oAuthWellKnownEndpoint = "https://openshift.default.svc/.well-known/oauth-authorization-server"
+
+// Holds OAuth2 endpoints information.
+type OAuth2Endpoints struct {
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+}
 
 var (
 	ctx        = context.TODO()
@@ -720,4 +732,31 @@ func PrintThisNoteWhenFinishedApplyingAndStartWaitLoop() {
 	log.Printf("  - This command has finished applying changes to the cluster.")
 	log.Printf("  - From now on, it only loops and reads the status, to monitor the operator work.")
 	log.Printf("  - You may Ctrl-C at any time to stop the loop and watch it manually.")
+}
+
+func DiscoverOAuthEndpoints() (*OAuth2Endpoints, error) {
+	client := http.Client{
+		Timeout: 120 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	res, err := client.Get(oAuthWellKnownEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoints := OAuth2Endpoints{}
+	err = json.Unmarshal(body, &endpoints)
+	if err != nil {
+		return nil, err
+	}
+
+	return &endpoints, nil
 }


### PR DESCRIPTION
- Discover OAuth2 endpoints using the .wellknown auth endpint and relay them to noobaa-core via env vars
- Relay noobaa service account to noobaa-core pod via env variable
- CLI: Add missing service account annotaion and cluster role binding (to system:auth-delegator)