### PR TITLE
fixed operator panic - ensure annotations map exist on service account

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -68,6 +68,9 @@ func (r *Reconciler) ReconcilePhaseCreating() error {
 
 // SetDesiredServiceAccount updates the ServiceAccount as desired for reconciling
 func (r *Reconciler) SetDesiredServiceAccount() {
+	if r.ServiceAccount.Annotations == nil {
+		r.ServiceAccount.Annotations = map[string]string{}
+	}
 	r.ServiceAccount.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.noobaa-mgmt"] =
 		`{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"` + r.RouteMgmt.Name + `"}}`
 }


### PR DESCRIPTION
* if an older version of noobaa service-account (one without `Annotations`) exists on the cluster, it causes the operator to crash when trying to assign to the `Annotations` map
* ensuring `Annotations` map existence before assignment.