### PR TITLE
In IBM Cloud configure IBM COS as default backing store

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -23,11 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	ibmCredSecret   = "ibm-cloud-cos-creds"
-	ibmCredSecretNS = "kube-system"
-)
-
 // ReconcilePhaseCreating runs the reconcile phase
 func (r *Reconciler) ReconcilePhaseCreating() error {
 
@@ -596,14 +591,12 @@ func (r *Reconciler) ReconcileGCPCredentials() error {
 	return err
 }
 
-// ReconcileIBMCredentials create dummy request
+// ReconcileIBMCredentials sets IsIBMCloud to indicate operator is running in IBM Cloud
 func (r *Reconciler) ReconcileIBMCredentials() error {
 	// Currently IBM Cloud is not supported by cloud credential operator
-	// In IBM Cloud, the HMAC keys will be provided through K8S Secret under kube-system namespace
-	r.Logger.Info("Running in IBM Cloud. Expecting Secret: <ibm-cloud-cos-creds> under NS: <kube-system>")
-	r.IBMCloudCreds.Spec.SecretRef.Name = ibmCredSecret
-	r.IBMCloudCreds.Spec.SecretRef.Namespace = ibmCredSecretNS
-	r.IBMCloudCreds.UID = "dummy-uid"
+	// In IBM Cloud, the COS Creds will be provided through Secret.
+	r.Logger.Info("Running in IBM Cloud")
+	r.IsIBMCloud = true
 	return nil
 }
 

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -23,6 +23,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	ibmCredSecret   = "ibm-cloud-cos-creds"
+	ibmCredSecretNS = "kube-system"
+)
+
 // ReconcilePhaseCreating runs the reconcile phase
 func (r *Reconciler) ReconcilePhaseCreating() error {
 
@@ -419,6 +424,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 // the bucket name allowed for the credentials. nil is returned if cloud credentials are not supported
 func (r *Reconciler) ReconcileBackingStoreCredentials() error {
 	// Skip if joining another NooBaa
+	r.Logger.Info("Reconciling Backing Store Credentials")
 	if r.JoinSecret != nil {
 		return nil
 	}
@@ -431,6 +437,9 @@ func (r *Reconciler) ReconcileBackingStoreCredentials() error {
 	}
 	if util.IsGCPPlatform() {
 		return r.ReconcileGCPCredentials()
+	}
+	if util.IsIBMPlatform() {
+		return r.ReconcileIBMCredentials()
 	}
 	return r.ReconcileRGWCredentials()
 }
@@ -585,6 +594,17 @@ func (r *Reconciler) ReconcileGCPCredentials() error {
 		return nil
 	}
 	return err
+}
+
+// ReconcileIBMCredentials create dummy request
+func (r *Reconciler) ReconcileIBMCredentials() error {
+	// Currently IBM Cloud is not supported by cloud credential operator
+	// In IBM Cloud, the HMAC keys will be provided through K8S Secret under kube-system namespace
+	r.Logger.Info("Running in IBM Cloud. Expecting Secret: <ibm-cloud-cos-creds> under NS: <kube-system>")
+	r.IBMCloudCreds.Spec.SecretRef.Name = ibmCredSecret
+	r.IBMCloudCreds.Spec.SecretRef.Namespace = ibmCredSecretNS
+	r.IBMCloudCreds.UID = "dummy-uid"
+	return nil
 }
 
 // SetDesiredAgentProfile updates the value of the AGENT_PROFILE env

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -32,6 +32,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+const (
+	ibmEndpoint = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
+	ibmLocation = "%s-standard"
+)
+
 type gcpAuthJSON struct {
 	ProjectID string `json:"project_id"`
 }
@@ -440,24 +445,29 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 		return nil
 	}
 
-	if r.CephObjectStoreUser.UID != "" {
-		log.Infof("CephObjectStoreUser %q created.  creating default backing store on ceph objectstore", r.CephObjectStoreUser.Name)
+	if r.CephObjectstoreUser.UID != "" {
+		log.Infof("CephObjectstoreUser %q created. Creating default backing store on ceph objectstore", r.CephObjectstoreUser.Name)
 		if err := r.prepareCephBackingStore(); err != nil {
 			return err
 		}
 	} else if r.AWSCloudCreds.UID != "" {
-		log.Infof("CredentialsRequest %q created.  creating default backing store on AWS objectstore", r.AWSCloudCreds.Name)
+		log.Infof("CredentialsRequest %q created. Creating default backing store on AWS objectstore", r.AWSCloudCreds.Name)
 		if err := r.prepareAWSBackingStore(); err != nil {
 			return err
 		}
 	} else if r.AzureCloudCreds.UID != "" {
-		log.Infof("CredentialsRequest %q created.  creating default backing store on Azure objectstore", r.AzureCloudCreds.Name)
+		log.Infof("CredentialsRequest %q created. Creating default backing store on Azure objectstore", r.AzureCloudCreds.Name)
 		if err := r.prepareAzureBackingStore(); err != nil {
 			return err
 		}
 	} else if r.GCPCloudCreds.UID != "" {
 		log.Infof("CredentialsRequest %q created.  creating default backing store on GCP objectstore", r.GCPCloudCreds.Name)
 		if err := r.prepareGCPBackingStore(); err != nil {
+			return err
+		}
+	} else if r.IBMCloudCreds.UID != "" {
+		log.Infof("CredentialsRequest %q created. Creating default backing store on IBM objectstore", r.IBMCloudCreds.Name)
+		if err := r.prepareIBMBackingStore(); err != nil {
 			return err
 		}
 	} else {
@@ -673,6 +683,104 @@ func (r *Reconciler) prepareGCPBackingStore() error {
 			Name:      r.GCPBucketCreds.Name,
 			Namespace: r.GCPBucketCreds.Namespace,
 		},
+	}
+	return nil
+}
+
+func (r *Reconciler) prepareIBMBackingStore() error {
+	r.Logger.Info("Preparing backing store in IBM Cloud")
+
+	var (
+		endpoint string
+		location string
+	)
+
+	cloudCredsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.IBMCloudCreds.Spec.SecretRef.Name,
+			Namespace: r.IBMCloudCreds.Spec.SecretRef.Namespace,
+		},
+	}
+
+	util.KubeCheck(cloudCredsSecret)
+	if cloudCredsSecret.UID == "" {
+		// Secret not found
+		r.Logger.Errorf("Cloud credentials secret %q is not ready yet", r.IBMCloudCreds.Spec.SecretRef.Name)
+		return fmt.Errorf("Cloud credentials secret %q is not ready yet", r.IBMCloudCreds.Spec.SecretRef.Name)
+	}
+
+	if val, ok := cloudCredsSecret.StringData["IBM_COS_Endpoint"]; ok {
+		// Use the endpoint provided in the secret
+		endpoint = val
+		r.Logger.Infof("Endpoint provided in secret: %q", endpoint)
+		if val, ok := cloudCredsSecret.StringData["IBM_COS_Location"]; ok {
+			location = val
+		}
+	} else {
+		// Endpoint not provided in the secret, construct one based on the cluster's region
+		// https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-endpoints#endpoints
+		region, err := util.GetIBMRegion()
+		if err != nil {
+			r.Logger.Errorf("Failed to get IBM Region. %q", err)
+			return fmt.Errorf("Failed to get IBM Region")
+		}
+		r.Logger.Infof("Constructing endpoint for region: %q", region)
+		// https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-classes#classes-locationconstraint
+		endpoint = fmt.Sprintf(ibmEndpoint, region)
+		location = fmt.Sprintf(ibmLocation, region)
+	}
+
+	if _, err := url.Parse(endpoint); err != nil {
+		r.Logger.Errorf("Invalid formate URL %q", endpoint)
+		return fmt.Errorf("Invalid formate URL %q", endpoint)
+	}
+
+	r.Logger.Infof("IBM COS Endpoint: %s   LocationConstraint: %s", endpoint, location)
+
+	var accessKeyID string
+	if val, ok := cloudCredsSecret.StringData["IBM_COS_ACCESS_KEY_ID"]; ok {
+		accessKeyID = val
+	} else {
+		r.Logger.Errorf("Missing IBM_COS_ACCESS_KEY_ID in the secret")
+		return fmt.Errorf("Missing IBM_COS_ACCESS_KEY_ID in the secret")
+	}
+
+	var secretAccessKey string
+	if val, ok := cloudCredsSecret.StringData["IBM_COS_SECRET_ACCESS_KEY"]; ok {
+		secretAccessKey = val
+	} else {
+		r.Logger.Errorf("Missing IBM_COS_SECRET_ACCESS_KEY in the secret")
+		return fmt.Errorf("Missing IBM_COS_SECRET_ACCESS_KEY in the secret")
+	}
+
+	bucketName := r.generateBackingStoreTargetName()
+	r.Logger.Infof("IBM COS Bucket Name: %s", bucketName)
+
+	s3Config := &aws.Config{
+		S3ForcePathStyle: aws.Bool(true),
+		Endpoint:         aws.String(endpoint),
+		Credentials: credentials.NewStaticCredentials(
+			accessKeyID,
+			secretAccessKey,
+			"",
+		),
+		Region: &location,
+	}
+	if err := r.createS3BucketForBackingStore(s3Config, bucketName); err != nil {
+		return err
+	}
+	r.Logger.Infof("Creadted bucket: %s", bucketName)
+
+	// create backing store
+	r.DefaultBackingStore.Spec.Type = nbv1.StoreTypeIBMCos
+	r.DefaultBackingStore.Spec.IBMCos = &nbv1.IBMCosSpec{
+		TargetBucket: bucketName,
+		Secret: corev1.SecretReference{
+			Name:      cloudCredsSecret.Name,
+			Namespace: cloudCredsSecret.Namespace,
+		},
+		Endpoint:         endpoint,
+		SignatureVersion: nbv1.S3SignatureVersionV2,
 	}
 	return nil
 }

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -703,7 +703,7 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 		targetNS := r.IBMCloudCOSCreds.Namespace
 		r.IBMCloudCOSCreds.Namespace = ibmCOSCredDefaultNS
 		util.KubeCheck(r.IBMCloudCOSCreds)
-		if r.IBMCloudCOSCreds.UID != "" {
+		if r.IBMCloudCOSCreds.UID == "" {
 			r.IBMCloudCOSCreds.Namespace = targetNS
 		}
 	}

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -33,10 +33,9 @@ import (
 )
 
 const (
-	ibmEndpoint         = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
-	ibmLocation         = "%s-standard"
-	ibmCOSCred          = "ibm-cloud-cos-creds"
-	ibmCOSCredDefaultNS = "openshift-storage"
+	ibmEndpoint = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
+	ibmLocation = "%s-standard"
+	ibmCOSCred  = "ibm-cloud-cos-creds"
 )
 
 type gcpAuthJSON struct {
@@ -698,15 +697,6 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 	)
 
 	util.KubeCheck(r.IBMCloudCOSCreds)
-	if r.IBMCloudCOSCreds.UID == "" && r.IBMCloudCOSCreds.Namespace != ibmCOSCredDefaultNS {
-		// Secret not found under target ns, check under default ns
-		targetNS := r.IBMCloudCOSCreds.Namespace
-		r.IBMCloudCOSCreds.Namespace = ibmCOSCredDefaultNS
-		util.KubeCheck(r.IBMCloudCOSCreds)
-		if r.IBMCloudCOSCreds.UID == "" {
-			r.IBMCloudCOSCreds.Namespace = targetNS
-		}
-	}
 	if r.IBMCloudCOSCreds.UID == "" {
 		r.Logger.Errorf("Cloud credentials secret %q is not ready yet", r.IBMCloudCOSCreds.Name)
 		return fmt.Errorf("Cloud credentials secret %q is not ready yet", r.IBMCloudCOSCreds.Name)
@@ -773,7 +763,7 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 	if err := r.createS3BucketForBackingStore(s3Config, bucketName); err != nil {
 		return err
 	}
-	r.Logger.Infof("Creadted bucket: %s", bucketName)
+	r.Logger.Infof("Created bucket: %s", bucketName)
 
 	// create backing store
 	r.DefaultBackingStore.Spec.Type = nbv1.StoreTypeIBMCos

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -446,8 +446,8 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 		return nil
 	}
 
-	if r.CephObjectstoreUser.UID != "" {
-		log.Infof("CephObjectstoreUser %q created. Creating default backing store on ceph objectstore", r.CephObjectstoreUser.Name)
+	if r.CephObjectStoreUser.UID != "" {
+		log.Infof("CephObjectStoreUser %q created. Creating default backing store on ceph objectstore", r.CephObjectStoreUser.Name)
 		if err := r.prepareCephBackingStore(); err != nil {
 			return err
 		}

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -81,10 +81,11 @@ type Reconciler struct {
 	SecretRootMasterKey *corev1.Secret
 	AWSCloudCreds       *cloudcredsv1.CredentialsRequest
 	AzureCloudCreds     *cloudcredsv1.CredentialsRequest
-	IBMCloudCreds       *cloudcredsv1.CredentialsRequest
 	AzureContainerCreds *corev1.Secret
 	GCPBucketCreds      *corev1.Secret
 	GCPCloudCreds       *cloudcredsv1.CredentialsRequest
+	IsIBMCloud          bool
+	IBMCloudCOSCreds    *corev1.Secret
 	DefaultBackingStore *nbv1.BackingStore
 	DefaultBucketClass  *nbv1.BucketClass
 	OBCStorageClass     *storagev1.StorageClass
@@ -138,7 +139,7 @@ func NewReconciler(
 		AWSCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		AzureCloudCreds:     util.KubeObject(bundle.File_deploy_internal_cloud_creds_azure_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		GCPCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_gcp_cr_yaml).(*cloudcredsv1.CredentialsRequest),
-		IBMCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
+		IBMCloudCOSCreds:    util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		DefaultBackingStore: util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml).(*nbv1.BackingStore),
 		DefaultBucketClass:  util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml).(*nbv1.BucketClass),
 		OBCStorageClass:     util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass),
@@ -177,8 +178,7 @@ func NewReconciler(
 	r.AzureCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
 	r.GCPCloudCreds.Namespace = r.Request.Namespace
 	r.GCPCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
-	r.IBMCloudCreds.Namespace = r.Request.Namespace
-	r.IBMCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
+	r.IBMCloudCOSCreds.Namespace = r.Request.Namespace
 	r.DefaultBackingStore.Namespace = r.Request.Namespace
 	r.DefaultBucketClass.Namespace = r.Request.Namespace
 	r.PrometheusRule.Namespace = r.Request.Namespace
@@ -216,8 +216,8 @@ func NewReconciler(
 	r.GCPCloudCreds.Name = r.Request.Name + "-gcp-cloud-creds"
 	r.GCPCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-gcp-cloud-creds-secret"
 	r.CephObjectStoreUser.Name = r.Request.Name + "-ceph-objectstore-user"
-	r.IBMCloudCreds.Name = r.Request.Name + "-ibm-cloud-creds"
-	r.IBMCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-ibm-cloud-creds-secret"
+	r.IsIBMCloud = false
+	r.IBMCloudCOSCreds.Name = ibmCOSCred
 	r.DefaultBackingStore.Name = r.Request.Name + "-default-backing-store"
 	r.DefaultBucketClass.Name = r.Request.Name + "-default-bucket-class"
 	r.PrometheusRule.Name = r.Request.Name + "-prometheus-rules"

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -81,6 +81,7 @@ type Reconciler struct {
 	SecretRootMasterKey *corev1.Secret
 	AWSCloudCreds       *cloudcredsv1.CredentialsRequest
 	AzureCloudCreds     *cloudcredsv1.CredentialsRequest
+	IBMCloudCreds       *cloudcredsv1.CredentialsRequest
 	AzureContainerCreds *corev1.Secret
 	GCPBucketCreds      *corev1.Secret
 	GCPCloudCreds       *cloudcredsv1.CredentialsRequest
@@ -137,6 +138,7 @@ func NewReconciler(
 		AWSCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		AzureCloudCreds:     util.KubeObject(bundle.File_deploy_internal_cloud_creds_azure_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		GCPCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_gcp_cr_yaml).(*cloudcredsv1.CredentialsRequest),
+		IBMCloudCreds:       util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		DefaultBackingStore: util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml).(*nbv1.BackingStore),
 		DefaultBucketClass:  util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml).(*nbv1.BucketClass),
 		OBCStorageClass:     util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass),
@@ -175,6 +177,8 @@ func NewReconciler(
 	r.AzureCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
 	r.GCPCloudCreds.Namespace = r.Request.Namespace
 	r.GCPCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
+	r.IBMCloudCreds.Namespace = r.Request.Namespace
+	r.IBMCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
 	r.DefaultBackingStore.Namespace = r.Request.Namespace
 	r.DefaultBucketClass.Namespace = r.Request.Namespace
 	r.PrometheusRule.Namespace = r.Request.Namespace
@@ -212,6 +216,8 @@ func NewReconciler(
 	r.GCPCloudCreds.Name = r.Request.Name + "-gcp-cloud-creds"
 	r.GCPCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-gcp-cloud-creds-secret"
 	r.CephObjectStoreUser.Name = r.Request.Name + "-ceph-objectstore-user"
+	r.IBMCloudCreds.Name = r.Request.Name + "-ibm-cloud-creds"
+	r.IBMCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-ibm-cloud-creds-secret"
 	r.DefaultBackingStore.Name = r.Request.Name + "-default-backing-store"
 	r.DefaultBucketClass.Name = r.Request.Name + "-default-bucket-class"
 	r.PrometheusRule.Name = r.Request.Name + "-prometheus-rules"


### PR DESCRIPTION
Signed-off-by: Neeraj K Kashyap <nkashyap@in.ibm.com>

This PR enables the configuration of IBM COS as backing store for NooBaa in the IBM Cloud (IKS /ROKS).
Currently, Cloud Credential Operator is not supporting IBM Cloud creds. The code change assumes a secret `ibm-cloud-cos-creds`, under `kube-system`, will be created by Admin or by the IBM Cloud at the time of cluster creation
```
apiVersion: v1
kind: Secret
metadata:
  name: ibm-cloud-cos-creds
  namespace: kube-system
type: Opaque
data:
  IBM_COS_ACCESS_KEY_ID: RlM2I4ODQ=
  IBM_COS_SECRET_ACCESS_KEY: NjNjNmEzZTNk
```

The code change has been tested in IBM Cloud
```
$ oc get backingstore
NAME                           TYPE      PHASE   AGE
noobaa-default-backing-store   ibm-cos   Ready   23m
```
