### PR TITLE
set resources requests & limits for db init-container

### DIFF
--- a/deploy/internal/statefulset-db.yaml
+++ b/deploy/internal/statefulset-db.yaml
@@ -28,6 +28,13 @@ spec:
         command:
         - /noobaa_init_files/noobaa_init.sh
         - init_mongo
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "500Mi"
+          limits:
+            cpu: "500m"
+            memory: "500Mi"
         volumeMounts:
         - name: db
           mountPath: /mongo_data

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2220,7 +2220,7 @@ spec:
               resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_db_yaml = "e0aac93d6d64905ac5c95d18efa671fa2e904e4da187ae5442787bfcf97a9fbb"
+const Sha256_deploy_internal_statefulset_db_yaml = "5916e76021db87d379658147871643bfa6e0f016a53e63afefac36ea9cbe62e3"
 
 const File_deploy_internal_statefulset_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -2252,6 +2252,13 @@ spec:
         command:
         - /noobaa_init_files/noobaa_init.sh
         - init_mongo
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "500Mi"
+          limits:
+            cpu: "500m"
+            memory: "500Mi"
         volumeMounts:
         - name: db
           mountPath: /mongo_data

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -441,7 +441,7 @@ func (r *Reconciler) UpgradeSplitDB() error {
 			Namespace: options.Namespace,
 		},
 	}
-	if util.KubeCheck(oldPvc) {
+	if util.KubeCheckQuiet(oldPvc) {
 		r.Logger.Infof("UpgradeSplitDB: Old OVC found, upgrading...")
 		if err := r.UpgradeSplitDBSetReclaimPolicy(oldPvc, corev1.PersistentVolumeReclaimRetain); err != nil {
 			return err


### PR DESCRIPTION
Fixes #223 
* required for getting Guaranteed QoS class
* when setting resources requests and limits for all containers in a pod (including init containers), the pod is assigned a `Guaranteed` QoS class


