### PR TITLE
Remove app label and finalizer from CR templates and add them in code

### DIFF
--- a/deploy/crds/noobaa.io_v1alpha1_backingstore_cr.yaml
+++ b/deploy/crds/noobaa.io_v1alpha1_backingstore_cr.yaml
@@ -1,9 +1,5 @@
 apiVersion: noobaa.io/v1alpha1
 kind: BackingStore
 metadata:
-  name: aws1
-  labels:
-    app: noobaa
-  finalizers:
-    - noobaa.io/finalizer
+  name: default
 spec:

--- a/deploy/crds/noobaa.io_v1alpha1_bucketclass_cr.yaml
+++ b/deploy/crds/noobaa.io_v1alpha1_bucketclass_cr.yaml
@@ -2,8 +2,6 @@ apiVersion: noobaa.io/v1alpha1
 kind: BucketClass
 metadata:
   name: default
-  labels:
-    app: noobaa
 spec:
   placementPolicy:
     tiers:

--- a/deploy/crds/noobaa.io_v1alpha1_noobaa_cr.yaml
+++ b/deploy/crds/noobaa.io_v1alpha1_noobaa_cr.yaml
@@ -2,6 +2,4 @@ apiVersion: noobaa.io/v1alpha1
 kind: NooBaa
 metadata:
   name: noobaa
-  labels:
-    app: noobaa
 spec: {}

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -149,8 +149,13 @@ func (r *Reconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, nil
 	}
 
-	if added := util.AddFinalizer(r.BackingStore, nbv1.Finalizer); added && !util.KubeUpdate(r.BackingStore) {
-		log.Errorf("BackingStore %q failed to add finalizer %q", r.BackingStore.Name, nbv1.Finalizer)
+	if util.EnsureCommonMetaFields(r.BackingStore, nbv1.Finalizer) {
+		if !util.KubeUpdate(r.BackingStore) {
+			log.Errorf("❌ BackingStore %q failed to add mandatory meta fields", r.BackingStore.Name)
+
+			res.RequeueAfter = 3 * time.Second
+			return res, nil
+		}
 	}
 
 	system.CheckSystem(r.NooBaa)

--- a/pkg/bucketclass/reconciler.go
+++ b/pkg/bucketclass/reconciler.go
@@ -86,8 +86,13 @@ func (r *Reconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, nil
 	}
 
-	if added := util.AddFinalizer(r.BucketClass, nbv1.Finalizer); added && !util.KubeUpdate(r.BucketClass) {
-		log.Errorf("BucketClass %q failed to add finalizer %q", r.BucketClass.Name, nbv1.Finalizer)
+	if util.EnsureCommonMetaFields(r.BucketClass, nbv1.Finalizer) {
+		if !util.KubeUpdate(r.BucketClass) {
+			log.Errorf("❌ BucketClass %q failed to add mandatory meta fields", r.BucketClass.Name)
+
+			res.RequeueAfter = 3 * time.Second
+			return res, nil
+		}
 	}
 
 	system.CheckSystem(r.NooBaa)

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1712,27 +1712,21 @@ spec:
     storage: true
 `
 
-const Sha256_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml = "507d6a8477b6c2073c91d85806dc79b953a5a6e0ac442c2fe337b8f5ce6eaadb"
+const Sha256_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml = "84ca6f2a35a413e74a51375bd0ec31c33bb76a00de8e0ef8d02a7798e02ec460"
 
 const File_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml = `apiVersion: noobaa.io/v1alpha1
 kind: BackingStore
 metadata:
-  name: aws1
-  labels:
-    app: noobaa
-  finalizers:
-    - noobaa.io/finalizer
+  name: default
 spec:
 `
 
-const Sha256_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml = "af1411669ca0b29bdb7836e9e1fc44a0ddb7d4a994266abbae793a7116f6499f"
+const Sha256_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml = "d781b04f37c9f376a52c71a1c5abd6acf78fc825fe7f2058d2bb9892afbbd6df"
 
 const File_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml = `apiVersion: noobaa.io/v1alpha1
 kind: BucketClass
 metadata:
   name: default
-  labels:
-    app: noobaa
 spec:
   placementPolicy:
     tiers:
@@ -1740,14 +1734,12 @@ spec:
       - aws1
 `
 
-const Sha256_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml = "0e1f573b02ad8f9f1e4e8bed5fe47e4651040277e0accf1e30b1369745371483"
+const Sha256_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml = "498c2013757409432cfd98b21a5934bccf506f1af1b885241db327024aa450fd"
 
 const File_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml = `apiVersion: noobaa.io/v1alpha1
 kind: NooBaa
 metadata:
   name: noobaa
-  labels:
-    app: noobaa
 spec: {}
 `
 

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -245,8 +245,13 @@ func (r *Reconciler) Reconcile() (reconcile.Result, error) {
 		return res, nil
 	}
 
-	if added := util.AddFinalizer(r.NooBaa, nbv1.GracefulFinalizer); added && !util.KubeUpdate(r.NooBaa) {
-		log.Errorf("NooBaa %q failed to add finalizer %q", r.NooBaa.Name, nbv1.GracefulFinalizer)
+	if util.EnsureCommonMetaFields(r.NooBaa, nbv1.GracefulFinalizer) {
+		if !util.KubeUpdate(r.NooBaa) {
+			log.Errorf("❌ NooBaa %q failed to add mandatory meta fields", r.NooBaa.Name)
+
+			res.RequeueAfter = 3 * time.Second
+			return res, nil
+		}
 	}
 
 	if err := r.VerifyObjectBucketCleanup(); err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1068,3 +1068,27 @@ func ReflectEnvVariable(env *[]corev1.EnvVar, name string) {
 		}
 	}
 }
+
+// EnsureCommonMetaFields ensures that the resource has all mandatory meta fields
+func EnsureCommonMetaFields(object metav1.Object, finalizer string) bool {
+	updated := false
+
+	labels := object.GetLabels()
+	if labels == nil {
+		object.SetLabels(map[string]string{
+			"app": "noobaa",
+		})
+		updated = true
+
+	} else if labels["app"] != "noobaa" {
+		labels["app"] = "noobaa"
+		object.SetLabels(labels)
+		updated = true
+
+	}
+	if AddFinalizer(object, finalizer) {
+		updated = true
+
+	}
+	return updated
+}


### PR DESCRIPTION
The `BackingStore` object sent to `KubeCheck` at the start of the backing store reconcile loop is already filled with a finalizer and label (loaded from the backing store cr template). This means that even in the case where the k8s resource has no finalizers or labels, the in-memory object will contain values for those fields. 
This prevents the operator from adding a finalizer at the start of the reconcile loop (because the operator believes that a finalizer is already present on the backing store).

This PR removed any meta info from the template and adds it back in code after checking that the loaded backing store is missing some or all of the desired meta fields.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1858385

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>