### PR TITLE
Reconcile multiple service monitors with multiple scrape paths

### DIFF
--- a/deploy/internal/service-mgmt.yaml
+++ b/deploy/internal/service-mgmt.yaml
@@ -4,6 +4,7 @@ metadata:
   name: SYSNAME-mgmt
   labels:
     app: noobaa
+    noobaa-mgmt-svc: "true"
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/scheme: http

--- a/deploy/internal/service-s3.yaml
+++ b/deploy/internal/service-s3.yaml
@@ -4,6 +4,7 @@ metadata:
   name: s3
   labels:
     app: noobaa
+    noobaa-s3-svc: "true"
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
     service.alpha.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
@@ -20,4 +21,6 @@ spec:
       name: s3-https
     - port: 8444
       name: md-https
+    - port: 7004
+      name: metrics
 

--- a/deploy/internal/servicemonitor-mgmt.yaml
+++ b/deploy/internal/servicemonitor-mgmt.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: noobaa-mgmt-service-monitor
+  labels:
+    app: noobaa
+spec:
+  endpoints:
+  - port: mgmt
+    path: /metrics/web_server
+  - port: mgmt
+    path: /metrics/bg_workers
+  - port: mgmt
+    path: /metrics/hosted_agents
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      noobaa-mgmt-svc: "true"

--- a/deploy/internal/servicemonitor-s3.yaml
+++ b/deploy/internal/servicemonitor-s3.yaml
@@ -1,13 +1,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: noobaa-mgmt-service-monitor
+  name: noobaa-s3-service-monitor
   labels:
     app: noobaa
 spec:
   endpoints:
-  - port: mgmt
+  - port: metrics
+    path: /
   namespaceSelector: {}
   selector:
     matchLabels:
-      app: noobaa
+      noobaa-s3-svc: "true"

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2213,7 +2213,7 @@ spec:
       name: mongodb
 `
 
-const Sha256_deploy_internal_service_mgmt_yaml = "3449be462a77ea7e66c529308cbd86fd1c3d18685aa4649aa05514303f23908a"
+const Sha256_deploy_internal_service_mgmt_yaml = "89c34cdc0078bec5fdd4146775838248fccfb30032ffe8279e62b460a3856204"
 
 const File_deploy_internal_service_mgmt_yaml = `apiVersion: v1
 kind: Service
@@ -2221,6 +2221,7 @@ metadata:
   name: SYSNAME-mgmt
   labels:
     app: noobaa
+    noobaa-mgmt-svc: "true"
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/scheme: http
@@ -2244,24 +2245,7 @@ spec:
       name: hosted-agents-https
 `
 
-const Sha256_deploy_internal_service_monitor_yaml = "224b1ce993c390fa80898dedfee8380f2d0209d3702eb0b8b514dd380ade453c"
-
-const File_deploy_internal_service_monitor_yaml = `apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: noobaa-mgmt-service-monitor
-  labels:
-    app: noobaa
-spec:
-  endpoints:
-  - port: mgmt
-  namespaceSelector: {}
-  selector:
-    matchLabels:
-      app: noobaa
-`
-
-const Sha256_deploy_internal_service_s3_yaml = "49fa69db96f9e06ac46874ec42d1a3bd81cfc7b159d75e2a2870d1f16708eafc"
+const Sha256_deploy_internal_service_s3_yaml = "df7d8c8ee81b820678b7d8648b26c6cf86da6be00caedad052c3848db5480c37"
 
 const File_deploy_internal_service_s3_yaml = `apiVersion: v1
 kind: Service
@@ -2269,6 +2253,7 @@ metadata:
   name: s3
   labels:
     app: noobaa
+    noobaa-s3-svc: "true"
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
     service.alpha.openshift.io/serving-cert-secret-name: 'noobaa-s3-serving-cert'
@@ -2285,7 +2270,49 @@ spec:
       name: s3-https
     - port: 8444
       name: md-https
+    - port: 7004
+      name: metrics
 
+`
+
+const Sha256_deploy_internal_servicemonitor_mgmt_yaml = "172b25b71872e74fb32ecf32b9c68d41cc60d155cb469ed5ecf7ad282f3e597a"
+
+const File_deploy_internal_servicemonitor_mgmt_yaml = `apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: noobaa-mgmt-service-monitor
+  labels:
+    app: noobaa
+spec:
+  endpoints:
+  - port: mgmt
+    path: /metrics/web_server
+  - port: mgmt
+    path: /metrics/bg_workers
+  - port: mgmt
+    path: /metrics/hosted_agents
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      noobaa-mgmt-svc: "true"
+`
+
+const Sha256_deploy_internal_servicemonitor_s3_yaml = "e3940bdfdfbaf5cacefa51f92623ffb00e5360e58640c67558b5cf5135edd57f"
+
+const File_deploy_internal_servicemonitor_s3_yaml = `apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: noobaa-s3-service-monitor
+  labels:
+    app: noobaa
+spec:
+  endpoints:
+  - port: metrics
+    path: /
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      noobaa-s3-svc: "true"
 `
 
 const Sha256_deploy_internal_statefulset_core_yaml = "560ee00673fd2c3559559fd69232bd39401178ae8f79531e910a037dcfa51909"

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -59,7 +59,7 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 	if err := r.ReconcilePrometheusRule(); err != nil {
 		return err
 	}
-	if err := r.ReconcileServiceMonitor(); err != nil {
+	if err := r.ReconcileServiceMonitors(); err != nil {
 		return err
 	}
 	if err := r.ReconcileReadSystem(); err != nil {
@@ -780,14 +780,20 @@ func (r *Reconciler) ReconcilePrometheusRule() error {
 	return r.ReconcileObjectOptional(r.PrometheusRule, nil)
 }
 
-// ReconcileServiceMonitor reconciles service monitor
-func (r *Reconciler) ReconcileServiceMonitor() error {
+// ReconcileServiceMonitors reconciles service monitors
+func (r *Reconciler) ReconcileServiceMonitors() error {
 	// Skip if joining another NooBaa
 	if r.JoinSecret != nil {
 		return nil
 	}
 
-	return r.ReconcileObjectOptional(r.ServiceMonitor, nil)
+	if err := r.ReconcileObjectOptional(r.ServiceMonitorMgmt, nil); err != nil {
+		return err
+	}
+	if err := r.ReconcileObjectOptional(r.ServiceMonitorS3, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ReconcileReadSystem calls read_system on noobaa server and stores the result

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -81,7 +81,8 @@ type Reconciler struct {
 	DefaultBucketClass  *nbv1.BucketClass
 	OBCStorageClass     *storagev1.StorageClass
 	PrometheusRule      *monitoringv1.PrometheusRule
-	ServiceMonitor      *monitoringv1.ServiceMonitor
+	ServiceMonitorMgmt  *monitoringv1.ServiceMonitor
+	ServiceMonitorS3    *monitoringv1.ServiceMonitor
 	SystemInfo          *nb.SystemInfo
 	CephObjectstoreUser *cephv1.CephObjectStoreUser
 	RouteMgmt           *routev1.Route
@@ -127,7 +128,8 @@ func NewReconciler(
 		DefaultBucketClass:  util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml).(*nbv1.BucketClass),
 		OBCStorageClass:     util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass),
 		PrometheusRule:      util.KubeObject(bundle.File_deploy_internal_prometheus_rules_yaml).(*monitoringv1.PrometheusRule),
-		ServiceMonitor:      util.KubeObject(bundle.File_deploy_internal_service_monitor_yaml).(*monitoringv1.ServiceMonitor),
+		ServiceMonitorMgmt:  util.KubeObject(bundle.File_deploy_internal_servicemonitor_mgmt_yaml).(*monitoringv1.ServiceMonitor),
+		ServiceMonitorS3:    util.KubeObject(bundle.File_deploy_internal_servicemonitor_s3_yaml).(*monitoringv1.ServiceMonitor),
 		CephObjectstoreUser: util.KubeObject(bundle.File_deploy_internal_ceph_objectstore_user_yaml).(*cephv1.CephObjectStoreUser),
 		RouteMgmt:           util.KubeObject(bundle.File_deploy_internal_route_mgmt_yaml).(*routev1.Route),
 		RouteS3:             util.KubeObject(bundle.File_deploy_internal_route_s3_yaml).(*routev1.Route),
@@ -156,7 +158,8 @@ func NewReconciler(
 	r.DefaultBackingStore.Namespace = r.Request.Namespace
 	r.DefaultBucketClass.Namespace = r.Request.Namespace
 	r.PrometheusRule.Namespace = r.Request.Namespace
-	r.ServiceMonitor.Namespace = r.Request.Namespace
+	r.ServiceMonitorMgmt.Namespace = r.Request.Namespace
+	r.ServiceMonitorS3.Namespace = r.Request.Namespace
 	r.CephObjectstoreUser.Namespace = r.Request.Namespace
 	r.RouteMgmt.Namespace = r.Request.Namespace
 	r.RouteS3.Namespace = r.Request.Namespace
@@ -185,7 +188,8 @@ func NewReconciler(
 	r.DefaultBackingStore.Name = r.Request.Name + "-default-backing-store"
 	r.DefaultBucketClass.Name = r.Request.Name + "-default-bucket-class"
 	r.PrometheusRule.Name = r.Request.Name + "-prometheus-rules"
-	r.ServiceMonitor.Name = r.Request.Name + "-service-monitor"
+	r.ServiceMonitorMgmt.Name = r.ServiceMgmt.Name + "-service-monitor"
+	r.ServiceMonitorS3.Name = r.ServiceS3.Name + "-service-monitor"
 	r.RouteMgmt.Name = r.ServiceMgmt.Name
 	r.RouteS3.Name = r.ServiceS3.Name
 	r.DeploymentEndpoint.Name = r.Request.Name + "-endpoint"
@@ -234,7 +238,8 @@ func (r *Reconciler) CheckAll() {
 	util.KubeCheckOptional(r.AzureCloudCreds)
 	util.KubeCheckOptional(r.AzureContainerCreds)
 	util.KubeCheckOptional(r.PrometheusRule)
-	util.KubeCheckOptional(r.ServiceMonitor)
+	util.KubeCheckOptional(r.ServiceMonitorMgmt)
+	util.KubeCheckOptional(r.ServiceMonitorS3)
 	util.KubeCheckOptional(r.RouteMgmt)
 	util.KubeCheckOptional(r.RouteS3)
 }


### PR DESCRIPTION
For each pod behind the `noobaa-mgmt` service we will scrape 3 paths:
1. `/metrics/web_server` - nodejs `web_server` process report + nooba reports
2. `/metrics/bg_workers` - nodejs `bg_workers` process report
3. `/metrics/hosted_agents`- nodejs `hosted_agents` process report

For each pod behind the `s3` service we will scrape one paths (on port 7001):
1. `/` - nodejs `endpoint` report

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>