### PR TITLE
Add db-type flag and the ability to install postgress using the CLI

### DIFF
--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -698,6 +698,13 @@ spec:
                 where the system stores its database which contains system config,
                 buckets, objects meta-data and mapping file parts to storage locations.
               type: string
+            dbType:
+              description: DBType (optional) overrides the default type image for
+                the db container
+              enum:
+              - mongodb
+              - postgres
+              type: string
             dbVolumeResources:
               description: 'DBVolumeResources (optional) overrides the default PVC
                 resource requirements for the database volume. For the time being
@@ -735,7 +742,7 @@ spec:
               properties:
                 additionalVirtualHosts:
                   description: 'AdditionalVirtualHosts (optional) provide a list of
-                    additional hostnames (on top of the buildin names defined by the
+                    additional hostnames (on top of the builtin names defined by the
                     cluster: service name, elb name, route name) to be used as virtual
                     hosts by the the endpoints in the endpoint deployment'
                   items:

--- a/deploy/internal/service-db.yaml
+++ b/deploy/internal/service-db.yaml
@@ -15,3 +15,6 @@ spec:
     - port: 27017
       targetPort: 27017
       name: mongodb
+    - port: 5432
+      targetPort: 5432
+      name: postgres

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: noobaa-db
+  labels:
+    app: noobaa
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      noobaa-db: noobaa
+  serviceName: noobaa-db
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: noobaa
+        noobaa-db: noobaa
+    spec:
+      serviceAccountName: noobaa
+      initContainers:
+        #----------------#
+        # INIT CONTAINER #
+        #----------------#
+        - name: init
+          image: NOOBAA_CORE_IMAGE
+          command:
+            - /noobaa_init_files/noobaa_init.sh
+            - init_mongo
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "500Mi"
+            limits:
+              cpu: "500m"
+              memory: "500Mi"
+          volumeMounts:
+            - name: db
+              mountPath: /mongo_data
+      containers:
+        #--------------------#
+        # Postgres CONTAINER #
+        #--------------------#
+        - name: db
+          image: NOOBAA_DB_IMAGE
+          env:
+            - name: POSTGRES_DB
+              value: nbcore
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: noobaa
+          magePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: db
+              # mountPath: /var/lib/postgresql/data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: db
+        labels:
+          app: noobaa
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -68,6 +68,11 @@ type NooBaaSpec struct {
 	// +optional
 	DBImage *string `json:"dbImage,omitempty"`
 
+	// DBType (optional) overrides the default type image for the db container
+	// +optional
+	// +kubebuilder:validation:Enum=mongodb;postgres
+	DBType DBTypes `json:"dbType,omitempty"`
+
 	// CoreResources (optional) overrides the default resource requirements for the server container
 	// +optional
 	CoreResources *corev1.ResourceRequirements `json:"coreResources,omitempty"`
@@ -143,7 +148,7 @@ type EndpointsSpec struct {
 	MaxCount int32 `json:"maxCount,omitempty"`
 
 	// AdditionalVirtualHosts (optional) provide a list of additional hostnames
-	// (on top of the buildin names defined by the cluster: service name, elb name, route name)
+	// (on top of the builtin names defined by the cluster: service name, elb name, route name)
 	// to be used as virtual hosts by the the endpoints in the endpoint deployment
 	// +optional
 	AdditionalVirtualHosts []string `json:"additionalVirtualHosts,omitempty"`
@@ -329,4 +334,15 @@ const (
 
 	// DeleteOBCConfirmation represents the validation to destry obc
 	DeleteOBCConfirmation CleanupConfirmationProperty = "yes-really-destroy-obc"
+)
+
+// DBTypes is a string enum type for specify the types of DB that are supported.
+type DBTypes string
+
+// These are the valid DB types:
+const (
+	// DBTypeMongo is mongodb
+	DBTypeMongo DBTypes = "mongodb"
+	// DBTypePostgres is postgres
+	DBTypePostgres DBTypes = "postgres"
 )

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -938,7 +938,7 @@ func (r *Reconciler) reconcileExistingPods(podsList *corev1.PodList) error {
 		// Deployment and Statefulset are handling this by taking down the pod and
 		// starting a new one.
 		// In order to support reconciling changes to the proxy env we need to mimic
-		// this behaviour which is not trival in the case of agent pods.
+		// this behavior which is not trivial in the case of agent pods.
 		var c = &pod.Spec.Containers[0]
 		for _, name := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
 			envVar := util.GetEnvVariable(&c.Env, name)

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -599,7 +599,7 @@ spec:
     storage: true
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "56aae3e1d98a7194df57733855733d9e07fb6e7f1883d3b20a95c23e73b2a193"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "a1b3661d6614535e354be74f26896004f24236b94277fd5858b65cb57810cfe6"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -1266,6 +1266,9 @@ spec:
             dbImage:
               description: DBImage (optional) overrides the default image for the
                 db container
+              enum:
+                  - mongodb
+                  - postgres
               type: string
             dbResources:
               description: DBResources (optional) overrides the default resource requirements
@@ -1300,6 +1303,13 @@ spec:
                 is immutable and can only be set on system creation. This affects
                 where the system stores its database which contains system config,
                 buckets, objects meta-data and mapping file parts to storage locations.
+              type: string
+            dbType:
+              description: DBType (optional) overrides the default type image for
+                the db container
+              enum:
+              - mongodb
+              - postgres
               type: string
             dbVolumeResources:
               description: 'DBVolumeResources (optional) overrides the default PVC
@@ -1338,7 +1348,7 @@ spec:
               properties:
                 additionalVirtualHosts:
                   description: 'AdditionalVirtualHosts (optional) provide a list of
-                    additional hostnames (on top of the buildin names defined by the
+                    additional hostnames (on top of the builtin names defined by the
                     cluster: service name, elb name, route name) to be used as virtual
                     hosts by the the endpoints in the endpoint deployment'
                   items:
@@ -3412,4 +3422,3 @@ metadata:
   annotations:
     serviceaccounts.openshift.io/oauth-redirectreference.noobaa-mgmt: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"noobaa-mgmt"}}'
 `
-

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -68,6 +68,14 @@ var NooBaaImage = ContainerImage
 // it can be overridden for testing or different registry locations.
 var DBImage = "centos/mongodb-36-centos7"
 
+// DBPostgresImage is the default postgres db image url
+// currently it can not be overridden.
+var DBPostgresImage = "postgres:12.3"
+
+// DBType is the default db image type
+// it can be overridden for testing or different types.
+var DBType = "mongodb"
+
 // DBVolumeSizeGB can be used to override the default database volume size
 var DBVolumeSizeGB = 0
 
@@ -83,7 +91,7 @@ var PVPoolDefaultStorageClass = ""
 // which is needed when using a private container registry.
 var ImagePullSecret = ""
 
-// MiniEnv setting this option indicates to the operator that it is deployed on low reosurce environment
+// MiniEnv setting this option indicates to the operator that it is deployed on low resource environment
 // This info is used by the operator for environment based decisions (e.g. number of resources to request per
 // pod)
 var MiniEnv = false
@@ -124,6 +132,10 @@ func init() {
 	FlagSet.StringVar(
 		&DBImage, "db-image",
 		DBImage, "The database container image",
+	)
+	FlagSet.StringVar(
+		&DBType, "db-type",
+		DBType, "The type of database container image (mongodb, postgres)",
 	)
 	FlagSet.IntVar(
 		&DBVolumeSizeGB, "db-volume-size-gb",

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -290,7 +290,7 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 				case "MONGODB_URL":
 					if r.JoinSecret == nil {
 						c.Env[j].Value = fmt.Sprintf(`mongodb://%s-0.%s/nbcore`,
-							r.NooBaaDB.Name, r.NooBaaDB.Spec.ServiceName)
+							r.NooBaaMongoDB.Name, r.NooBaaMongoDB.Spec.ServiceName)
 					}
 				case "LOCAL_MD_SERVER":
 					if r.JoinSecret == nil {
@@ -447,7 +447,7 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 		if minutesSinceCreation < 2 {
 			return nil
 		}
-		if err := r.preparePVoolBackingStore(); err != nil {
+		if err := r.preparePVPoolBackingStore(); err != nil {
 			return err
 		}
 	}
@@ -460,7 +460,7 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 	return nil
 }
 
-func (r *Reconciler) preparePVoolBackingStore() error {
+func (r *Reconciler) preparePVPoolBackingStore() error {
 
 	// create backing store
 	defaultPVSize := int64(50) * 1024 * 1024 * 1024 // 50GB
@@ -491,9 +491,9 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", r.AWSCloudCreds.Spec.SecretRef.Name)
 		return fmt.Errorf("cloud credentials secret %q is not ready yet", r.AWSCloudCreds.Spec.SecretRef.Name)
 	}
-	r.Logger.Infof("Secret %s was created succesfully by cloud-credentials operator", r.AWSCloudCreds.Spec.SecretRef.Name)
+	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", r.AWSCloudCreds.Spec.SecretRef.Name)
 
-	// create the acutual S3 bucket
+	// create the actual S3 bucket
 	region, err := util.GetAWSRegion()
 	if err != nil {
 		r.Recorder.Eventf(r.NooBaa, corev1.EventTypeWarning, "DefaultBackingStoreFailure",
@@ -539,7 +539,7 @@ func (r *Reconciler) prepareAzureBackingStore() error {
 		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", r.AzureCloudCreds.Spec.SecretRef.Name)
 		return fmt.Errorf("cloud credentials secret %q is not ready yet", r.AzureCloudCreds.Spec.SecretRef.Name)
 	}
-	r.Logger.Infof("Secret %s was created succesfully by cloud-credentials operator", r.AzureCloudCreds.Spec.SecretRef.Name)
+	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", r.AzureCloudCreds.Spec.SecretRef.Name)
 
 	util.KubeCheck(r.AzureContainerCreds)
 	if r.AzureContainerCreds.UID == "" {
@@ -552,7 +552,7 @@ func (r *Reconciler) prepareAzureBackingStore() error {
 			return fmt.Errorf("got error on AzureContainerCreds creation. error: %v", err)
 		}
 	}
-	r.Logger.Infof("Secret %s was created succesfully", r.AzureContainerCreds.Name)
+	r.Logger.Infof("Secret %s was created successfully", r.AzureContainerCreds.Name)
 
 	var azureGroupName = r.AzureContainerCreds.StringData["azure_resourcegroup"]
 


### PR DESCRIPTION
### Added
- Added db-type flag that can get mongodb or postgres
- Adding statfulset postgres db
- Implemeting the db-type functionality, when using --db-type postgres the db to be installed is postgres

### Missing 
- In statfulset postgres db get the cradentials should be from a secret, currently is is hard coded defaults.
- In statfulset postgres db the mountPath is the same as mongo's

- ~We override NooBaaDB with the postgres yaml when we are calling db-type flag. probebly better way is to keep one NooBaaDB and instead of replacing it, assigned it with NooBaaMongoDB or NooBaaPostgresDB~ 

### Limitations
- noobaa-core is not connecting - as planned for this stage. 
- When using this flag it revokes the db-image flag and currently the postgres image is hard coded (in the options). 
- We might want to change also the `/noobaa_init_files/noobaa_init.sh` in the core side. 

Signed-off-by: liranmauda <liran.mauda@gmail.com>
