### PR TITLE
changed RPC client in the operator to connect using the management service DNS name

### DIFF
--- a/pkg/nb/router.go
+++ b/pkg/nb/router.go
@@ -184,7 +184,7 @@ func (r *APIRouterNodePort) GetAddress(api string) string {
 // GetAddress implements the router
 func (r *APIRouterServicePort) GetAddress(api string) string {
 	port := FindPortByName(r.ServiceMgmt, GetAPIPortName(api)).Port
-	return fmt.Sprintf("wss://%s.%s:%d/rpc/", r.ServiceMgmt.Name, r.ServiceMgmt.Namespace, port)
+	return fmt.Sprintf("wss://%s.%s.svc.cluster.local:%d/rpc/", r.ServiceMgmt.Name, r.ServiceMgmt.Namespace, port)
 }
 
 // FindPortByName returns the port in the service that matches the given name.

--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
@@ -137,19 +136,8 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 // InitNBClient initialize the noobaa client for making calls to the server.
 func (r *Reconciler) InitNBClient() error {
 	if r.JoinSecret == nil {
-		if len(r.NooBaa.Status.Services.ServiceMgmt.NodePorts) == 0 {
-			return fmt.Errorf("mgmt port not ready yet")
-		}
-
-		mgmtAddress := r.NooBaa.Status.Services.ServiceMgmt.NodePorts[0]
-		mgmtURL, err := url.Parse(mgmtAddress)
-		if err != nil {
-			return fmt.Errorf("failed to parse mgmt address %q. got error: %v", mgmtAddress, err)
-		}
-
-		r.NBClient = nb.NewClient(&nb.APIRouterNodePort{
+		r.NBClient = nb.NewClient(&nb.APIRouterServicePort{
 			ServiceMgmt: r.ServiceMgmt,
-			NodeIP:      mgmtURL.Hostname(),
 		})
 
 	} else {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -691,13 +691,8 @@ func Connect(isExternal bool) (*Client, error) {
 		}
 
 	} else {
-		nodePortURL, err := url.Parse(mgmtEndpoint)
-		if err != nil {
-			return nil, fmt.Errorf("Connect(): Failed to parse mgmt url %q. got error: %v", mgmtEndpoint, err)
-		}
-		nbClient = nb.NewClient(&nb.APIRouterNodePort{
+		nbClient = nb.NewClient(&nb.APIRouterServicePort{
 			ServiceMgmt: r.ServiceMgmt,
-			NodeIP:      nodePortURL.Hostname(),
 		})
 	}
 


### PR DESCRIPTION
* when connecting through the node port, it is possible that there is no connection between different nodes in the cluster using the node ports (e.g. firewall)
* instead of the node port, using the mgmt service DNS name `noobaa-mgmt.[namespace].svc.cluster.local`