### PR TITLE
Backport into 5.6

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.5.0-rc3"
+	ContainerImageTag = "5.6.0-20200802"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
Bumped core image to 5.6.0-20200802

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit 4c9e41ed5dd420142bf3cb76242db2e7252985e4)