### PR TITLE
Trim the prerelease part from the version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.23.8
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/coreos/go-semver v0.2.0
 	github.com/coreos/prometheus-operator v0.29.0
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/go-openapi/spec v0.19.2
 	github.com/gobuffalo/flect v0.1.6 // indirect
 	github.com/google/uuid v1.1.1
-	github.com/hashicorp/go-version v1.2.0
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20190924175516-f3ba69cc601e
 	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190614194054-1ccced634f6c

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.12+incompatible h1:pAWNwdf7QiT1zfaWyqCtNZQWCLByQyA3JrSQyuYAqnQ=
 github.com/coreos/etcd v3.3.12+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
+github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -262,8 +263,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.5 h1:2+KSC78XiO6Qy0hIjfc1OD9H+hsaJdJ
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-health-probe v0.2.0/go.mod h1:4GVx/bTCtZaSzhjbGueDY5YgBdsmKeVx+LErv/n0L6s=
 github.com/grpc-ecosystem/grpc-health-probe v0.2.1-0.20181220223928-2bf0a5b182db/go.mod h1:uBKkC2RbarFsvS5jMJHpVhTLvGlGQj9JJwkaePE3FWI=
-github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
-github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.openapi.go
@@ -11,15 +11,15 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./pkg/apis/noobaa/v1alpha1.BackingStore":       schema_pkg_apis_noobaa_v1alpha1_BackingStore(ref),
-		"./pkg/apis/noobaa/v1alpha1.BackingStoreSpec":   schema_pkg_apis_noobaa_v1alpha1_BackingStoreSpec(ref),
-		"./pkg/apis/noobaa/v1alpha1.BackingStoreStatus": schema_pkg_apis_noobaa_v1alpha1_BackingStoreStatus(ref),
-		"./pkg/apis/noobaa/v1alpha1.BucketClass":        schema_pkg_apis_noobaa_v1alpha1_BucketClass(ref),
-		"./pkg/apis/noobaa/v1alpha1.BucketClassSpec":    schema_pkg_apis_noobaa_v1alpha1_BucketClassSpec(ref),
-		"./pkg/apis/noobaa/v1alpha1.BucketClassStatus":  schema_pkg_apis_noobaa_v1alpha1_BucketClassStatus(ref),
-		"./pkg/apis/noobaa/v1alpha1.NooBaa":             schema_pkg_apis_noobaa_v1alpha1_NooBaa(ref),
-		"./pkg/apis/noobaa/v1alpha1.NooBaaSpec":         schema_pkg_apis_noobaa_v1alpha1_NooBaaSpec(ref),
-		"./pkg/apis/noobaa/v1alpha1.NooBaaStatus":       schema_pkg_apis_noobaa_v1alpha1_NooBaaStatus(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BackingStore":       schema_pkg_apis_noobaa_v1alpha1_BackingStore(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BackingStoreSpec":   schema_pkg_apis_noobaa_v1alpha1_BackingStoreSpec(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BackingStoreStatus": schema_pkg_apis_noobaa_v1alpha1_BackingStoreStatus(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BucketClass":        schema_pkg_apis_noobaa_v1alpha1_BucketClass(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BucketClassSpec":    schema_pkg_apis_noobaa_v1alpha1_BucketClassSpec(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BucketClassStatus":  schema_pkg_apis_noobaa_v1alpha1_BucketClassStatus(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.NooBaa":             schema_pkg_apis_noobaa_v1alpha1_NooBaa(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.NooBaaSpec":         schema_pkg_apis_noobaa_v1alpha1_NooBaaSpec(ref),
+		"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.NooBaaStatus":       schema_pkg_apis_noobaa_v1alpha1_NooBaaStatus(ref),
 	}
 }
 
@@ -52,20 +52,20 @@ func schema_pkg_apis_noobaa_v1alpha1_BackingStore(ref common.ReferenceCallback) 
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the noobaa BackingStore.",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.BackingStoreSpec"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BackingStoreSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the noobaa BackingStore.",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.BackingStoreStatus"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BackingStoreStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/noobaa/v1alpha1.BackingStoreSpec", "./pkg/apis/noobaa/v1alpha1.BackingStoreStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BackingStoreSpec", "github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BackingStoreStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -85,31 +85,31 @@ func schema_pkg_apis_noobaa_v1alpha1_BackingStoreSpec(ref common.ReferenceCallba
 					"awsS3": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AWSS3Spec specifies a backing store of type aws-s3",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.AWSS3Spec"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.AWSS3Spec"),
 						},
 					},
 					"s3Compatible": {
 						SchemaProps: spec.SchemaProps{
 							Description: "S3Compatible specifies a backing store of type s3-compatible",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.S3CompatibleSpec"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.S3CompatibleSpec"),
 						},
 					},
 					"azureBlob": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AzureBlob specifies a backing store of type azure-blob",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.AzureBlobSpec"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.AzureBlobSpec"),
 						},
 					},
 					"googleCloudStorage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "GoogleCloudStorage specifies a backing store of type google-cloud-storage",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.GoogleCloudStorageSpec"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.GoogleCloudStorageSpec"),
 						},
 					},
 					"pvPool": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PVPool specifies a backing store of type pv-pool",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.PVPoolSpec"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.PVPoolSpec"),
 						},
 					},
 				},
@@ -117,7 +117,7 @@ func schema_pkg_apis_noobaa_v1alpha1_BackingStoreSpec(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/noobaa/v1alpha1.AWSS3Spec", "./pkg/apis/noobaa/v1alpha1.AzureBlobSpec", "./pkg/apis/noobaa/v1alpha1.GoogleCloudStorageSpec", "./pkg/apis/noobaa/v1alpha1.PVPoolSpec", "./pkg/apis/noobaa/v1alpha1.S3CompatibleSpec"},
+			"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.AWSS3Spec", "github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.AzureBlobSpec", "github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.GoogleCloudStorageSpec", "github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.PVPoolSpec", "github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.S3CompatibleSpec"},
 	}
 }
 
@@ -203,20 +203,20 @@ func schema_pkg_apis_noobaa_v1alpha1_BucketClass(ref common.ReferenceCallback) c
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the noobaa BucketClass.",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.BucketClassSpec"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BucketClassSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the noobaa BackingStore.",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.BucketClassStatus"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BucketClassStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/noobaa/v1alpha1.BucketClassSpec", "./pkg/apis/noobaa/v1alpha1.BucketClassStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BucketClassSpec", "github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.BucketClassStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -229,7 +229,7 @@ func schema_pkg_apis_noobaa_v1alpha1_BucketClassSpec(ref common.ReferenceCallbac
 					"placementPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PlacementPolicy specifies the placement policy for the bucket class",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.PlacementPolicy"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.PlacementPolicy"),
 						},
 					},
 				},
@@ -237,7 +237,7 @@ func schema_pkg_apis_noobaa_v1alpha1_BucketClassSpec(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/noobaa/v1alpha1.PlacementPolicy"},
+			"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.PlacementPolicy"},
 	}
 }
 
@@ -323,20 +323,20 @@ func schema_pkg_apis_noobaa_v1alpha1_NooBaa(ref common.ReferenceCallback) common
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the noobaa system.",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.NooBaaSpec"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.NooBaaSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the noobaa system.",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.NooBaaStatus"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.NooBaaStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/noobaa/v1alpha1.NooBaaSpec", "./pkg/apis/noobaa/v1alpha1.NooBaaStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.NooBaaSpec", "github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.NooBaaStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -487,13 +487,13 @@ func schema_pkg_apis_noobaa_v1alpha1_NooBaaStatus(ref common.ReferenceCallback) 
 					"accounts": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Accounts reports accounts info for the admin account",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.AccountsStatus"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.AccountsStatus"),
 						},
 					},
 					"services": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Services reports addresses for the services",
-							Ref:         ref("./pkg/apis/noobaa/v1alpha1.ServicesStatus"),
+							Ref:         ref("github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.ServicesStatus"),
 						},
 					},
 					"readme": {
@@ -507,6 +507,6 @@ func schema_pkg_apis_noobaa_v1alpha1_NooBaaStatus(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/noobaa/v1alpha1.AccountsStatus", "./pkg/apis/noobaa/v1alpha1.ServicesStatus", "github.com/openshift/custom-resource-status/conditions/v1.Condition", "k8s.io/api/core/v1.ObjectReference"},
+			"github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.AccountsStatus", "github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1.ServicesStatus", "github.com/openshift/custom-resource-status/conditions/v1.Condition", "k8s.io/api/core/v1.ObjectReference"},
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,9 +30,11 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.3-nighlty-12-15-19"
-	// ContainerImageConstraintSemver is the constraints of supported image versions
-	ContainerImageConstraintSemver = ">=5, <6"
+	ContainerImageTag = "5.3.0-master20191215"
+	// ContainerImageSemverLowerBound is the lower bound for supported image versions
+	ContainerImageSemverLowerBound = "5.0.0"
+	// ContainerImageSemverUpperBound is the upper bound for supported image versions
+	ContainerImageSemverUpperBound = "6.0.0"
 	// ContainerImageName is the default image name without the tag/version
 	ContainerImageName = ContainerImageOrg + "/" + ContainerImageRepo
 	// ContainerImage is the full default image url

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -15,7 +15,6 @@ import (
 	"github.com/noobaa/noobaa-operator/v2/version"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
-	semver "github.com/hashicorp/go-version"
 	routev1 "github.com/openshift/api/route/v1"
 	cloudcredsv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -34,9 +33,6 @@ import (
 )
 
 var (
-	// ContainerImageConstraint is the instantiated semver contraints used for image verification
-	ContainerImageConstraint, _ = semver.NewConstraint(options.ContainerImageConstraintSemver)
-
 	// ReadmeReady is a template for system.status.readme
 	ReadmeReady = template.Must(template.New("system_status_readme_ready").
 			Parse(bundle.File_deploy_internal_text_system_status_readme_ready_tmpl))


### PR DESCRIPTION
By default, version constraint checks will fail on the prerelease version if the constraint does not exactly match the version. Trimming the prerelease part solves this problem