### PR TITLE
rgw-endpoint label will be changed to a base-64 one

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -347,8 +347,8 @@ func (r *Reconciler) ReconcileRGWCredentials() error {
 	}
 
 	if r.CephObjectstoreUser.Spec.Store == "" {
-		if r.NooBaa.Labels == nil || r.NooBaa.Labels["rgw-endpoint"] == "" {
-			r.Logger.Warnf("did not find an rgw-endpoint label on the noobaa CR")
+		if r.NooBaa.Labels == nil || r.NooBaa.Labels["rgw-endpoint-base64"] == "" {
+			r.Logger.Warnf("did not find an rgw-endpoint-base64 label on the noobaa CR")
 			return nil
 		}
 	}

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/url"
@@ -604,8 +605,13 @@ func (r *Reconciler) prepareCephBackingStore() error {
 	if r.CephObjectstoreUser.Spec.Store != "" {
 		endpoint = "http://rook-ceph-rgw-" + r.CephObjectstoreUser.Spec.Store + "." + options.Namespace + ".svc.cluster.local:80"
 
-	} else if r.NooBaa.Labels != nil && r.NooBaa.Labels["rgw-endpoint"] != "" {
-		endpoint = fmt.Sprintf("http://%s", r.NooBaa.Labels["rgw-endpoint"])
+	} else if r.NooBaa.Labels != nil && r.NooBaa.Labels["rgw-endpoint-base64"] != "" {
+		decodedEndpoint, err := base64.StdEncoding.DecodeString(r.NooBaa.Labels["rgw-endpoint-base64"])
+		if err != nil {
+			r.Logger.Infof("Ceph RGW endpoint base64 address failed to be decoded. base64=%q", r.NooBaa.Labels["rgw-endpoint-base64"])
+			return nil
+		}
+		endpoint = fmt.Sprintf("http://%s", string(decodedEndpoint))
 
 	} else {
 		return fmt.Errorf("Ceph RGW endpoint address is not available")


### PR DESCRIPTION
RGW endpoint label will be base64 instead of a regular string to avoid this:
```
Error while reconciling: NooBaa.noobaa.io "noobaa" is invalid: metadata.labels:
 Invalid value: "10.70.56.202:8080": a valid label must be an empty string or
 consist of alphanumeric characters, '-', '_' or '.', and must start and end with an
 alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for
 validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```
OCS operator side is in https://github.com/openshift/ocs-operator/pull/580