### PR TITLE
Adding timeout to RPC calls

### DIFF
--- a/pkg/nb/rpc.go
+++ b/pkg/nb/rpc.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	util "github.com/noobaa/noobaa-operator/v2/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -16,6 +17,9 @@ const (
 	// RPCMaxMessageSize is a limit to protect the process from allocating too much memory
 	// for a single incoming message for example in case the connection is out of sync or other bugs.
 	RPCMaxMessageSize = 64 * 1024 * 1024
+
+	// RPCSendTimeout is a limit the time we wait for getting reply from the server
+	RPCSendTimeout = 120 * time.Second;
 )
 
 // GlobalRPC is the global rpc

--- a/pkg/nb/rpc_ws.go
+++ b/pkg/nb/rpc_ws.go
@@ -171,7 +171,9 @@ func (c *RPCConnWS) NewRequest(req *RPCMessage, res RPCResponse) chan error {
 
 // SendMessage sends the pending request
 func (c *RPCConnWS) SendMessage(msg interface{}) error {
-	writer, err := c.WS.Writer(context.TODO(), websocket.MessageBinary)
+	ctx, cancel := context.WithTimeout(context.TODO(), RPCSendTimeout)
+	defer cancel()
+	writer, err := c.WS.Writer(ctx, websocket.MessageBinary)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixing BZ1915261

it seems we didn't timeout RPC calls which led to a hanging requests which hold the whole reconcile flow. limiting now to 2 minutes like we do in the server.

Signed-off-by: jackyalbo <jalbo@redhat.com>