### PR TITLE
Fixing upgrade issue with old STS values

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -319,6 +319,9 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			}
 		case "POSTGRES_USER":
 			if r.NooBaa.Spec.DBType == "postgres" {
+				if (c.Env[j].Value != "") {
+					c.Env[j].Value = ""
+				}
 				c.Env[j].ValueFrom = &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
@@ -330,6 +333,9 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			}
 		case "POSTGRES_PASSWORD":
 			if r.NooBaa.Spec.DBType == "postgres" {
+				if (c.Env[j].Value != "") {
+					c.Env[j].Value = ""
+				}
 				c.Env[j].ValueFrom = &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{


### PR DESCRIPTION
Old sts use to have value before moving to valueFrom - old Value needs to be deleted, otherwise pods can't start
Fix to BZ1915698

Signed-off-by: jackyalbo <jalbo@redhat.com>