### PR TITLE
Fixing dbType from non supported CR

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -499,7 +499,7 @@ func (r *Reconciler) ReconcileDB() error {
 	var err error = nil
 	if r.NooBaa.Spec.DBType == "postgres" {
 		err = r.ReconcileObject(r.NooBaaPostgresDB, r.SetDesiredNooBaaDB)
-	} else if r.NooBaa.Spec.DBType == "mongodb" {
+	} else if r.NooBaa.Spec.DBType == "" || r.NooBaa.Spec.DBType == "mongodb" {
 		err = r.ReconcileObject(r.NooBaaMongoDB, r.SetDesiredNooBaaDB)
 	} else {
 		err = util.NewPersistentError("UnknownDBType", "Unknown dbType is specified in NooBaa spec")


### PR DESCRIPTION
Added checks for non existing dbType variable in the CR.
This is done in order to support previous CRs.
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1876118

Signed-off-by: Evgeniy Belyi <jeniawhite92@gmail.com>