### PR TITLE
In IBM Cloud configure IBM COS as default backing store

### DIFF
--- a/deploy/internal/cloud_creds_gcp_cr.yaml
+++ b/deploy/internal/cloud_creds_gcp_cr.yaml
@@ -1,0 +1,17 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: CRED-REQ-NAME
+  namespace: CRED-REQ-NAMESPACE
+spec:
+  secretRef:
+    name: CRED-SECRET-NAME
+    namespace: CRED-SECRET-NAMESPACE
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+    - roles/storage.admin
+    skipServiceCheck: true

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/noobaa/noobaa-operator/v2
 go 1.15
 
 require (
+	cloud.google.com/go/storage v1.3.0
 	github.com/Azure/azure-sdk-for-go v39.2.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest v0.9.4
@@ -31,6 +32,7 @@ require (
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200915031644-64986481280e // indirect
+	google.golang.org/api v0.14.0
 	k8s.io/api v0.17.4
 	k8s.io/apiextensions-apiserver v0.17.4
 	k8s.io/apimachinery v0.17.4

--- a/go.sum
+++ b/go.sum
@@ -13,10 +13,14 @@ cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg
 cloud.google.com/go v0.49.0 h1:CH+lkubJzcPYB1Ggupcq0+k8Ni2ILdG2lYjDIgavDBQ=
 cloud.google.com/go v0.49.0/go.mod h1:hGvAdzcWNbyuxS3nWhD7H2cIJxjRRTRLQVB0bdputVY=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
+cloud.google.com/go/bigquery v1.3.0 h1:sAbMqjY1PEQKZBWfbu6Y6bsupJ9c4QdHnzg/VvYTLcE=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
+cloud.google.com/go/datastore v1.0.0 h1:Kt+gOPPp2LEPWp8CSfxhsM8ik9CcyE/gYu+0r+RnZvM=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
+cloud.google.com/go/pubsub v1.0.1 h1:W9tAK3E57P75u0XLLR82LZyw8VpAnhmyTOxW9qzmyj8=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
+cloud.google.com/go/storage v1.3.0 h1:2Ze/3nQD5F+HfL0xOPM2EeawDWs+NPRtzgcre+17iZU=
 cloud.google.com/go/storage v1.3.0/go.mod h1:9IAwXhoyBJ7z9LcAwkj0/7NnPzYaPeZxxVp3zm+5IqA=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeSEBLPA9YJp5bjrofdU3pIXs=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -428,6 +432,7 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -438,8 +443,10 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -553,6 +560,7 @@ github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGn
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jsonnet-bundler/jsonnet-bundler v0.2.0/go.mod h1:/by7P/OoohkI3q4CgSFqcoFsVY+IaNbzOVDknEsKDeU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -925,6 +933,7 @@ go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.opencensus.io v0.22.2 h1:75k/FF0Q2YM8QYo07VPddOLBslDt1MZOdEslOHvmzAs=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
@@ -976,6 +985,7 @@ golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
+golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136 h1:A1gGSx58LAGVHUUsOf7IiR0u8Xb6W51gRwfDBhkdcaw=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -1056,6 +1066,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1189,6 +1200,7 @@ google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.13.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
+google.golang.org/api v0.14.0 h1:uMf5uLi4eQMRrMKhCplNik4U4H8Z6C1br3zOtAa/aDE=
 google.golang.org/api v0.14.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1212,6 +1224,7 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
+google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9 h1:6XzpBoANz1NqMNfDXzc2QmHmbb1vyMsvRfoP5rM+K1I=
 google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
@@ -1225,6 +1238,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
+google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -1127,6 +1127,9 @@ func (r *Reconciler) updatePodTemplate() {
 	if r.NooBaa.Spec.Tolerations != nil {
 		r.PodAgentTemplate.Spec.Tolerations = r.NooBaa.Spec.Tolerations
 	}
+	if r.NooBaa.Spec.Affinity != nil {
+		r.PodAgentTemplate.Spec.Affinity = r.NooBaa.Spec.Affinity
+	}
 }
 
 func (r *Reconciler) updatePvcTemplate() {

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1810,6 +1810,27 @@ spec:
     namespace: CRED-SECRET-NAMESPACE
 `
 
+const Sha256_deploy_internal_cloud_creds_gcp_cr_yaml = "f4415e851da03426e8c31a7cb5b904b4438d958a5297c70b967ca6c2881d360f"
+
+const File_deploy_internal_cloud_creds_gcp_cr_yaml = `apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: CRED-REQ-NAME
+  namespace: CRED-REQ-NAMESPACE
+spec:
+  secretRef:
+    name: CRED-SECRET-NAME
+    namespace: CRED-SECRET-NAMESPACE
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+    - roles/storage.admin
+    skipServiceCheck: true
+`
+
 const Sha256_deploy_internal_configmap_empty_yaml = "6405c531c6522ecd54808f5cb531c1001b9ad01a73917427c523a92be44f348f"
 
 const File_deploy_internal_configmap_empty_yaml = `apiVersion: v1

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.6.0-20200909"
+	ContainerImageTag = "5.6.0-20201013"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -330,6 +330,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 // the bucket name allowed for the credentials. nil is returned if cloud credentials are not supported
 func (r *Reconciler) ReconcileBackingStoreCredentials() error {
 	// Skip if joining another NooBaa
+	r.Logger.Info("Reconciling Backing Store Credentials")
 	if r.JoinSecret != nil {
 		return nil
 	}
@@ -339,6 +340,9 @@ func (r *Reconciler) ReconcileBackingStoreCredentials() error {
 	}
 	if util.IsAzurePlatform() {
 		return r.ReconcileAzureCredentials()
+	}
+	if util.IsIBMPlatform() {
+		return r.ReconcileIBMCredentials()
 	}
 	return r.ReconcileRGWCredentials()
 }
@@ -474,6 +478,17 @@ func (r *Reconciler) ReconcileAzureCredentials() error {
 		return nil
 	}
 	return err
+}
+
+// ReconcileIBMCredentials create dummy request
+func (r *Reconciler) ReconcileIBMCredentials() error {
+	// Currently IBM Cloud is not supported by cloud credential operator
+	// In IBM Cloud, the HMAC keys will be provided through K8S Secret under kube-system namespace
+	r.Logger.Info("Running in IBM Cloud. Expecting Secret: <ibm-cloud-cos-creds> under NS: <kube-system>")
+	r.IBMCloudCreds.Spec.SecretRef.Name = "ibm-cloud-cos-creds"
+	r.IBMCloudCreds.Spec.SecretRef.Namespace = "kube-system"
+	r.IBMCloudCreds.UID = "dummy-uid"
+	return nil
 }
 
 // SetDesiredAgentProfile updates the value of the AGENT_PROFILE env

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -23,6 +23,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	ibmCredSecret   = "ibm-cloud-cos-creds"
+	ibmCredSecretNS = "kube-system"
+)
+
 // ReconcilePhaseCreating runs the reconcile phase
 func (r *Reconciler) ReconcilePhaseCreating() error {
 
@@ -485,8 +490,8 @@ func (r *Reconciler) ReconcileIBMCredentials() error {
 	// Currently IBM Cloud is not supported by cloud credential operator
 	// In IBM Cloud, the HMAC keys will be provided through K8S Secret under kube-system namespace
 	r.Logger.Info("Running in IBM Cloud. Expecting Secret: <ibm-cloud-cos-creds> under NS: <kube-system>")
-	r.IBMCloudCreds.Spec.SecretRef.Name = "ibm-cloud-cos-creds"
-	r.IBMCloudCreds.Spec.SecretRef.Namespace = "kube-system"
+	r.IBMCloudCreds.Spec.SecretRef.Name = ibmCredSecret
+	r.IBMCloudCreds.Spec.SecretRef.Namespace = ibmCredSecretNS
 	r.IBMCloudCreds.UID = "dummy-uid"
 	return nil
 }

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -310,6 +310,9 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	if r.NooBaa.Spec.Tolerations != nil {
 		podSpec.Tolerations = r.NooBaa.Spec.Tolerations
 	}
+	if r.NooBaa.Spec.Affinity != nil {
+		podSpec.Affinity = r.NooBaa.Spec.Affinity
+	}
 
 	if r.CoreApp.UID == "" {
 		// generate info event for the first creation of noobaa
@@ -345,6 +348,9 @@ func (r *Reconciler) ReconcileBackingStoreCredentials() error {
 	}
 	if util.IsAzurePlatform() {
 		return r.ReconcileAzureCredentials()
+	}
+	if util.IsGCPPlatform() {
+		return r.ReconcileGCPCredentials()
 	}
 	if util.IsIBMPlatform() {
 		return r.ReconcileIBMCredentials()
@@ -478,6 +484,27 @@ func (r *Reconciler) ReconcileAzureCredentials() error {
 		err = r.Client.Create(r.Ctx, r.AzureCloudCreds)
 		if err != nil {
 			r.Logger.Errorf("got error when trying to create credentials request for azure. %v", err)
+			return err
+		}
+		return nil
+	}
+	return err
+}
+
+// ReconcileGCPCredentials creates a CredentialsRequest resource if cloud credentials operator is available
+func (r *Reconciler) ReconcileGCPCredentials() error {
+	r.Logger.Info("Running on GCP. will create a CredentialsRequest resource")
+	err := r.Client.Get(r.Ctx, util.ObjectKey(r.GCPCloudCreds), r.GCPCloudCreds)
+	if err == nil || meta.IsNoMatchError(err) || runtime.IsNotRegisteredError(err) {
+		return nil
+	}
+	if errors.IsNotFound(err) {
+		// credential request does not exist. create one
+		r.Logger.Info("Creating CredentialsRequest resource")
+		r.Own(r.GCPCloudCreds)
+		err = r.Client.Create(r.Ctx, r.GCPCloudCreds)
+		if err != nil {
+			r.Logger.Errorf("got error when trying to create credentials request for GCP. %v", err)
 			return err
 		}
 		return nil

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1,12 +1,18 @@
 package system
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"encoding/json"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
 
 	"github.com/marstr/randname"
 	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
@@ -30,6 +36,10 @@ const (
 	ibmEndpoint = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
 	ibmLocation = "%s-standard"
 )
+
+type gcpAuthJSON struct {
+	ProjectID string `json:"project_id"`
+}
 
 // ReconcilePhaseConfiguring runs the reconcile phase
 func (r *Reconciler) ReconcilePhaseConfiguring() error {
@@ -238,6 +248,9 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 	podSpec := &r.DeploymentEndpoint.Spec.Template.Spec
 	if r.NooBaa.Spec.Tolerations != nil {
 		podSpec.Tolerations = r.NooBaa.Spec.Tolerations
+	}
+	if r.NooBaa.Spec.Affinity != nil {
+		podSpec.Affinity = r.NooBaa.Spec.Affinity
 	}
 	if r.NooBaa.Spec.ImagePullSecret == nil {
 		podSpec.ImagePullSecrets =
@@ -448,6 +461,11 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 		if err := r.prepareAzureBackingStore(); err != nil {
 			return err
 		}
+	} else if r.GCPCloudCreds.UID != "" {
+		log.Infof("CredentialsRequest %q created.  creating default backing store on GCP objectstore", r.GCPCloudCreds.Name)
+		if err := r.prepareGCPBackingStore(); err != nil {
+			return err
+		}
 	} else if r.IBMCloudCreds.UID != "" {
 		log.Infof("CredentialsRequest %q created. Creating default backing store on IBM objectstore", r.IBMCloudCreds.Name)
 		if err := r.prepareIBMBackingStore(); err != nil {
@@ -608,6 +626,68 @@ func (r *Reconciler) prepareAzureBackingStore() error {
 	return nil
 }
 
+func (r *Reconciler) prepareGCPBackingStore() error {
+
+	cloudCredsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.GCPCloudCreds.Spec.SecretRef.Name,
+			Namespace: r.GCPCloudCreds.Spec.SecretRef.Namespace,
+		},
+	}
+
+	util.KubeCheck(cloudCredsSecret)
+	if cloudCredsSecret.UID == "" {
+		// TODO: we need to figure out why secret is not created, and react accordingly
+		// e.g. maybe we are running on AWS but our CredentialsRequest is for GCP
+		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", r.GCPCloudCreds.Spec.SecretRef.Name)
+		return fmt.Errorf("cloud credentials secret %q is not ready yet", r.GCPCloudCreds.Spec.SecretRef.Name)
+	}
+	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", r.GCPCloudCreds.Spec.SecretRef.Name)
+
+	util.KubeCheck(r.GCPBucketCreds)
+	if r.GCPBucketCreds.UID == "" {
+		r.GCPBucketCreds.StringData = cloudCredsSecret.StringData
+		r.Own(r.GCPBucketCreds)
+		if err := r.Client.Create(r.Ctx, r.GCPBucketCreds); err != nil {
+			return fmt.Errorf("got error on GCPBucketCreds creation. error: %v", err)
+		}
+	}
+	authJSON := &gcpAuthJSON{}
+	err := json.Unmarshal([]byte(cloudCredsSecret.StringData["service_account.json"]), authJSON)
+	if err != nil {
+		fmt.Println("Failed to parse secret", err)
+		return err
+	}
+	projectID := authJSON.ProjectID
+	r.GCPBucketCreds.StringData["GoogleServiceAccountPrivateKeyJson"] = cloudCredsSecret.StringData["service_account.json"]
+	ctx := context.Background()
+	gcpclient, err := storage.NewClient(ctx, option.WithCredentialsJSON([]byte(cloudCredsSecret.StringData["service_account.json"])))
+	if err != nil {
+		r.Logger.Info(err)
+		return err
+	}
+
+	var bucketName = strings.ToLower(randname.GenerateWithPrefix("noobaabucket", 5))
+	if err := r.createGCPBucketForBackingStore(gcpclient, projectID, bucketName); err != nil {
+		r.Logger.Info(err)
+		return err
+	}
+
+	if errUpdate := r.Client.Update(r.Ctx, r.GCPBucketCreds); errUpdate != nil {
+		return fmt.Errorf("got error on GCPBucketCreds update. error: %v", errUpdate)
+	}
+	// create backing store
+	r.DefaultBackingStore.Spec.Type = nbv1.StoreTypeGoogleCloudStorage
+	r.DefaultBackingStore.Spec.GoogleCloudStorage = &nbv1.GoogleCloudStorageSpec{
+		TargetBucket: bucketName,
+		Secret: corev1.SecretReference{
+			Name:      r.GCPBucketCreds.Name,
+			Namespace: r.GCPBucketCreds.Namespace,
+		},
+	}
+	return nil
+}
+
 func (r *Reconciler) prepareIBMBackingStore() error {
 	r.Logger.Info("Preparing backing store in IBM Cloud")
 
@@ -703,6 +783,19 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 		Endpoint:         endpoint,
 		SignatureVersion: nbv1.S3SignatureVersionV2,
 	}
+	return nil
+}
+
+func (r *Reconciler) createGCPBucketForBackingStore(client *storage.Client, projectID, bucketName string) error {
+	// [START create_bucket]
+	ctx := context.Background()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+	if err := client.Bucket(bucketName).Create(ctx, projectID, nil); err != nil {
+		return err
+	}
+	// [END create_bucket]
 	return nil
 }
 

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -26,6 +26,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+const (
+	ibmEndpoint = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
+	ibmLocation = "%s-standard"
+)
+
 // ReconcilePhaseConfiguring runs the reconcile phase
 func (r *Reconciler) ReconcilePhaseConfiguring() error {
 
@@ -429,22 +434,22 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 	}
 
 	if r.CephObjectstoreUser.UID != "" {
-		log.Infof("CephObjectstoreUser %q created.  creating default backing store on ceph objectstore", r.CephObjectstoreUser.Name)
+		log.Infof("CephObjectstoreUser %q created. Creating default backing store on ceph objectstore", r.CephObjectstoreUser.Name)
 		if err := r.prepareCephBackingStore(); err != nil {
 			return err
 		}
 	} else if r.AWSCloudCreds.UID != "" {
-		log.Infof("CredentialsRequest %q created.  creating default backing store on AWS objectstore", r.AWSCloudCreds.Name)
+		log.Infof("CredentialsRequest %q created. Creating default backing store on AWS objectstore", r.AWSCloudCreds.Name)
 		if err := r.prepareAWSBackingStore(); err != nil {
 			return err
 		}
 	} else if r.AzureCloudCreds.UID != "" {
-		log.Infof("CredentialsRequest %q created.  creating default backing store on Azure objectstore", r.AzureCloudCreds.Name)
+		log.Infof("CredentialsRequest %q created. Creating default backing store on Azure objectstore", r.AzureCloudCreds.Name)
 		if err := r.prepareAzureBackingStore(); err != nil {
 			return err
 		}
 	} else if r.IBMCloudCreds.UID != "" {
-		log.Infof("CredentialsRequest %q created.  creating default backing store on IBM objectstore", r.IBMCloudCreds.Name)
+		log.Infof("CredentialsRequest %q created. Creating default backing store on IBM objectstore", r.IBMCloudCreds.Name)
 		if err := r.prepareIBMBackingStore(); err != nil {
 			return err
 		}
@@ -642,8 +647,8 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 		}
 		r.Logger.Infof("Constructing endpoint for region: %q", region)
 		// https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-classes#classes-locationconstraint
-		endpoint = "https://s3.direct." + region + ".cloud-object-storage.appdomain.cloud"
-		location = region + "-standard"
+		endpoint = fmt.Sprintf(ibmEndpoint, region)
+		location = fmt.Sprintf(ibmLocation, region)
 	}
 
 	if _, err := url.Parse(endpoint); err != nil {

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -78,6 +78,8 @@ type Reconciler struct {
 	AzureCloudCreds     *cloudcredsv1.CredentialsRequest
 	IBMCloudCreds       *cloudcredsv1.CredentialsRequest
 	AzureContainerCreds *corev1.Secret
+	GCPBucketCreds      *corev1.Secret
+	GCPCloudCreds       *cloudcredsv1.CredentialsRequest
 	DefaultBackingStore *nbv1.BackingStore
 	DefaultBucketClass  *nbv1.BucketClass
 	OBCStorageClass     *storagev1.StorageClass
@@ -123,8 +125,10 @@ func NewReconciler(
 		SecretAdmin:         util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretEndpoints:     util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		AzureContainerCreds: util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
+		GCPBucketCreds:      util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		AWSCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		AzureCloudCreds:     util.KubeObject(bundle.File_deploy_internal_cloud_creds_azure_cr_yaml).(*cloudcredsv1.CredentialsRequest),
+		GCPCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_gcp_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		IBMCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		DefaultBackingStore: util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml).(*nbv1.BackingStore),
 		DefaultBucketClass:  util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml).(*nbv1.BucketClass),
@@ -153,12 +157,15 @@ func NewReconciler(
 	r.SecretAdmin.Namespace = r.Request.Namespace
 	r.SecretEndpoints.Namespace = r.Request.Namespace
 	r.AzureContainerCreds.Namespace = r.Request.Namespace
+	r.GCPBucketCreds.Namespace = r.Request.Namespace
 	r.AWSCloudCreds.Namespace = r.Request.Namespace
 	r.AWSCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
-	r.IBMCloudCreds.Namespace = r.Request.Namespace
-	r.IBMCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
 	r.AzureCloudCreds.Namespace = r.Request.Namespace
 	r.AzureCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
+	r.GCPCloudCreds.Namespace = r.Request.Namespace
+	r.GCPCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
+	r.IBMCloudCreds.Namespace = r.Request.Namespace
+	r.IBMCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
 	r.DefaultBackingStore.Namespace = r.Request.Namespace
 	r.DefaultBucketClass.Namespace = r.Request.Namespace
 	r.PrometheusRule.Namespace = r.Request.Namespace
@@ -183,13 +190,16 @@ func NewReconciler(
 	r.SecretOp.Name = r.Request.Name + "-operator"
 	r.SecretAdmin.Name = r.Request.Name + "-admin"
 	r.SecretEndpoints.Name = r.Request.Name + "-endpoints"
-	r.AzureContainerCreds.Name = r.Request.Name + "-azure-container-creds"
 	r.AWSCloudCreds.Name = r.Request.Name + "-aws-cloud-creds"
 	r.AWSCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-aws-cloud-creds-secret"
-	r.IBMCloudCreds.Name = r.Request.Name + "-ibm-cloud-creds"
-	r.IBMCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-ibm-cloud-creds-secret"
+	r.AzureContainerCreds.Name = r.Request.Name + "-azure-container-creds"
 	r.AzureCloudCreds.Name = r.Request.Name + "-azure-cloud-creds"
 	r.AzureCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-azure-cloud-creds-secret"
+	r.GCPBucketCreds.Name = r.Request.Name + "-gcp-bucket-creds"
+	r.GCPCloudCreds.Name = r.Request.Name + "-gcp-cloud-creds"
+	r.GCPCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-gcp-cloud-creds-secret"
+	r.IBMCloudCreds.Name = r.Request.Name + "-ibm-cloud-creds"
+	r.IBMCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-ibm-cloud-creds-secret"
 	r.CephObjectstoreUser.Name = r.Request.Name + "-ceph-objectstore-user"
 	r.DefaultBackingStore.Name = r.Request.Name + "-default-backing-store"
 	r.DefaultBucketClass.Name = r.Request.Name + "-default-bucket-class"
@@ -243,6 +253,8 @@ func (r *Reconciler) CheckAll() {
 	util.KubeCheckOptional(r.AWSCloudCreds)
 	util.KubeCheckOptional(r.AzureCloudCreds)
 	util.KubeCheckOptional(r.AzureContainerCreds)
+	util.KubeCheckOptional(r.GCPBucketCreds)
+	util.KubeCheckOptional(r.GCPCloudCreds)
 	util.KubeCheckOptional(r.PrometheusRule)
 	util.KubeCheckOptional(r.ServiceMonitorMgmt)
 	util.KubeCheckOptional(r.ServiceMonitorS3)

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -76,6 +76,7 @@ type Reconciler struct {
 	SecretEndpoints     *corev1.Secret
 	AWSCloudCreds       *cloudcredsv1.CredentialsRequest
 	AzureCloudCreds     *cloudcredsv1.CredentialsRequest
+	IBMCloudCreds       *cloudcredsv1.CredentialsRequest
 	AzureContainerCreds *corev1.Secret
 	DefaultBackingStore *nbv1.BackingStore
 	DefaultBucketClass  *nbv1.BucketClass
@@ -124,6 +125,7 @@ func NewReconciler(
 		AzureContainerCreds: util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		AWSCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		AzureCloudCreds:     util.KubeObject(bundle.File_deploy_internal_cloud_creds_azure_cr_yaml).(*cloudcredsv1.CredentialsRequest),
+		IBMCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		DefaultBackingStore: util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml).(*nbv1.BackingStore),
 		DefaultBucketClass:  util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml).(*nbv1.BucketClass),
 		OBCStorageClass:     util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass),
@@ -153,6 +155,8 @@ func NewReconciler(
 	r.AzureContainerCreds.Namespace = r.Request.Namespace
 	r.AWSCloudCreds.Namespace = r.Request.Namespace
 	r.AWSCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
+	r.IBMCloudCreds.Namespace = r.Request.Namespace
+	r.IBMCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
 	r.AzureCloudCreds.Namespace = r.Request.Namespace
 	r.AzureCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
 	r.DefaultBackingStore.Namespace = r.Request.Namespace
@@ -182,6 +186,8 @@ func NewReconciler(
 	r.AzureContainerCreds.Name = r.Request.Name + "-azure-container-creds"
 	r.AWSCloudCreds.Name = r.Request.Name + "-aws-cloud-creds"
 	r.AWSCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-aws-cloud-creds-secret"
+	r.IBMCloudCreds.Name = r.Request.Name + "-ibm-cloud-creds"
+	r.IBMCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-ibm-cloud-creds-secret"
 	r.AzureCloudCreds.Name = r.Request.Name + "-azure-cloud-creds"
 	r.AzureCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-azure-cloud-creds-secret"
 	r.CephObjectstoreUser.Name = r.Request.Name + "-ceph-objectstore-user"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -804,6 +804,27 @@ func IsAzurePlatform() bool {
 	return isAzure
 }
 
+// IsIBMPlatform returns true if this cluster is running on IBM Cloud
+func IsIBMPlatform() bool {
+	nodesList := &corev1.NodeList{}
+	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
+		Panic(fmt.Errorf("failed to list kubernetes nodes"))
+	}
+	isIBM := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "ibm")
+	return isIBM
+}
+
+// GetIBMRegion returns the cluster's region in IBM Cloud
+func GetIBMRegion() (string, error) {
+	nodesList := &corev1.NodeList{}
+	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
+		return "", fmt.Errorf("failed to list kubernetes nodes")
+	}
+	labels := nodesList.Items[0].GetLabels()
+	region := labels["ibm-cloud.kubernetes.io/region"]
+	return region, nil
+}
+
 // GetAWSRegion parses the region from a node's name
 func GetAWSRegion() (string, error) {
 	// parse the node name to get AWS region according to this:

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -52,6 +52,7 @@ import (
 
 const (
 	oAuthWellKnownEndpoint = "https://openshift.default.svc/.well-known/oauth-authorization-server"
+	ibmRegion              = "ibm-cloud.kubernetes.io/region"
 )
 
 // OAuth2Endpoints holds OAuth2 endpoints information.
@@ -811,6 +812,12 @@ func IsIBMPlatform() bool {
 		Panic(fmt.Errorf("failed to list kubernetes nodes"))
 	}
 	isIBM := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "ibm")
+	if isIBM {
+		// Incase of Satellite cluster is deplyed in user provided infrastructure
+		if strings.Contains(nodesList.Items[0].Spec.ProviderID, "sat-ibm") {
+			isIBM = false
+		}
+	}
 	return isIBM
 }
 
@@ -821,7 +828,7 @@ func GetIBMRegion() (string, error) {
 		return "", fmt.Errorf("failed to list kubernetes nodes")
 	}
 	labels := nodesList.Items[0].GetLabels()
-	region := labels["ibm-cloud.kubernetes.io/region"]
+	region := labels[ibmRegion]
 	return region, nil
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -805,6 +805,16 @@ func IsAzurePlatform() bool {
 	return isAzure
 }
 
+// IsGCPPlatform returns true if this cluster is running on GCP
+func IsGCPPlatform() bool {
+	nodesList := &corev1.NodeList{}
+	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
+		Panic(fmt.Errorf("failed to list kubernetes nodes"))
+	}
+	isGCP := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "gce")
+	return isGCP
+}
+
 // IsIBMPlatform returns true if this cluster is running on IBM Cloud
 func IsIBMPlatform() bool {
 	nodesList := &corev1.NodeList{}


### PR DESCRIPTION
This PR enables the configuration of IBM COS as backing store for NooBaa in the IBM Cloud (IKS /ROKS).
Currently, Cloud Credential Operator is not supporting IBM Cloud creds. The code change assumes a secret `ibm-cloud-cos-creds`, under `kube-system`, will be created by Admin or by the IBM Cloud at the time of cluster creation
```
apiVersion: v1
kind: Secret
metadata:
  name: ibm-cloud-cos-creds
  namespace: kube-system
type: Opaque
data:
  IBM_COS_ACCESS_KEY_ID: RlM2I4ODQ=
  IBM_COS_SECRET_ACCESS_KEY: NjNjNmEzZTNk
```

The code change has been tested in IBM Cloud
```
$ oc get backingstore
NAME                           TYPE      PHASE   AGE
noobaa-default-backing-store   ibm-cos   Ready   23m
```
