### PR TITLE
Add predicates to filter out non-relevant events and log relevant events

### DIFF
--- a/pkg/controller/bucketclass/bucketclass_controller.go
+++ b/pkg/controller/bucketclass/bucketclass_controller.go
@@ -3,10 +3,13 @@ package bucketclass
 import (
 	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v2/pkg/bucketclass"
+	"github.com/noobaa/noobaa-operator/v2/pkg/util"
+
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -33,21 +36,33 @@ func Add(mgr manager.Manager) error {
 		return err
 	}
 
-	// Watch for changes on resources to trigger reconcile
+	// Predicate that allow us to log event that are being queued
+	logEventsPredicate := util.LogEventsPredicate{}
 
-	err = c.Watch(&source.Kind{Type: &nbv1.BucketClass{}}, &handler.EnqueueRequestForObject{})
+	// Predicate that allows events that only change spec, labels or finalizers and will log any allowed events
+	// This will stop infinite reconciles that triggered by status or irrelevant metadata changes
+	bucketClassPredicate := util.ComposePredicates(
+		predicate.GenerationChangedPredicate{},
+		util.LabelsChangedPredicate{},
+		util.FinalizersChangedPredicate{},
+	)
+
+	// Watch for changes on resources to trigger reconcile
+	err = c.Watch(&source.Kind{Type: &nbv1.BucketClass{}}, &handler.EnqueueRequestForObject{},
+		bucketClassPredicate, &logEventsPredicate)
 	if err != nil {
 		return err
 	}
 
-	err = c.Watch(&source.Kind{Type: &nbv1.BackingStore{}}, &handler.EnqueueRequestsFromMapFunc{
+	backingStoreHandler := handler.EnqueueRequestsFromMapFunc{
 		ToRequests: handler.ToRequestsFunc(func(obj handler.MapObject) []reconcile.Request {
 			return bucketclass.MapBackingstoreToBucketclasses(types.NamespacedName{
 				Name:      obj.Meta.GetName(),
 				Namespace: obj.Meta.GetNamespace(),
 			})
 		}),
-	})
+	}
+	err = c.Watch(&source.Kind{Type: &nbv1.BackingStore{}}, &backingStoreHandler, logEventsPredicate)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/manager.go
+++ b/pkg/operator/manager.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/noobaa/noobaa-operator/v2/pkg/options"
 	"github.com/noobaa/noobaa-operator/v2/pkg/system"
@@ -42,14 +41,11 @@ func RunOperator(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to become leader: %s", err)
 	}
 
-	recocileDelta := time.Duration(5 * 60) // 5 minutes
-
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(config, manager.Options{
 		Namespace:          options.Namespace,
 		MapperProvider:     util.MapperProvider, // restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-		SyncPeriod:         &recocileDelta,
 	})
 	if err != nil {
 		log.Fatalf("Failed to create manager: %s", err)

--- a/pkg/util/predicates.go
+++ b/pkg/util/predicates.go
@@ -1,0 +1,112 @@
+package util
+
+import (
+	"reflect"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ComposePredicates will compose a variable number of predicte and return a predicate that
+// will allow events that are allowed by any of the given predicates.
+func ComposePredicates(predicates ...predicate.Predicate) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Create(e) {
+					return true
+				}
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Delete(e) {
+					return true
+				}
+			}
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Update(e) {
+					return true
+				}
+			}
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Generic(e) {
+					return true
+				}
+			}
+			return false
+		},
+	}
+}
+
+// LabelsChangedPredicate will only allow events that changed Metadata.Labels
+type LabelsChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements the update event trap for LabelsChangedPredicate
+func (p LabelsChangedPredicate) Update(e event.UpdateEvent) bool {
+	return e.MetaOld != nil &&
+		e.MetaNew != nil &&
+		!reflect.DeepEqual(e.MetaOld.GetLabels(), e.MetaNew.GetLabels())
+}
+
+// FinalizersChangedPredicate will only allow events that changed Metadata.Finalizers
+type FinalizersChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements the update event trap for FinalizersChangedPredicate
+func (p FinalizersChangedPredicate) Update(e event.UpdateEvent) bool {
+	return e.MetaOld != nil &&
+		e.MetaNew != nil &&
+		!reflect.DeepEqual(e.MetaOld.GetFinalizers(), e.MetaNew.GetFinalizers())
+}
+
+// LogEventsPredicate will passthrough events while loging a message for each
+type LogEventsPredicate struct {
+}
+
+// Create implements the create event trap for LogEventsPredicate
+func (p LogEventsPredicate) Create(e event.CreateEvent) bool {
+	if e.Meta != nil {
+		logrus.Infof("Create event detected for %s (%s), queuing Reconcile",
+			e.Meta.GetName(), e.Meta.GetNamespace())
+	}
+	return true
+}
+
+// Delete implements the delete event trap for LogEventsPredicate
+func (p LogEventsPredicate) Delete(e event.DeleteEvent) bool {
+	if e.Meta != nil {
+		logrus.Infof("Delete event detected for %s (%s), queuing Reconcile",
+			e.Meta.GetName(), e.Meta.GetNamespace())
+	}
+	return true
+}
+
+// Update implements the update event trap for LogEventsPredicate
+func (p LogEventsPredicate) Update(e event.UpdateEvent) bool {
+	if e.MetaOld != nil {
+		logrus.Infof("Update event detected for %s (%s), queuing Reconcile",
+			e.MetaOld.GetName(), e.MetaOld.GetNamespace())
+	}
+	return true
+}
+
+// Generic implements the generic event trap for LogEventsPredicate
+func (p LogEventsPredicate) Generic(e event.GenericEvent) bool {
+	if e.Meta != nil {
+		logrus.Infof("Generic event detected for %s (%s), queuing Reconcile",
+			e.Meta.GetName(), e.Meta.GetNamespace())
+	}
+	return true
+}


### PR DESCRIPTION
Also, remove manager SyncPeriod time dev code left by accident in the code

This PR solves the infinite reconcile problem we have in the operator. 
The main reason for the problem is that the operator is watching resources (`NooBaa`, `BackingStore`, `BucketClass`) that it is also responsible for updating,  specifically writing the status of each of these resources on every reconcile cycle.

The fix is to filter the events the reconcile reacts to. Allowing only meaningful changes to passthrough  

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1849309

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>