### PR TITLE
Adding support for serving certs for OCP3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ wget https://github.com/noobaa/noobaa-operator/releases/download/v2.0.9/noobaa-l
 
 # Troubleshooting
 
-- The operator is running, but there is no noobaa-core-0 pod 
+- The operator is running, but there is no noobaa-core-0 pod
 
     Make sure that there is a single default storage class with `oc get sc`. run `oc describe sts` for more information
-    
+
 - The operator is running, but the noobaa-core-0 is pending
 
     Verify that there are enough resources. run `oc describe pod noobaa-core-0` for more information
@@ -51,7 +51,7 @@ Applications
 - Fork and clone the repo: `git clone https://github.com/<username>/noobaa-operator`
 - Use minikube: `minikube start`
 - Use your package manager to install `go` and `python3`.
-- Install operator-sdk 
+- Install operator-sdk
   For Mac:
    ```
     wget https://github.com/operator-framework/operator-sdk/releases/download/v0.13.0/operator-sdk-v0.13.0-x86_64-apple-darwin
@@ -62,13 +62,13 @@ Applications
     ```
 
   For Linux:
-```
+   ```
     wget https://github.com/operator-framework/operator-sdk/releases/download/v0.13.0/operator-sdk-v0.13.0-x86_64-linux-gnu
     chmod +x operator-sdk-v0.13.0-x86_64-linux-gnu
     sudo mv operator-sdk-v0.13.0-x86_64-linux-gnu /usr/local/bin/operator-sdk
-    operator-sdk version    
+    operator-sdk version
 
-```
+    ```
 - Source the devenv into your shell: `. devenv.sh`
 - Build the project: `make`
 - Test with the alias `nb` that runs the local operator from `build/_output/bin` (alias created by devenv)

--- a/deploy/internal/service-db.yaml
+++ b/deploy/internal/service-db.yaml
@@ -4,6 +4,9 @@ metadata:
   name: noobaa-db
   labels:
     app: noobaa
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: 'noobaa-db-serving-cert'
+    service.alpha.openshift.io/serving-cert-secret-name: 'noobaa-db-serving-cert'
 spec:
   type: ClusterIP
   selector:

--- a/deploy/internal/service-mgmt.yaml
+++ b/deploy/internal/service-mgmt.yaml
@@ -9,6 +9,7 @@ metadata:
     prometheus.io/scheme: http
     prometheus.io/port: "8080"
     service.beta.openshift.io/serving-cert-secret-name: noobaa-mgmt-serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: noobaa-mgmt-serving-cert
 spec:
   type: LoadBalancer
   selector:

--- a/deploy/internal/service-s3.yaml
+++ b/deploy/internal/service-s3.yaml
@@ -6,6 +6,7 @@ metadata:
     app: noobaa
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
+    service.alpha.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
 spec:
   type: LoadBalancer
   selector:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2051,7 +2051,7 @@ type: Opaque
 data: {}
 `
 
-const Sha256_deploy_internal_service_db_yaml = "73f358a75a8a89f47f9b1319657ac7e72ab81216369b624f06d2929f6cb45052"
+const Sha256_deploy_internal_service_db_yaml = "64559363daddd9caf781f104b876b33fb63e4f2551570e73bdb2bfae736f33ee"
 
 const File_deploy_internal_service_db_yaml = `apiVersion: v1
 kind: Service
@@ -2059,6 +2059,9 @@ metadata:
   name: noobaa-db
   labels:
     app: noobaa
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: 'noobaa-db-serving-cert'
+    service.alpha.openshift.io/serving-cert-secret-name: 'noobaa-db-serving-cert'
 spec:
   type: ClusterIP
   selector:
@@ -2069,7 +2072,7 @@ spec:
       name: mongodb
 `
 
-const Sha256_deploy_internal_service_mgmt_yaml = "450984e5e72eee3a761e240c6c0731dd14160c5fcb502fc81beb6abe2789e906"
+const Sha256_deploy_internal_service_mgmt_yaml = "3449be462a77ea7e66c529308cbd86fd1c3d18685aa4649aa05514303f23908a"
 
 const File_deploy_internal_service_mgmt_yaml = `apiVersion: v1
 kind: Service
@@ -2082,6 +2085,7 @@ metadata:
     prometheus.io/scheme: http
     prometheus.io/port: "8080"
     service.beta.openshift.io/serving-cert-secret-name: noobaa-mgmt-serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: noobaa-mgmt-serving-cert
 spec:
   type: LoadBalancer
   selector:
@@ -2116,7 +2120,7 @@ spec:
       app: noobaa
 `
 
-const Sha256_deploy_internal_service_s3_yaml = "9e5b3d6ef68b19be9f431481154faae1ed708b642e760b6cd0bd77eb7fc1d5f0"
+const Sha256_deploy_internal_service_s3_yaml = "49fa69db96f9e06ac46874ec42d1a3bd81cfc7b159d75e2a2870d1f16708eafc"
 
 const File_deploy_internal_service_s3_yaml = `apiVersion: v1
 kind: Service
@@ -2126,6 +2130,7 @@ metadata:
     app: noobaa
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
+    service.alpha.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
Also, generate a serving cert for the new database service (This will not force the DB pod to use the cert in any way)

fixes #117 