### PR TITLE
The endpoint pod should use the secrets as well

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -212,6 +212,13 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 
 	endpointsSpec := r.NooBaa.Spec.Endpoints
 	podSpec := &r.DeploymentEndpoint.Spec.Template.Spec
+	if r.NooBaa.Spec.ImagePullSecret == nil {
+		podSpec.ImagePullSecrets =
+			[]corev1.LocalObjectReference{}
+	} else {
+		podSpec.ImagePullSecrets =
+			[]corev1.LocalObjectReference{*r.NooBaa.Spec.ImagePullSecret}
+	}
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]
 		switch c.Name {


### PR DESCRIPTION
The endpoint pod will fail to pull the image if it's in a private docker registry. Therefore we need to specify the image pull secrets the same way we do in the other deployments