### PR TITLE
Don't require minikube for building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ VENV ?= $(OUTPUT)/venv
 export OPERATOR_SDK_VERSION ?= v0.17.0
 export OPERATOR_SDK ?= build/_tools/operator-sdk-$(OPERATOR_SDK_VERSION)
 
+KUBECONFIG ?= build/empty-kubeconfig
+
 #------------#
 #- Building -#
 #------------#
@@ -39,7 +41,7 @@ build: cli image gen-olm
 .PHONY: build
 
 cli: $(OPERATOR_SDK) gen
-	$(OPERATOR_SDK) run --local --operator-flags "version"
+	$(OPERATOR_SDK) run --kubeconfig="$(KUBECONFIG)" --local --operator-flags "version"
 	@echo "✅ cli"
 .PHONY: cli
 
@@ -108,7 +110,7 @@ gen-api-fail-if-dirty: gen-api
 
 gen-olm: $(OPERATOR_SDK) gen
 	rm -rf $(OLM)
-	$(OPERATOR_SDK) run --local --operator-flags "olm catalog -n my-noobaa-operator --dir $(OLM)"
+	$(OPERATOR_SDK) run --kubeconfig="$(KUBECONFIG)" --local --operator-flags "olm catalog -n my-noobaa-operator --dir $(OLM)"
 	python3 -m venv $(VENV) && \
 		. $(VENV)/bin/activate && \
 		pip3 install --upgrade pip && \

--- a/build/empty-kubeconfig
+++ b/build/empty-kubeconfig
@@ -1,0 +1,22 @@
+#
+# This trival and invalid kubeconfig file has the purpose of allowing us to
+# build some targets using `operator-sdk run ...` without requiring a running
+# kubernetes environment.
+# It will not allow you to really run and use the operator.
+#
+apiVersion: v1
+kind: Config
+preferences: {}
+current-context: temp
+clusters:
+- name: temp
+  cluster:
+    server: temp
+users:
+- name: temp
+contexts:
+- name: temp
+  context:
+    cluster: temp
+    user: temp
+    namespace: temp


### PR DESCRIPTION
`make cli` runs `openshift-sdk run ...` which requires a kubeconfig.
Up to now, this target relied on minikube being started.

This modifies `devenv.sh` to generate an empty kubeconfig file and set the
KUBECONFIG variable to avoid failure if minikube is not running.

Fixes: #325

Signed-off-by: Michael Adam <obnox@redhat.com>