### PR TITLE
Added graceful uninstall support 

### DIFF
--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -311,4 +311,7 @@ type EndpointsStatus struct {
 const (
 	// Finalizer is the name of the noobaa finalizer
 	Finalizer = "noobaa.io/finalizer"
+
+	// GracefulFinalizer is the name of the noobaa graceful finalizer
+	GracefulFinalizer = "noobaa.io/graceful_finalizer"
 )

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -89,6 +89,14 @@ func (p *Provisioner) Provision(bucketOptions *obAPI.BucketOptions) (*nbv1.Objec
 		return nil, err
 	}
 
+	if r.SysClient.NooBaa.DeletionTimestamp != nil {
+		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
+		if util.Contains("noobaa.io/graceful_finalizer", finalizersArray) {
+			msg := fmt.Sprintf("NooBaa is in deleting state, new requests will be ignored")
+			log.Errorf(msg)
+			return nil, obErrors.NewBucketExistsError(msg)
+		}
+	}
 	// TODO: we need to better handle the case that a bucket was created, but Provision failed
 	// right now we will fail on create bucket when Provision is called the second time
 	err = r.CreateBucket()
@@ -114,6 +122,15 @@ func (p *Provisioner) Grant(bucketOptions *obAPI.BucketOptions) (*nbv1.ObjectBuc
 	r, err := NewBucketRequest(p, nil, bucketOptions)
 	if err != nil {
 		return nil, err
+	}
+
+	if r.SysClient.NooBaa.DeletionTimestamp != nil {
+		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
+		if util.Contains("noobaa.io/graceful_finalizer", finalizersArray) {
+			msg := fmt.Sprintf("NooBaa is in deleting state, new requests will be ignored")
+			log.Errorf(msg)
+			return nil, obErrors.NewBucketExistsError(msg)
+		}
 	}
 
 	// create account and give permissions for bucket

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1023,3 +1023,13 @@ func WriteYamlFile(name string, obj runtime.Object, moreObjects ...runtime.Objec
 
 	return nil
 }
+
+// Contains checks if string array arr contains string s
+func Contains(s string, arr []string) bool {
+	for _, b := range arr {
+		if b == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
### Explain the changes
1. Added support for graceful uninstall.
2. Added a check in system reconcile  - if  the system has deletionTimestamp and if graceful_finalizer exist and num of object buckets == 0, remove the graceful_finalizer. else, return error.
3. Added a check in Provision and Grant - if the system has deletionTimestamp and it has graceful_finalizer - return error.

### Issues: Fixed #xxx / Gap #xxx
1. need to create a PR for ocs-operator that adds graceful_finalizer to noobaa.

### Testing Instructions:
1. 
