### PR TITLE
Fixes for issues with retrieving agent_config when the server has issues while creating a pvpool

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -928,6 +928,16 @@ func (r *Reconciler) ReconcilePool() error {
 }
 
 func (r *Reconciler) reconcilePvPool() error {
+	if r.Secret.StringData["AGENT_CONFIG"] == "" {
+		res, err := r.NBClient.GetHostsPoolAgentConfigAPI(nb.GetHostsPoolAgentConfigParams{
+			Name: r.BackingStore.Name,
+		})
+		if err != nil {
+			return err
+		}
+		r.Secret.StringData["AGENT_CONFIG"] = res
+		util.KubeUpdate(r.Secret)
+	}
 	podsList := &corev1.PodList{}
 	pvcsList := &corev1.PersistentVolumeClaimList{}
 	util.KubeList(podsList, client.InNamespace(options.Namespace), client.MatchingLabels{"pool": r.BackingStore.Name})
@@ -1060,12 +1070,7 @@ func (r *Reconciler) isPodinNoobaa(pod *corev1.Pod) bool {
 	return false
 }
 
-func (r *Reconciler) updatePodTemplate() error {
-	if r.Secret.StringData["AGENT_CONFIG"] == "" {
-		return util.NewPersistentError("No AgentConfig - Can't add Missing Agents",
-			fmt.Sprintf("Current Backing store spec is: %q", r.BackingStore.Spec.PVPool))
-	}
-
+func (r *Reconciler) updatePodTemplate() {
 	c := &r.PodAgentTemplate.Spec.Containers[0]
 	for j := range c.Env {
 		switch c.Env[j].Name {
@@ -1096,10 +1101,9 @@ func (r *Reconciler) updatePodTemplate() error {
 	if r.NooBaa.Spec.Tolerations != nil {
 		r.PodAgentTemplate.Spec.Tolerations = r.NooBaa.Spec.Tolerations
 	}
-	return nil
 }
 
-func (r *Reconciler) updatePvcTemplate() error {
+func (r *Reconciler) updatePvcTemplate() {
 	if r.BackingStore.Spec.PVPool.StorageClass != "" {
 		r.PvcAgentTemplate.Spec.StorageClassName = &r.BackingStore.Spec.PVPool.StorageClass
 	} else if r.NooBaa.Spec.PVPoolDefaultStorageClass != nil {
@@ -1107,7 +1111,6 @@ func (r *Reconciler) updatePvcTemplate() error {
 	}
 	r.PvcAgentTemplate.Spec.Resources = *r.BackingStore.Spec.PVPool.VolumeResources
 	r.PvcAgentTemplate.Labels = map[string]string{"pool": r.BackingStore.Name}
-	return nil
 }
 
 func (r *Reconciler) deletePvPool() error {

--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -24,6 +24,7 @@ type Client interface {
 	CreateAccountAPI(CreateAccountParams) (CreateAccountReply, error)
 	CreateBucketAPI(CreateBucketParams) error
 	CreateHostsPoolAPI(CreateHostsPoolParams) (string, error)
+	GetHostsPoolAgentConfigAPI(GetHostsPoolAgentConfigParams) (string, error)
 	UpdateHostsPoolAPI(UpdateHostsPoolParams) error
 	CreateCloudPoolAPI(CreateCloudPoolParams) error
 	CreateTierAPI(CreateTierParams) error
@@ -189,6 +190,17 @@ func (c *RPCClient) CreateBucketAPI(params CreateBucketParams) error {
 // CreateHostsPoolAPI calls pool_api.create_hosts_pool()
 func (c *RPCClient) CreateHostsPoolAPI(params CreateHostsPoolParams) (string, error) {
 	req := &RPCMessage{API: "pool_api", Method: "create_hosts_pool", Params: params}
+	res := &struct {
+		RPCMessage `json:",inline"`
+		Reply      string `json:"reply"`
+	}{}
+	err := c.Call(req, res)
+	return res.Reply, err
+}
+
+// GetHostsPoolAgentConfigAPI calls pool_api.get_hosts_pool_agent_config()
+func (c *RPCClient) GetHostsPoolAgentConfigAPI(params GetHostsPoolAgentConfigParams) (string, error) {
+	req := &RPCMessage{API: "pool_api", Method: "get_hosts_pool_agent_config", Params: params}
 	res := &struct {
 		RPCMessage `json:",inline"`
 		Reply      string `json:"reply"`

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -328,6 +328,12 @@ type CreateHostsPoolParams struct {
 	Backingstore *BackingStoreInfo `json:"backingstore,omitempty"`
 }
 
+// GetHostsPoolAgentConfigParams is the params of pool_api.get_hosts_pool_agent_config()
+type GetHostsPoolAgentConfigParams struct {
+	Name         string            `json:"name"`
+	Backingstore *BackingStoreInfo `json:"backingstore,omitempty"`
+}
+
 // UpdateHostsPoolParams is the params of pool_api.update_hosts_pool()
 type UpdateHostsPoolParams struct {
 	Name         string            `json:"name"`


### PR DESCRIPTION
fix for overlooking a missing AGENT_CONFIG in pvpool secret
recheck for agent_config in case it wasn't available

Signed-off-by: jackyalbo <jalbo@redhat.com>