### PR TITLE
Backport: olm.go tolerations descriptor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ For Mac
 ```
 brew install noobaa/noobaa/noobaa
 # or
-wget https://github.com/noobaa/noobaa-operator/releases/download/v2.0.9/noobaa-mac-v2.0.9; mv noobaa-mac-* noobaa; chmod +x noobaa
+wget https://github.com/noobaa/noobaa-operator/releases/download/v2.0.10/noobaa-mac-v2.0.10; mv noobaa-mac-* noobaa; chmod +x noobaa
 ```
 
 For Linux
 ```
-wget https://github.com/noobaa/noobaa-operator/releases/download/v2.0.9/noobaa-linux-v2.0.9; mv noobaa-linux-* noobaa; chmod +x noobaa
+wget https://github.com/noobaa/noobaa-operator/releases/download/v2.0.10/noobaa-linux-v2.0.10; mv noobaa-linux-* noobaa; chmod +x noobaa
 ```
 
 - Run: `./noobaa --help` for CLI usage

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1,6 +1,6 @@
 package bundle
 
-const Version = "2.0.9"
+const Version = "2.0.10"
 
 const Sha256_deploy_cluster_role_yaml = "b7002d09a74061e0d16e9414d60f97ed7f6a8fb3192699f957169e1170f2a669"
 

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -214,7 +214,9 @@ func GenerateCSV(opConf *operator.Conf) *operv1.ClusterServiceVersion {
 			operv1.SpecDescriptor{Path: "dbVolumeResources", XDescriptors: uiResources},
 			operv1.SpecDescriptor{Path: "dbStorageClass", XDescriptors: uiText},
 			operv1.SpecDescriptor{Path: "pvPoolDefaultStorageClass", XDescriptors: uiText},
-			operv1.SpecDescriptor{Path: "tolerations", XDescriptors: []string{"urn:alm:descriptor:io.kubernetes:Tolerations"}},
+			// this descriptor caused the OCP console to crash on noobaa CRD page, when trying to display tolerations.
+			// removing for now
+			// operv1.SpecDescriptor{Path: "tolerations", XDescriptors: []string{"urn:alm:descriptor:io.kubernetes:Tolerations"}},
 			operv1.SpecDescriptor{Path: "imagePullSecret", XDescriptors: []string{"urn:alm:descriptor:io.kubernetes:Secret"}},
 		},
 		"BackingStore":      []operv1.SpecDescriptor{},

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.2.11"
+	ContainerImageTag = "5.2.13"
 	// ContainerImageConstraintSemver is the constraints of supported image versions
 	ContainerImageConstraintSemver = ">=5, <6"
 	// ContainerImageName is the default image name without the tag/version

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 const (
 	// Version is the noobaa-operator version (semver)
-	Version = "2.0.9"
+	Version = "2.0.10"
 )


### PR DESCRIPTION
* removed tolerations descriptor in olm.go
* updated noobaa version in operator `options.go` to 5.2.13
* bumped operator version to 2.0.10

Fixes BZ 1785267