### PR TITLE
Add secret for postgres creds

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -68,9 +68,7 @@ spec:
             - name: POSTGRES_DBNAME
               value: nbcore
             - name: POSTGRES_USER
-              value: postgres
             - name: POSTGRES_PASSWORD
-              value: noobaa
             - name: DB_TYPE
               value: mongodb
             - name: CONTAINER_PLATFORM

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -29,9 +29,7 @@ spec:
             - name: POSTGRESQL_DATABASE
               value: nbcore
             - name: POSTGRESQL_USER
-              value: postgres
             - name: POSTGRESQL_PASSWORD
-              value: noobaa
           magePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2342,7 +2342,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "2789548c2f42e0faa3e2b7d5065ab541ae4b09f050dc17a8020e0dfa57ccdac1"
+const Sha256_deploy_internal_statefulset_core_yaml = "d602d62cd0eed9656a96dbef4d8312fa595164178e55474041a258c7e04741bf"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -2414,9 +2414,7 @@ spec:
             - name: POSTGRES_DBNAME
               value: nbcore
             - name: POSTGRES_USER
-              value: postgres
             - name: POSTGRES_PASSWORD
-              value: noobaa
             - name: DB_TYPE
               value: mongodb
             - name: CONTAINER_PLATFORM
@@ -2546,7 +2544,7 @@ spec:
           storage: 50Gi
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "2d25c5ac73690aceea74d8d17853999b1b9a1a05f0342c12d80aa8056ad6f206"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "a41849d20af288d4e005cb479ceb978891f731ad4d9d5fb9f6824a2dc7d80635"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -2579,9 +2577,7 @@ spec:
             - name: POSTGRESQL_DATABASE
               value: nbcore
             - name: POSTGRESQL_USER
-              value: postgres
             - name: POSTGRESQL_PASSWORD
-              value: noobaa
           magePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -71,6 +71,7 @@ type Reconciler struct {
 	ServiceS3           *corev1.Service
 	ServiceDb           *corev1.Service
 	SecretServer        *corev1.Secret
+	SecretDB            *corev1.Secret
 	SecretOp            *corev1.Secret
 	SecretAdmin         *corev1.Secret
 	SecretEndpoints     *corev1.Secret
@@ -121,6 +122,7 @@ func NewReconciler(
 		ServiceMgmt:         util.KubeObject(bundle.File_deploy_internal_service_mgmt_yaml).(*corev1.Service),
 		ServiceS3:           util.KubeObject(bundle.File_deploy_internal_service_s3_yaml).(*corev1.Service),
 		SecretServer:        util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
+		SecretDB:            util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretOp:            util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretAdmin:         util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretEndpoints:     util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
@@ -153,6 +155,7 @@ func NewReconciler(
 	r.ServiceS3.Namespace = r.Request.Namespace
 	r.ServiceDb.Namespace = r.Request.Namespace
 	r.SecretServer.Namespace = r.Request.Namespace
+	r.SecretDB.Namespace = r.Request.Namespace
 	r.SecretOp.Namespace = r.Request.Namespace
 	r.SecretAdmin.Namespace = r.Request.Namespace
 	r.SecretEndpoints.Namespace = r.Request.Namespace
@@ -186,6 +189,7 @@ func NewReconciler(
 	r.ServiceS3.Name = "s3"
 	r.ServiceDb.Name = r.Request.Name + "-db"
 	r.SecretServer.Name = r.Request.Name + "-server"
+	r.SecretDB.Name = r.Request.Name + "-db"
 	r.SecretOp.Name = r.Request.Name + "-operator"
 	r.SecretAdmin.Name = r.Request.Name + "-admin"
 	r.SecretEndpoints.Name = r.Request.Name + "-endpoints"
@@ -223,6 +227,9 @@ func NewReconciler(
 	r.SecretServer.StringData["jwt"] = util.RandomBase64(16)
 	r.SecretServer.StringData["server_secret"] = util.RandomHex(4)
 
+	r.SecretDB.StringData["user"] = "noobaa"
+	r.SecretDB.StringData["password"] = util.RandomBase64(10)
+
 	// set noobaa root master key secret
 	r.SecretRootMasterKey.StringData["cipher_key_b64"] = util.RandomBase64(32)
 	return r
@@ -236,6 +243,7 @@ func (r *Reconciler) CheckAll() {
 	util.KubeCheck(r.ServiceMgmt)
 	util.KubeCheck(r.ServiceS3)
 	if r.NooBaa.Spec.DBType == "postgres" {
+		util.KubeCheck(r.SecretDB)
 		util.KubeCheck(r.NooBaaPostgresDB)
 	} else {
 		util.KubeCheck(r.NooBaaMongoDB)


### PR DESCRIPTION
1. Add secret for postgres creds: user/password
2. connect to both db sts and core sts so they can communicate
3. changed postgres user to noobaa - as postgres user insisted in creating the default db - postgres and not nbcore
4. fixed issues with labels and selectors - to enable db service to really work

Signed-off-by: jackyalbo <jalbo@redhat.com>