### PR TITLE
changed deafult backing store target to be more descriptive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/go-openapi/spec v0.19.2
 	github.com/gobuffalo/flect v0.1.6 // indirect
-	github.com/google/uuid v1.1.1
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20200107223247-51020689f1fb
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20190614194054-1ccced634f6c


### PR DESCRIPTION
* fixes https://bugzilla.redhat.com/show_bug.cgi?id=1768382
* changed target bucket name to be of the format `nb.[timestamp milliseconds].[route host name]`
* if the generated name length is longer than 63 it is truncated to 63 (max bucket name length)