### PR TITLE
SCC fixes

### DIFF
--- a/deploy/internal/statefulset-db.yaml
+++ b/deploy/internal/statefulset-db.yaml
@@ -59,6 +59,9 @@ spec:
         volumeMounts:
         - name: db
           mountPath: /data
+      securityContext: 
+        runAsUser: 10001
+        runAsGroup: 0
   volumeClaimTemplates:
   - metadata:
       name: db

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -19,30 +19,52 @@ spec:
         noobaa-db: postgres
     spec:
       serviceAccountName: noobaa
-      containers:
-        #--------------------#
-        # Postgres CONTAINER #
-        #--------------------#
+      initContainers:
+      #----------------#
+      # INIT CONTAINER #
+      #----------------#
+      - name: init
+        image: NOOBAA_CORE_IMAGE
+        command:
+        - /noobaa_init_files/noobaa_init.sh
+        - init_postgres
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "500Mi"
+          limits:
+            cpu: "500m"
+            memory: "500Mi"
+        volumeMounts:
         - name: db
-          image: NOOBAA_DB_IMAGE
-          env:
-            - name: POSTGRESQL_DATABASE
-              value: nbcore
-            - name: POSTGRESQL_USER
-            - name: POSTGRESQL_PASSWORD
-          magePullPolicy: "IfNotPresent"
-          ports:
-            - containerPort: 5432
-          resources:
-            requests:
-              cpu: "2"
-              memory: "4Gi"
-            limits:
-              cpu: "2"
-              memory: "4Gi"
-          volumeMounts:
-            - name: db
-              mountPath: /var/lib/pgsql
+          mountPath: /var/lib/pgsql
+      containers:
+      #--------------------#
+      # Postgres CONTAINER #
+      #--------------------#
+      - name: db
+        image: NOOBAA_DB_IMAGE
+        env:
+          - name: POSTGRESQL_DATABASE
+            value: nbcore
+          - name: POSTGRESQL_USER
+          - name: POSTGRESQL_PASSWORD
+        magePullPolicy: "IfNotPresent"
+        ports:
+          - containerPort: 5432
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+          limits:
+            cpu: "2"
+            memory: "4Gi"
+        volumeMounts:
+          - name: db
+            mountPath: /var/lib/pgsql
+      securityContext: 
+        runAsUser: 10001
+        runAsGroup: 0
   volumeClaimTemplates:
     - metadata:
         name: db

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -168,6 +168,10 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 
 	podSpec := &NooBaaDB.Spec.Template.Spec
 	podSpec.ServiceAccountName = "noobaa"
+	defaultUID := int64(10001)
+	defaulfGID := int64(0)
+	podSpec.SecurityContext.RunAsUser = &defaultUID
+	podSpec.SecurityContext.RunAsGroup = &defaulfGID
 	for i := range podSpec.InitContainers {
 		c := &podSpec.InitContainers[i]
 		if c.Name == "init" {


### PR DESCRIPTION
will now start using running always under uid 10001 and gid 0
need to merge after allowing RunAsAny in noobaa SCC - in OCS opertor
in order for the change to work in upgrades also need to merge the equivalent core PR

Signed-off-by: jackyalbo <jalbo@redhat.com>