### PR TITLE
fixing pvpool bs name limit to 43 chars instead of 47

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -435,7 +435,7 @@ func RunCreatePVPool(cmd *cobra.Command, args []string) {
 		pvSizeGB, _ := cmd.Flags().GetUint32("pv-size-gb")
 		storageClass, _ := cmd.Flags().GetString("storage-class")
 		pvPoolName := args[0]
-		if len(pvPoolName) > 47 {
+		if len(pvPoolName) > 43 {
 			log.Fatalf(`❌ Number of characters in <backing-store-name> should not exceed 63 `)
 		}
 		if numVolumes == 0 {


### PR DESCRIPTION
Due to the pv-pool suffix names being changed - possible name is now shorter to fit to linux max allowed length of 63 chars

Signed-off-by: jackyalbo <jalbo@redhat.com>