### PR TITLE
Add support for images from env variable

### DIFF
--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/asaskevich/govalidator"
 	semver "github.com/coreos/go-semver/semver"
@@ -41,6 +42,9 @@ func (r *Reconciler) CheckSystemCR() error {
 	}
 
 	specImage := options.ContainerImage
+	if os.Getenv("NOOBAA_CORE_IMAGE") != "" {
+		specImage = os.Getenv("NOOBAA_CORE_IMAGE")
+	}
 	if r.NooBaa.Spec.Image != nil {
 		specImage = *r.NooBaa.Spec.Image
 	}

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -3,6 +3,7 @@ package system
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -121,11 +122,15 @@ func (r *Reconciler) SetDesiredNooBaaDB() {
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]
 		if c.Name == "db" {
-			if r.NooBaa.Spec.DBImage == nil {
-				c.Image = options.DBImage
-			} else {
+
+			c.Image = options.DBImage
+			if os.Getenv("NOOBAA_DB_IMAGE") != "" {
+				c.Image = os.Getenv("NOOBAA_DB_IMAGE")
+			}
+			if r.NooBaa.Spec.DBImage != nil {
 				c.Image = *r.NooBaa.Spec.DBImage
 			}
+
 			if r.NooBaa.Spec.DBResources != nil {
 				c.Resources = *r.NooBaa.Spec.DBResources
 			}

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -270,6 +270,8 @@ function delete_backingstore_path {
         done
     fi
     sleep 30
+    local buckets=($(test_noobaa silence bucket list  | grep -v "BUCKET-NAME" | awk '{print $1}'))
+    echo "✅  buckets in system: ${buckets}"
     test_noobaa backingstore delete ${backingstore[1]}
     test_noobaa failure backingstore delete ${backingstore[0]}
     echo "✅  delete ${backingstore[1]} path is done"


### PR DESCRIPTION
Supporting the following issue from noobaa-operator side:
https://github.com/openshift/ocs-operator/issues/372

it will now get the images (both core and db) in the following order:
1. from the spec - if exists
2. from the env variables - if exists
3. default value in options.go file 