### PR TITLE
fixed wrong endpoint address when RGW is deployed externally

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -618,17 +618,24 @@ func (r *Reconciler) prepareCephBackingStore() error {
 	}
 
 	endpoint := ""
-	if r.CephObjectstoreUser.Spec.Store != "" {
+	if cephObjectUserSecret.StringData["Endpoint"] != "" {
+		// first look for the endpoint in the secret
+		endpoint = cephObjectUserSecret.StringData["Endpoint"]
+		r.Logger.Infof("Found RGW endpoint in cephObjectUserSecret %q",secretName)
+	} else if r.CephObjectstoreUser.Spec.Store != "" {
+		// if not found in the secret compose from the ceph-object-store name
 		endpoint = "http://rook-ceph-rgw-" + r.CephObjectstoreUser.Spec.Store + "." + options.Namespace + ".svc.cluster.local:80"
-
+		r.Logger.Infof("Found RGW endpoint in CephObjectstoreUser %q",r.CephObjectstoreUser.Name)
 	} else if r.NooBaa.Labels != nil && r.NooBaa.Labels["rgw-endpoint"] != "" {
+		// take from label if not found so far
 		raw := r.NooBaa.Labels["rgw-endpoint"]
 		i := strings.LastIndex(raw, "_")
 		endpoint = fmt.Sprintf("http://%s:%s", raw[:i], raw[i+1:])
-
+		r.Logger.Info("Found RGW endpoint in noobaa label \"endpoint\"")
 	} else {
 		return fmt.Errorf("Ceph RGW endpoint address is not available")
 	}
+	r.Logger.Infof("RGW endpoint %q",endpoint)
 
 	region := "us-east-1"
 	forcePathStyle := true


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1876520

* for default backing-stores on top of RGW, the endpoint was constructed from the ceph object-store name. The port that was used was hard-coded `80`
* when RGW is deployed externally (external mode) the endpoint port is different (`8080` in the BZ case). 
* the correct endpoint actually appears in the ceph user secret, so changed the flow to take the endpoint from there. the construction of the endpoint as before only happens as a fallback. 