### PR TITLE
Support deployment of a joined NooBaa on a remote cluster 

### DIFF
--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -753,6 +753,19 @@ spec:
                     TODO: Add other useful fields. apiVersion, kind, uid?'
                   type: string
               type: object
+            joinSecret:
+              description: JoinSecret (optional) instructs the operator to join another
+                cluster and point to a secret that holds the join information
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             pvPoolDefaultStorageClass:
               description: PVPoolDefaultStorageClass (optional) overrides the default
                 cluster StorageClass for the pv-pool volumes. This affects where the

--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -46,16 +46,22 @@ spec:
         - containerPort: 6001
         - containerPort: 6443
         env:
-        - name: JWT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: noobaa-server
-              key: jwt
-        - name: MGMT_URL
+        - name: MGMT_ADDR
+        - name: BG_ADDR
+        - name: MD_ADDR
+        - name: HOSTED_AGENTS_ADDR
         - name: MONGODB_URL
         - name: VIRTUAL_HOSTS
         - name: REGION
         - name: ENDPOINT_GROUP_ID
+        - name: LOCAL_MD_SERVER
+        - name: LOCAL_N2N_AGENT
+        - name: JWT_SECRET
+        - name: NOOBAA_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: noobaa-endpoints
+              key: auth_token
         - name: CONTAINER_CPU_REQUEST
           valueFrom:
             resourceFieldRef:

--- a/deploy/internal/service-mgmt.yaml
+++ b/deploy/internal/service-mgmt.yaml
@@ -20,8 +20,6 @@ spec:
     - port: 443
       name: mgmt-https
       targetPort: 8443
-    - port: 8444
-      name: md-https
     - port: 8445
       name: bg-https
     - port: 8446

--- a/deploy/internal/service-s3.yaml
+++ b/deploy/internal/service-s3.yaml
@@ -17,3 +17,6 @@ spec:
     - port: 443
       targetPort: 6443
       name: s3-https
+    - port: 8444
+      name: md-https
+

--- a/go.sum
+++ b/go.sum
@@ -714,6 +714,7 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190409202823-959b441ac422 h1:QzoH/1pFpZguR8NrRHLcO6jKqfv2zpuSqZLgdm7ZmjI=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -121,7 +121,13 @@ type NooBaaSpec struct {
 
 	// Endpoints (optional) sets configuration info for the noobaa endpoint
 	// deployment.
+	// +optional
 	Endpoints *EndpointsSpec `json:"endpoints,omitempty"`
+
+	// JoinSecret (optional) instructs the operator to join another cluster
+	// and point to a secret that holds the join information
+	// +optional
+	JoinSecret *corev1.SecretReference `json:"joinSecret,omitempty"`
 }
 
 // EndpointsSpec defines the desired state of noobaa endpoint deployment

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -515,6 +515,11 @@ func (in *NooBaaSpec) DeepCopyInto(out *NooBaaSpec) {
 		*out = new(EndpointsSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.JoinSecret != nil {
+		in, out := &in.JoinSecret, &out.JoinSecret
+		*out = new(corev1.SecretReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -547,7 +547,7 @@ spec:
     storage: true
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "bea454a865d4510e25f6703409495603357c060538aa43a2e4f4f1605bc3b9c0"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "e2da8ecd82bd3eb411d3fefbf0f76f67547023bb665b0ce607137ad99af4aef6"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -1304,6 +1304,19 @@ spec:
                     TODO: Add other useful fields. apiVersion, kind, uid?'
                   type: string
               type: object
+            joinSecret:
+              description: JoinSecret (optional) instructs the operator to join another
+                cluster and point to a secret that holds the join information
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             pvPoolDefaultStorageClass:
               description: PVPoolDefaultStorageClass (optional) overrides the default
                 cluster StorageClass for the pv-pool volumes. This affects where the
@@ -1699,7 +1712,7 @@ metadata:
 data: {}
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "7c3a8c9818e98da25e3c1f27271c614171b6db53989f2beee709c9f19d47d539"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "ff6d715cce677a81b36bab784aeaed016b44750b342b4fc8a48a8743eaac7d2f"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -1749,16 +1762,22 @@ spec:
         - containerPort: 6001
         - containerPort: 6443
         env:
-        - name: JWT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: noobaa-server
-              key: jwt
-        - name: MGMT_URL
+        - name: MGMT_ADDR
+        - name: BG_ADDR
+        - name: MD_ADDR
+        - name: HOSTED_AGENTS_ADDR
         - name: MONGODB_URL
         - name: VIRTUAL_HOSTS
         - name: REGION
         - name: ENDPOINT_GROUP_ID
+        - name: LOCAL_MD_SERVER
+        - name: LOCAL_N2N_AGENT
+        - name: JWT_SECRET
+        - name: NOOBAA_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: noobaa-endpoints
+              key: auth_token
         - name: CONTAINER_CPU_REQUEST
           valueFrom:
             resourceFieldRef:
@@ -2013,7 +2032,7 @@ spec:
       name: mongodb
 `
 
-const Sha256_deploy_internal_service_mgmt_yaml = "528fb9ccd535776579e59dc5ae60602d0679ce9c6c59c7d5d5a22526fe79131d"
+const Sha256_deploy_internal_service_mgmt_yaml = "450984e5e72eee3a761e240c6c0731dd14160c5fcb502fc81beb6abe2789e906"
 
 const File_deploy_internal_service_mgmt_yaml = `apiVersion: v1
 kind: Service
@@ -2037,8 +2056,6 @@ spec:
     - port: 443
       name: mgmt-https
       targetPort: 8443
-    - port: 8444
-      name: md-https
     - port: 8445
       name: bg-https
     - port: 8446
@@ -2062,7 +2079,7 @@ spec:
       app: noobaa
 `
 
-const Sha256_deploy_internal_service_s3_yaml = "220a8196a5937ca7763bcedf3ea42e9ed6dd99cbfc38dd428a884d2712a7a3bd"
+const Sha256_deploy_internal_service_s3_yaml = "9e5b3d6ef68b19be9f431481154faae1ed708b642e760b6cd0bd77eb7fc1d5f0"
 
 const File_deploy_internal_service_s3_yaml = `apiVersion: v1
 kind: Service
@@ -2083,6 +2100,9 @@ spec:
     - port: 443
       targetPort: 6443
       name: s3-https
+    - port: 8444
+      name: md-https
+
 `
 
 const Sha256_deploy_internal_statefulset_core_yaml = "3bf734db9a1c6d2dde8a5afb3582389b7d005d75938bacbd4e169994dad66bda"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.3.0-master20191223"
+	ContainerImageTag = "5.3.0-master20200116"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -25,6 +25,12 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 		return err
 	}
 
+	if r.JoinSecret != nil {
+		if err := r.CheckJoinSecret(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -120,5 +126,31 @@ func (r *Reconciler) CheckSystemCR() error {
 		}
 	}
 
+	return nil
+}
+
+// CheckJoinSecret checks that all need information to allow to join
+// another noobaa clauster is specified in the join secret
+func (r *Reconciler) CheckJoinSecret() error {
+	if r.JoinSecret.StringData["mgmt_addr"] == "" {
+		return util.NewPersistentError("InvalidJoinSecert",
+			"JoinSecret is missing mgmt_addr")
+	}
+	if r.JoinSecret.StringData["bg_addr"] == "" {
+		return util.NewPersistentError("InvalidJoinSecert",
+			"JoinSecret is missing bg_addr")
+	}
+	if r.JoinSecret.StringData["md_addr"] == "" {
+		return util.NewPersistentError("InvalidJoinSecert",
+			"JoinSecret is missing md_addr")
+	}
+	if r.JoinSecret.StringData["hosted_agents_addr"] == "" {
+		return util.NewPersistentError("InvalidJoinSecert",
+			"JoinSecret is missing hosted_agents_addr")
+	}
+	if r.JoinSecret.StringData["auth_token"] == "" {
+		return util.NewPersistentError("InvalidJoinSecert",
+			"JoinSecret is missing auth_token")
+	}
 	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -233,6 +233,8 @@ func KubeDelete(obj runtime.Object, opts ...client.DeleteOption) bool {
 	} else if errors.IsConflict(err) {
 		conflicted = true
 		log.Printf("🗑️  Conflict (OK): %s %q: %s\n", gvk.Kind, objKey.Name, err)
+	} else if errors.IsNotFound(err) {
+		return true
 	}
 
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
Currently, we mainly deploy an S3 service and an auto-scaled endpoint group

Changes:
- Create an auth_token secret to be used by endpoints
- Introduce a join secret to hold information on how to join an existing NooBaa cluster
- Add a join secret reference on the NooBaa CRD to indicate that the deployed NooBaa should join an existing cluster using the join information specified in the referenced secret