### PR TITLE
Fix the build after broken backport.

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -356,14 +356,14 @@ func (r *Reconciler) ReconcileBackingStoreCredentials() error {
 // ReconcileRGWCredentials creates a ceph objectstore user if a ceph objectstore exists in the same namespace
 func (r *Reconciler) ReconcileRGWCredentials() error {
 	r.Logger.Info("Not running in AWS. will attempt to create a ceph objectstore user")
-	util.KubeCheck(r.CephObjectstoreUser)
-	if r.CephObjectstoreUser.UID != "" {
+	util.KubeCheck(r.CephObjectStoreUser)
+	if r.CephObjectStoreUser.UID != "" {
 		return nil
 	}
 
 	// create user if not already exists
 	// list ceph objectstores and pick the first one
-	r.CephObjectstoreUser.Spec.Store = ""
+	r.CephObjectStoreUser.Spec.Store = ""
 	cephObjectStoresList := &cephv1.CephObjectStoreList{}
 	if util.KubeList(cephObjectStoresList, &client.ListOptions{Namespace: options.Namespace}) {
 		if len(cephObjectStoresList.Items) > 0 {
@@ -371,7 +371,7 @@ func (r *Reconciler) ReconcileRGWCredentials() error {
 			// for now take the first one. need to decide what to do if multiple objectstores in one namespace
 			storeName := cephObjectStoresList.Items[0].ObjectMeta.Name
 			r.Logger.Infof("using objectstore %q as a default backing store", storeName)
-			r.CephObjectstoreUser.Spec.Store = storeName
+			r.CephObjectStoreUser.Spec.Store = storeName
 
 		} else {
 			r.Logger.Info("did not find any ceph objectstore to use as backing store, assuming independent mode")
@@ -381,18 +381,18 @@ func (r *Reconciler) ReconcileRGWCredentials() error {
 		r.Logger.Info("failed to list ceph objectstore to use as backing store, assuming independent mode")
 	}
 
-	if r.CephObjectstoreUser.Spec.Store == "" {
+	if r.CephObjectStoreUser.Spec.Store == "" {
 		if r.NooBaa.Labels == nil || r.NooBaa.Labels["rgw-endpoint"] == "" {
 			r.Logger.Warn("did not find an rgw-endpoint label on the noobaa CR")
 			return nil
 		}
 	}
 
-	r.Own(r.CephObjectstoreUser)
+	r.Own(r.CephObjectStoreUser)
 	// create ceph objectstore user
-	err := r.Client.Create(r.Ctx, r.CephObjectstoreUser)
+	err := r.Client.Create(r.Ctx, r.CephObjectStoreUser)
 	if err != nil {
-		r.Logger.Errorf("got error on CephObjectstoreUser creation. error: %v", err)
+		r.Logger.Errorf("got error on CephObjectStoreUser creation. error: %v", err)
 		return err
 	}
 	return nil

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -794,7 +794,7 @@ func (r *Reconciler) createGCPBucketForBackingStore(client *storage.Client, proj
 
 func (r *Reconciler) prepareCephBackingStore() error {
 
-	secretName := "rook-ceph-object-user-" + r.CephObjectstoreUser.Spec.Store + "-" + r.CephObjectstoreUser.Name
+	secretName := "rook-ceph-object-user-" + r.CephObjectStoreUser.Spec.Store + "-" + r.CephObjectStoreUser.Name
 
 	// get access\secret keys from user secret
 	cephObjectUserSecret := &corev1.Secret{
@@ -823,10 +823,10 @@ func (r *Reconciler) prepareCephBackingStore() error {
 		i := strings.LastIndex(raw, "_")
 		endpoint = fmt.Sprintf("http://%s:%s", raw[:i], raw[i+1:])
 		r.Logger.Info("Found RGW endpoint in noobaa label \"endpoint\"")
-	} else if r.CephObjectstoreUser.Spec.Store != "" {
+	} else if r.CephObjectStoreUser.Spec.Store != "" {
 		// if not found in the secret compose from the ceph-object-store name
-		endpoint = "http://rook-ceph-rgw-" + r.CephObjectstoreUser.Spec.Store + "." + options.Namespace + ".svc.cluster.local:80"
-		r.Logger.Infof("Found RGW endpoint in CephObjectstoreUser %q", r.CephObjectstoreUser.Name)
+		endpoint = "http://rook-ceph-rgw-" + r.CephObjectStoreUser.Spec.Store + "." + options.Namespace + ".svc.cluster.local:80"
+		r.Logger.Infof("Found RGW endpoint in CephObjectStoreUser %q", r.CephObjectStoreUser.Name)
 	} else {
 		return fmt.Errorf("Ceph RGW endpoint address is not available")
 	}

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -87,7 +87,7 @@ type Reconciler struct {
 	PrometheusRule      *monitoringv1.PrometheusRule
 	ServiceMonitor      *monitoringv1.ServiceMonitor
 	SystemInfo          *nb.SystemInfo
-	CephObjectstoreUser *cephv1.CephObjectStoreUser
+	CephObjectStoreUser *cephv1.CephObjectStoreUser
 	RouteMgmt           *routev1.Route
 	RouteS3             *routev1.Route
 	DeploymentEndpoint  *appsv1.Deployment
@@ -135,7 +135,7 @@ func NewReconciler(
 		OBCStorageClass:     util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass),
 		PrometheusRule:      util.KubeObject(bundle.File_deploy_internal_prometheus_rules_yaml).(*monitoringv1.PrometheusRule),
 		ServiceMonitor:      util.KubeObject(bundle.File_deploy_internal_service_monitor_yaml).(*monitoringv1.ServiceMonitor),
-		CephObjectstoreUser: util.KubeObject(bundle.File_deploy_internal_ceph_objectstore_user_yaml).(*cephv1.CephObjectStoreUser),
+		CephObjectStoreUser: util.KubeObject(bundle.File_deploy_internal_ceph_objectstore_user_yaml).(*cephv1.CephObjectStoreUser),
 		RouteMgmt:           util.KubeObject(bundle.File_deploy_internal_route_mgmt_yaml).(*routev1.Route),
 		RouteS3:             util.KubeObject(bundle.File_deploy_internal_route_s3_yaml).(*routev1.Route),
 		DeploymentEndpoint:  util.KubeObject(bundle.File_deploy_internal_deployment_endpoint_yaml).(*appsv1.Deployment),
@@ -168,7 +168,7 @@ func NewReconciler(
 	r.DefaultBucketClass.Namespace = r.Request.Namespace
 	r.PrometheusRule.Namespace = r.Request.Namespace
 	r.ServiceMonitor.Namespace = r.Request.Namespace
-	r.CephObjectstoreUser.Namespace = r.Request.Namespace
+	r.CephObjectStoreUser.Namespace = r.Request.Namespace
 	r.RouteMgmt.Namespace = r.Request.Namespace
 	r.RouteS3.Namespace = r.Request.Namespace
 	r.DeploymentEndpoint.Namespace = r.Request.Namespace


### PR DESCRIPTION
PR #486 introduced some compile problems in conflict resolution.
It was missing some renames of `CephObjectstoreUser` to
`CephObjectStoreUser` that had been done in the master branch
as part of PR #448 and not been backported to 5.6.

This fixes the build by adding the missing renames.

Signed-off-by: Michael Adam <obnox@redhat.com>