### PR TITLE
Backport Version change and travis for into 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ install:
   - bash .travis/install-minikube.sh
 
 script:
-  - make gen-api-fail-if-dirty --always-make
-  - make build
-  - make test
-  - make test-olm
-  - make test-cli-flow
+  - make gen-api-fail-if-dirty --always-make || exit 1
+  - make build || exit 1
+  - make test || exit 1
+  - make test-olm || exit 1
+  - make test-cli-flow || exit 1

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ The following options can be passed to any command:
 out-of-cluster.
       --mini=false: Signal the operator that it is running in a low resource environment
   -n, --namespace='noobaa': Target namespace
-      --noobaa-image='noobaa/noobaa-core:5.3.0': NooBaa image
-      --operator-image='noobaa/noobaa-operator:2.1.1': Operator image
+      --noobaa-image='noobaa/noobaa-core:5.4.0': NooBaa image
+      --operator-image='noobaa/noobaa-operator:2.2.0': Operator image
       --pv-pool-default-storage-class='': The default storage class name for BackingStores of type pv-pool
 
 ```
@@ -108,9 +108,9 @@ out-of-cluster.
 ```shell
 $ noobaa version
 
-INFO[0000] CLI version: 2.1.1
-INFO[0000] noobaa-image: noobaa/noobaa-core:5.3.0
-INFO[0000] operator-image: noobaa/noobaa-operator:2.1.1
+INFO[0000] CLI version: 2.2.0
+INFO[0000] noobaa-image: noobaa/noobaa-core:5.4.0
+INFO[0000] operator-image: noobaa/noobaa-operator:2.2.0
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ out-of-cluster.
       --mini=false: Signal the operator that it is running in a low resource environment
   -n, --namespace='noobaa': Target namespace
       --noobaa-image='noobaa/noobaa-core:5.4.0': NooBaa image
-      --operator-image='noobaa/noobaa-operator:2.2.0': Operator image
+      --operator-image='noobaa/noobaa-operator:2.3.0': Operator image
       --pv-pool-default-storage-class='': The default storage class name for BackingStores of type pv-pool
 
 ```
@@ -108,9 +108,9 @@ out-of-cluster.
 ```shell
 $ noobaa version
 
-INFO[0000] CLI version: 2.2.0
+INFO[0000] CLI version: 2.3.0
 INFO[0000] noobaa-image: noobaa/noobaa-core:5.4.0
-INFO[0000] operator-image: noobaa/noobaa-operator:2.2.0
+INFO[0000] operator-image: noobaa/noobaa-operator:2.3.0
 
 ```
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1,6 +1,6 @@
 package bundle
 
-const Version = "2.2.0"
+const Version = "2.3.0"
 
 const Sha256_deploy_cluster_role_yaml = "349e613915ed288629c4926e22cd42f4a3776ed38dfbc9e814a9b28211a67b3c"
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1,6 +1,6 @@
 package bundle
 
-const Version = "2.1.1"
+const Version = "2.2.0"
 
 const Sha256_deploy_cluster_role_yaml = "349e613915ed288629c4926e22cd42f4a3776ed38dfbc9e814a9b28211a67b3c"
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.3.1"
+	ContainerImageTag = "5.4.0-rc1"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 const (
 	// Version is the noobaa-operator version (semver)
-	Version = "2.2.0"
+	Version = "2.3.0"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 const (
 	// Version is the noobaa-operator version (semver)
-	Version = "2.1.1"
+	Version = "2.2.0"
 )


### PR DESCRIPTION
Bump version to 2.3.0

(cherry picked from commit 3d806c3bf12e969c65f705a4baee1257a98b9468)

.travis.yml:
- Added || exit 1 on all scripts calls

(cherry picked from commit ec02220f8543d4d277083280891ab75974c8723a)