### PR TITLE
Making db service headless - GKE/k8s DNS resolution

### DIFF
--- a/deploy/internal/service-db.yaml
+++ b/deploy/internal/service-db.yaml
@@ -8,7 +8,7 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: 'noobaa-db-serving-cert'
     service.alpha.openshift.io/serving-cert-secret-name: 'noobaa-db-serving-cert'
 spec:
-  type: ClusterIP
+  clusterIP: None
   selector:
     noobaa-db: SYSNAME
   ports:


### PR DESCRIPTION
Using non-headless db kubenetes services, internal DNS only contains record for `noobaa-db.noobaa.svc.cluster.local`.
When nooba-core starts, it looks for  `noobaa-db-0.noobaa-db` record instead, failing resolution.
Using a headless service makes both names resolvable, tested on GKE stable (k8s 1.15) and on-prem private cluster