### PR TITLE
Adding mongodb-url flag that can change the url of mongo, enabling to connect to a remote mongodb

### DIFF
--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -832,6 +832,10 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+              mongoDbURL:
+                description: MongoDbURL (optional) overrides the default mongo db
+                  remote url
+                type: string
               pvPoolDefaultStorageClass:
                 description: PVPoolDefaultStorageClass (optional) overrides the default
                   cluster StorageClass for the pv-pool volumes. This affects where

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -97,6 +97,10 @@ type NooBaaSpec struct {
 	// +optional
 	DBStorageClass *string `json:"dbStorageClass,omitempty"`
 
+	// MongoDbURL (optional) overrides the default mongo db remote url
+	// +optional
+	MongoDbURL string `json:"mongoDbURL,omitempty"`
+
 	// PVPoolDefaultStorageClass (optional) overrides the default cluster StorageClass for the pv-pool volumes.
 	// This affects where the system stores data chunks (encrypted).
 	// Updates to this field will only affect new pv-pools,

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -980,7 +980,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "5c4b7453e4946428a0c53867dbf7f30cfffb34ad95d4c7bb6141ad6003b75f64"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "a7a87b507e0d7ca2ee52f440e86b1d7383123d14c5e9265ca5b837345175aca8"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1816,6 +1816,10 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+              mongoDbURL:
+                description: MongoDbURL (optional) overrides the default mongo db
+                  remote url
+                type: string
               pvPoolDefaultStorageClass:
                 description: PVPoolDefaultStorageClass (optional) overrides the default
                   cluster StorageClass for the pv-pool volumes. This affects where

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -82,6 +82,10 @@ var DBVolumeSizeGB = 0
 // it can be overridden for testing or different PV providers.
 var DBStorageClass = ""
 
+// MongoDbURL is used for providing mongodb url
+// it can be overridden for testing or different url.
+var MongoDbURL = ""
+
 // PVPoolDefaultStorageClass is used for PVC's allocation for the noobaa server data
 // it can be overridden for testing or different PV providers.
 var PVPoolDefaultStorageClass = ""
@@ -143,6 +147,10 @@ func init() {
 	FlagSet.StringVar(
 		&DBStorageClass, "db-storage-class",
 		DBStorageClass, "The database volume storage class name",
+	)
+	FlagSet.StringVar(
+		&MongoDbURL, "mongodb-url",
+		MongoDbURL, "url for mongodb",
 	)
 	FlagSet.StringVar(
 		&PVPoolDefaultStorageClass, "pv-pool-default-storage-class",

--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -104,7 +104,7 @@ func (r *Reconciler) CheckSystemCR() error {
 	// Set ActualImage to be updated in the noobaa status
 	r.NooBaa.Status.ActualImage = specImage
 
-	// Verfify the endpoints spec
+	// Verify the endpoints spec
 	endpointsSpec := r.NooBaa.Spec.Endpoints
 	if endpointsSpec != nil {
 		if endpointsSpec.MinCount <= 0 {

--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -126,6 +126,11 @@ func (r *Reconciler) CheckSystemCR() error {
 		}
 	}
 
+	err = CheckMongoURL(r.NooBaa)
+	if err != nil {
+		return util.NewPersistentError("InvalidMongoDbURL", fmt.Sprintf(`%s`, err))
+	}
+
 	return nil
 }
 

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -298,7 +298,11 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			c.Env[j].Value = r.SetDesiredAgentProfile(c.Env[j].Value)
 
 		case "MONGODB_URL":
-			c.Env[j].Value = "mongodb://" + r.NooBaaMongoDB.Name + "-0." + r.NooBaaMongoDB.Spec.ServiceName + "/nbcore"
+			if r.NooBaa.Spec.MongoDbURL != "" {
+				c.Env[j].Value = r.NooBaa.Spec.MongoDbURL
+			} else {
+				c.Env[j].Value = "mongodb://" + r.NooBaaMongoDB.Name + "-0." + r.NooBaaMongoDB.Spec.ServiceName + "/nbcore"
+			}
 
 		case "POSTGRES_HOST":
 			c.Env[j].Value = r.NooBaaPostgresDB.Name + "-0." + r.NooBaaPostgresDB.Spec.ServiceName
@@ -373,7 +377,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 				coreImageChanged = true
 				c.Image = r.NooBaa.Status.ActualImage
 			}
-			// adding the missing Env varibale from default container
+			// adding the missing Env variable from default container
 			util.MergeEnvArrays(&c.Env, &r.DefaultCoreApp.Env)
 			r.setDesiredCoreEnv(c)
 

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -309,6 +309,10 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 					} else {
 						c.Env[j].Value = r.JoinSecret.StringData["hosted_agents_addr"]
 					}
+				case "MONGODB_URL":
+					if r.JoinSecret == nil {
+						c.Env[j].Value = r.MongoConnectionString
+					}
 				case "LOCAL_MD_SERVER":
 					if r.JoinSecret == nil {
 						c.Env[j].Value = "true"

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -52,16 +52,17 @@ var (
 
 // Reconciler is the context for loading or reconciling a noobaa system
 type Reconciler struct {
-	Request         types.NamespacedName
-	Client          client.Client
-	Scheme          *runtime.Scheme
-	Ctx             context.Context
-	Logger          *logrus.Entry
-	Recorder        record.EventRecorder
-	NBClient        nb.Client
-	CoreVersion     string
-	OperatorVersion string
-	OAuthEndpoints  *util.OAuth2Endpoints
+	Request               types.NamespacedName
+	Client                client.Client
+	Scheme                *runtime.Scheme
+	Ctx                   context.Context
+	Logger                *logrus.Entry
+	Recorder              record.EventRecorder
+	NBClient              nb.Client
+	CoreVersion           string
+	OperatorVersion       string
+	OAuthEndpoints        *util.OAuth2Endpoints
+	MongoConnectionString string
 
 	NooBaa                    *nbv1.NooBaa
 	ServiceAccount            *corev1.ServiceAccount
@@ -262,12 +263,14 @@ func (r *Reconciler) CheckAll() {
 	util.KubeCheck(r.CoreApp)
 	util.KubeCheck(r.ServiceMgmt)
 	util.KubeCheck(r.ServiceS3)
-	if r.NooBaa.Spec.DBType == "postgres" {
-		util.KubeCheck(r.SecretDB)
-		util.KubeCheck(r.NooBaaPostgresDB)
-		util.KubeCheck(r.ServiceDbPg)
-	} else {
-		util.KubeCheck(r.NooBaaMongoDB)
+	if r.NooBaa.Spec.MongoDbURL == "" {
+		if r.NooBaa.Spec.DBType == "postgres" {
+			util.KubeCheck(r.SecretDB)
+			util.KubeCheck(r.NooBaaPostgresDB)
+			util.KubeCheck(r.ServiceDbPg)
+		} else {
+			util.KubeCheck(r.NooBaaMongoDB)
+		}
 		util.KubeCheck(r.ServiceDb)
 	}
 	util.KubeCheck(r.SecretServer)


### PR DESCRIPTION
- Adding mongodb-url flag that can change the URL of mongo, enabling to connect to a remote mongodb
- Skipping create of db pod when given an external db URL

Expecting URL to start with:  `mongodb://` or `mongodb+srv://`

Fixes: #304 
