### PR TITLE
Remove OwnerReferences on OBCStorageClass

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -321,11 +321,6 @@ func (r *Reconciler) ReconcileOBCStorageClass() error {
 		"bucketclass": r.DefaultBucketClass.Name,
 	}
 
-	// unsetting BlockOwnerDeletion to acoid error when trying to own storage class:
-	// "cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on"
-	r.Own(r.OBCStorageClass)
-	r.OBCStorageClass.OwnerReferences[0].BlockOwnerDeletion = nil
-
 	err := r.Client.Create(r.Ctx, r.OBCStorageClass)
 	if err != nil {
 		return err


### PR DESCRIPTION
Invalid OwnerReferences can lead to the other children of the owner
being garbage collected. Ref [1][1].

The OBCStorageClass is a non-namespaced (global) resource, which has
OwnerReference set to the NooBaa resource which is a namespaced
resource. This is an invalid OwnerReference.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1691546