### PR TITLE
Change pod delete handling for pvpool

### DIFF
--- a/deploy/internal/pod-agent.yaml
+++ b/deploy/internal/pod-agent.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app: noobaa
   name: noobaa-agent
-  finalizers:
-    - noobaa.io/finalizer
 spec:
   containers:
     - name: noobaa-agent

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1937,7 +1937,7 @@ spec:
   targetCPUUtilizationPercentage: 80
 `
 
-const Sha256_deploy_internal_pod_agent_yaml = "af92f0db07b5645470bc390d759c2a0014ee9fb0467984dd3f1c91d2133372c5"
+const Sha256_deploy_internal_pod_agent_yaml = "a111e68beec272ac08d240755904bfde4df9b4e64783c67dd4289450e55b02bc"
 
 const File_deploy_internal_pod_agent_yaml = `apiVersion: v1
 kind: Pod
@@ -1945,8 +1945,6 @@ metadata:
   labels:
     app: noobaa
   name: noobaa-agent
-  finalizers:
-    - noobaa.io/finalizer
 spec:
   containers:
     - name: noobaa-agent


### PR DESCRIPTION
Few updates on how we handle the pods of the pv-pools:
- removed finalizers in order to not get the drain process getting stuck (during OCP upgrade) BZ1867762
- on spec changes in existing pods - check if the pods need to be deleted and then delete it and create a new one with the right spec - fix issue we had with changing the imagePullSecret BZ1868646
- fixing a known gap of ours #364 

Signed-off-by: jackyalbo <jalbo@redhat.com>