### PR TITLE
Backport to 5.7: Fixing CLI when using postgres as DB

### DIFF
--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -279,7 +279,7 @@ func RunDelete(cmd *cobra.Command, args []string) {
 		pvc := &corev1.PersistentVolumeClaim{
 			TypeMeta: metav1.TypeMeta{Kind: "PersistentVolumeClaim"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      t.Name + "-" + options.SystemName + "-db-0",
+				Name:      t.Name + "-" + noobaaDB.Name + "-0",
 				Namespace: options.Namespace,
 			},
 		}
@@ -512,7 +512,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 		pvc := &corev1.PersistentVolumeClaim{
 			TypeMeta: metav1.TypeMeta{Kind: "PersistentVolumeClaim"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      t.Name + "-" + options.SystemName + "-db-0",
+				Name:      t.Name + "-" + NooBaaDB.Name + "-0",
 				Namespace: options.Namespace,
 			},
 		}


### PR DESCRIPTION
Fixing CLI when using postgres as DB
- Fixes: BZ #1909488

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit b0036cbb724228922d100ef467d2f7a9f56d78ea)