### PR TITLE
Fix OOMKilled problem

### DIFF
--- a/pkg/diagnose/diagnose.go
+++ b/pkg/diagnose/diagnose.go
@@ -120,10 +120,7 @@ func (c *Collector) CollectPodLogs(corePodSelector labels.Selector) {
 
 // 	targetAddress := fmt.Sprintf("%s/metrics/counter", mgmtURL.String())
 // 	log.Printf("JENIA THIS IS THE URL %s", targetAddress)
-// 	tr := &http.Transport{
-// 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-// 	}
-// 	client := &http.Client{Transport: tr}
+// 	client := &http.Client{Transport: util.InsecureHTTPTransport}
 // 	resp, err := client.Get(targetAddress)
 // 	if err != nil {
 // 		log.Printf(`%s`, err)

--- a/pkg/nb/rpc.go
+++ b/pkg/nb/rpc.go
@@ -1,11 +1,11 @@
 package nb
 
 import (
-	"crypto/tls"
 	"net/http"
 	"strings"
 	"sync"
 
+	util "github.com/noobaa/noobaa-operator/v2/pkg/util"
 	"github.com/sirupsen/logrus"
 )
 
@@ -125,10 +125,7 @@ var _ error = &RPCError{}
 func NewRPC() *RPC {
 	return &RPC{
 		HTTPClient: http.Client{
-			//Timeout: 120 * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+			Transport: util.InsecureHTTPTransport,
 		},
 		ConnMap:     make(map[string]RPCConn),
 		ConnMapLock: sync.Mutex{},

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -292,19 +292,16 @@ func (r *Reconciler) ReconcilePhases() error {
 	if err := r.ReconcilePhaseVerifying(); err != nil {
 		return err
 	}
-	r.PrintMemUsage("Verifying")
 	if err := r.ReconcilePhaseCreating(); err != nil {
 		return err
 	}
-	r.PrintMemUsage("Creating")
 	if err := r.ReconcilePhaseConnecting(); err != nil {
 		return err
 	}
-	r.PrintMemUsage("Connecting")
 	if err := r.ReconcilePhaseConfiguring(); err != nil {
 		return err
 	}
-	r.PrintMemUsage("Configuring")
+	r.PrintMemUsage("Finishing")
 	return nil
 }
 


### PR DESCRIPTION
### Explain the changes
1. Instead of creating http.Client  in every call to util.DiscoverOAuthEndpoints() - Moved the http.Client creation to phase2_creating and passed the same client as argument. 
2. Called res.Body.Close() when it's empty.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ #1799077

### Testing Instructions:
1. 