### PR TITLE
set fixed version for base image in catalog-source.Dockerfile (v1.5.7) and fixed paths

### DIFF
--- a/build/catalog-source.Dockerfile
+++ b/build/catalog-source.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/upstream-registry-builder as builder
+FROM quay.io/operator-framework/upstream-registry-builder:v1.5.7 as builder
 # Add noobaa manifests
 COPY build/_output/olm manifests/noobaa
 # Add lib-bucket-provisioner manifests
@@ -6,11 +6,11 @@ COPY deploy/obc/lib-bucket-provisioner.package.yaml manifests/lib-bucket-provisi
 COPY deploy/obc/lib-bucket-provisioner.v1.0.0.clusterserviceversion.yaml manifests/lib-bucket-provisioner/1.0.0/
 COPY deploy/obc/objectbucket.io_objectbuckets_crd.yaml manifests/lib-bucket-provisioner/1.0.0/
 COPY deploy/obc/objectbucket.io_objectbucketclaims_crd.yaml manifests/lib-bucket-provisioner/1.0.0/
-RUN ./bin/initializer -o ./bundles.db
+RUN /bin/initializer -o ./bundles.db
 
 FROM scratch
 COPY --from=builder /build/bundles.db /bundles.db
-COPY --from=builder /build/bin/registry-server /registry-server
+COPY --from=builder /bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]


### PR DESCRIPTION
* fixes to `make gen-olm` failures
   * in `quay.io/operator-framework/upstream-registry-builder` the location of `/build/bin/initializer` was changed to `/bin/initializer`
   * as a result `registry-server` was also created in `/bin` instead of `/build/bin`
   * fixed the paths to make the docker build pass
   * also set the base image to a fixed version `quay.io/operator-framework/upstream-registry-builder:v1.5.7`
