### PR TITLE
Increasing test_cli_flow.sh default timeout

### DIFF
--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -7,7 +7,7 @@ export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} 
 
 NAMESPACE='test'
 #the timeout is that big because it sometimes take a while to get pvc
-DEFAULT_TIMEOUT=120
+DEFAULT_TIMEOUT=180
 
 directory=$(dirname ${0})
 . ${directory}/test_cli_functions.sh


### PR DESCRIPTION
test_cli_flow.sh:
- Increasing default timeout to avoid rapid timeouts failures