### PR TITLE
Created diagnostic tar file directly to the specified dir

### DIFF
--- a/pkg/diagnose/diagnose.go
+++ b/pkg/diagnose/diagnose.go
@@ -144,6 +144,15 @@ func (c *Collector) CollectPodLogs(corePodSelector labels.Selector) {
 // ExportDiagnostics info
 func (c *Collector) ExportDiagnostics(destDir string) {
 	targetFile := fmt.Sprintf("%s.tar.gz", c.folderName)
+	if destDir != "" {
+		if _, err := os.Stat(destDir); os.IsNotExist(err) {
+			err := os.MkdirAll(destDir, os.ModePerm)
+			if err != nil {
+				c.log.Fatalf(`❌ Could not create directory %s, reason: %s`, destDir, err)
+			}
+		}
+		targetFile = fmt.Sprintf("%s/%s", destDir, targetFile)
+	}
 	fileToWrite, err := os.Create(targetFile)
 	if err != nil {
 		c.log.Fatalf(`❌ Could not create target file %s, reason: %s`, targetFile, err)
@@ -153,19 +162,7 @@ func (c *Collector) ExportDiagnostics(destDir string) {
 	if err != nil {
 		c.log.Fatalf(`❌ Could not compress and package diagnostics, reason: %s`, err)
 	}
-	if destDir != "" {
-		if _, err := os.Stat(destDir); os.IsNotExist(err) {
-			err := os.Mkdir(destDir, os.ModePerm)
-			if err != nil {
-				c.log.Fatalf(`❌ Could not create directory %s, reason: %s`, destDir, err)
-			}
-		}
-		newLocation := fmt.Sprintf("%s/%s", destDir, targetFile)
-		err1 := os.Rename(targetFile, newLocation)
-		if err1 != nil {
-			c.log.Fatalf(`❌ Could not move tar file to destination, reason: %s`, err1)
-		}
-	}
+
 	err = os.RemoveAll(c.folderName)
 	if err != nil {
 		c.log.Fatalf(`❌ Could not delete diagnostics collecting folder %s, reason: %s`, c.folderName, err)


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

Changes: 
1. Created the diagnostics tar file directly to specified dir.

Problem: 
using the `nb diagnose --dir` didn't work as expected inside the must-gather pod.
Renaming the tar file to the wanted directory didn't work inside of the must-gather pod and raised an error that implies that the source directory and the target directory are not on the same file systems.
