### PR TITLE
Added to NooBaa CLI new install and uninstall flags

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -22,6 +22,7 @@ func CmdInstall() *cobra.Command {
 		Short: "Install the operator and create the noobaa system",
 		Run:   RunInstall,
 	}
+	cmd.Flags().Bool("use-obc-cleanup-policy", false, "Create NooBaa system with obc cleanup policy")
 	return cmd
 }
 
@@ -33,6 +34,7 @@ func CmdUninstall() *cobra.Command {
 		Run:   RunUninstall,
 	}
 	cmd.Flags().Bool("cleanup", false, "Enable deletion of Namespace and CRD's")
+	cmd.Flags().Bool("cleanup_data", false, "Clean object buckets")
 	return cmd
 }
 


### PR DESCRIPTION
1. Added cleanup_data flag for uninstall. From now on every uninstallation of noobaa will require the user to cleanup his OBs/OBCs by him self / use the new cleanup_data flag that will remove forcefully all his OBs/OBCs.
2. Added use_graceful_finalizer flag for install. by default, noobaa will have graceful_finalizer, by using the use_graceful_flag=false, the finalizer will be removed.