### PR TITLE
Use the GracefulFinalizer constant

### DIFF
--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -91,7 +91,7 @@ func (p *Provisioner) Provision(bucketOptions *obAPI.BucketOptions) (*nbv1.Objec
 
 	if r.SysClient.NooBaa.DeletionTimestamp != nil {
 		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
-		if util.Contains("noobaa.io/graceful_finalizer", finalizersArray) {
+		if util.Contains(nbv1.GracefulFinalizer, finalizersArray) {
 			msg := fmt.Sprintf("NooBaa is in deleting state, new requests will be ignored")
 			log.Errorf(msg)
 			return nil, obErrors.NewBucketExistsError(msg)
@@ -126,7 +126,7 @@ func (p *Provisioner) Grant(bucketOptions *obAPI.BucketOptions) (*nbv1.ObjectBuc
 
 	if r.SysClient.NooBaa.DeletionTimestamp != nil {
 		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
-		if util.Contains("noobaa.io/graceful_finalizer", finalizersArray) {
+		if util.Contains(nbv1.GracefulFinalizer, finalizersArray) {
 			msg := fmt.Sprintf("NooBaa is in deleting state, new requests will be ignored")
 			log.Errorf(msg)
 			return nil, obErrors.NewBucketExistsError(msg)

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -300,7 +300,7 @@ func (r *Reconciler) VerifyObjectBucketCleanup() error {
 	if r.NooBaa.DeletionTimestamp != nil {
 		finalizersArray := r.NooBaa.GetFinalizers()
 
-		if util.Contains("noobaa.io/graceful_finalizer", finalizersArray) {
+		if util.Contains(nbv1.GracefulFinalizer, finalizersArray) {
 
 			obcSelector, _ := labels.Parse("noobaa-domain=" + options.SubDomainNS())
 			objectBuckets := &nbv1.ObjectBucketList{}


### PR DESCRIPTION
Some places uses the string literal where it could have used the
constant. This lets all places use the constant.

Follow-up from reviewing PR #309 

Signed-off-by: Michael Adam <obnox@redhat.com>