### PR TITLE
CLI | Wait for System Phase is "Ready" on status

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -109,6 +109,11 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	log.Printf("Operator Status:")
 	operator.RunStatus(cmd, args)
 	log.Printf("")
+	log.Printf("System Wait Ready:")
+	if system.WaitReady() {
+		log.Printf("")
+		log.Printf("")
+	}
 	log.Printf("System Status:")
 	system.RunStatus(cmd, args)
 


### PR DESCRIPTION
### Explain the changes:

When running status and the system is not ready, we will not print an empty "System Status"
We will wait for "System Phase is Ready",  and then we will then print the System Status.

### Testing Instructions:
Have a working noobaa and do:
1. Run `kubectl edit noobaa noobaa`
2. Edit the image and replace it with a new core image 
3. Wait for the system to go down, then run `noobaa status` using the CLI.

Signed-off-by: liranmauda <liran.mauda@gmail.com>