### PR TITLE
added SecurityContext to mongo statefulset to with a know uid

### DIFF
--- a/deploy/internal/statefulset-db.yaml
+++ b/deploy/internal/statefulset-db.yaml
@@ -37,7 +37,7 @@ spec:
             memory: "500Mi"
         volumeMounts:
         - name: db
-          mountPath: /mongo_data
+          mountPath: /data
       containers:
       #--------------------#
       # DATABASE CONTAINER #

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2318,7 +2318,7 @@ spec:
               resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_db_yaml = "5916e76021db87d379658147871643bfa6e0f016a53e63afefac36ea9cbe62e3"
+const Sha256_deploy_internal_statefulset_db_yaml = "d704f723394443041084acf32922ebe30c35ea0388b4f7015c1a67a57b674dc0"
 
 const File_deploy_internal_statefulset_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -2359,7 +2359,7 @@ spec:
             memory: "500Mi"
         volumeMounts:
         - name: db
-          mountPath: /mongo_data
+          mountPath: /data
       containers:
       #--------------------#
       # DATABASE CONTAINER #

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -129,6 +129,11 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 
 	podSpec := &r.NooBaaDB.Spec.Template.Spec
 	podSpec.ServiceAccountName = "noobaa"
+
+	// set security context to run as a constant uid in kubernetes or openshift with anyuid scc
+	runAsUser := int64(10001)
+	podSpec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: &runAsUser}
+
 	for i := range podSpec.InitContainers {
 		c := &podSpec.InitContainers[i]
 		if c.Name == "init" {


### PR DESCRIPTION
* added SecurityContext to mongo statefulset to with a know uid
   * solves permissions error in Mongo when SCC is changed in openshift to `anyuid`
* changed /mongo_data mountPath to /data in init container
   * to be consistent with DB container

Fixing BZ #1835125