### PR TITLE
Backport to 2.3

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -339,16 +339,16 @@ func (r *Reconciler) ReconcileRGWCredentials() error {
 			r.CephObjectstoreUser.Spec.Store = storeName
 
 		} else {
-			r.Logger.Infof("did not find any ceph objectstore to use as backing store, assuming independent mode")
+			r.Logger.Info("did not find any ceph objectstore to use as backing store, assuming independent mode")
 		}
 
 	} else {
-		r.Logger.Infof("failed to list ceph objectstore to use as backing store, assuming independent mode")
+		r.Logger.Info("failed to list ceph objectstore to use as backing store, assuming independent mode")
 	}
 
 	if r.CephObjectstoreUser.Spec.Store == "" {
-		if r.NooBaa.Labels == nil || r.NooBaa.Labels["rgw-endpoint-base64"] == "" {
-			r.Logger.Warnf("did not find an rgw-endpoint-base64 label on the noobaa CR")
+		if r.NooBaa.Labels == nil || r.NooBaa.Labels["rgw-endpoint"] == "" {
+			r.Logger.Warn("did not find an rgw-endpoint label on the noobaa CR")
 			return nil
 		}
 	}

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net"
 	"net/url"
@@ -622,13 +621,10 @@ func (r *Reconciler) prepareCephBackingStore() error {
 	if r.CephObjectstoreUser.Spec.Store != "" {
 		endpoint = "http://rook-ceph-rgw-" + r.CephObjectstoreUser.Spec.Store + "." + options.Namespace + ".svc.cluster.local:80"
 
-	} else if r.NooBaa.Labels != nil && r.NooBaa.Labels["rgw-endpoint-base64"] != "" {
-		decodedEndpoint, err := base64.StdEncoding.DecodeString(r.NooBaa.Labels["rgw-endpoint-base64"])
-		if err != nil {
-			r.Logger.Infof("Ceph RGW endpoint base64 address failed to be decoded. base64=%q", r.NooBaa.Labels["rgw-endpoint-base64"])
-			return nil
-		}
-		endpoint = fmt.Sprintf("http://%s", string(decodedEndpoint))
+	} else if r.NooBaa.Labels != nil && r.NooBaa.Labels["rgw-endpoint"] != "" {
+		raw := r.NooBaa.Labels["rgw-endpoint"]
+		i := strings.LastIndex(raw, "_")
+		endpoint = fmt.Sprintf("http://%s:%s", raw[:i], raw[i+1:])
 
 	} else {
 		return fmt.Errorf("Ceph RGW endpoint address is not available")


### PR DESCRIPTION
… encoding

Base64 padding char `=` cannot be used in a label.
So we dropped base64 encoding in favor of a simple replace for the host-port seperator char `:`

(cherry picked from commit 28ae9752f6091588e43a1a58f3c89a12a779e229)