### PR TITLE
fixed default backing store creation in aws GovCloud

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -495,9 +495,16 @@ func (r *Reconciler) ReconcileRGWCredentials() error {
 
 // ReconcileAWSCredentials creates a CredentialsRequest resource if cloud credentials operator is available
 func (r *Reconciler) ReconcileAWSCredentials() error {
+	arnPrefix := "arn:aws:s3:::"
+	awsRegion, err := util.GetAWSRegion()
+	if err != nil {
+		r.Logger.Errorf("Got error from util.GetAWSRegion(). will use arnPrefix=%q. error=%v", arnPrefix, err)
+	} else if awsRegion == "us-gov-east-1" || awsRegion == "us-gov-west-1" {
+		arnPrefix = "arn:aws-us-gov:s3:::"
+	}
 	r.Logger.Info("Running in AWS. will create a CredentialsRequest resource")
 	var bucketName string
-	err := r.Client.Get(r.Ctx, util.ObjectKey(r.AWSCloudCreds), r.AWSCloudCreds)
+	err = r.Client.Get(r.Ctx, util.ObjectKey(r.AWSCloudCreds), r.AWSCloudCreds)
 	if err == nil {
 		// credential request already exist. get the bucket name
 		codec, err := cloudcredsv1.NewCodec()
@@ -511,7 +518,7 @@ func (r *Reconciler) ReconcileAWSCredentials() error {
 			r.Logger.Error("error decoding providerSpec from cloud credentials request")
 			return err
 		}
-		bucketName = strings.TrimPrefix(awsProviderSpec.StatementEntries[0].Resource, "arn:aws:s3:::")
+		bucketName = strings.TrimPrefix(awsProviderSpec.StatementEntries[0].Resource, arnPrefix)
 		r.Logger.Infof("found existing credential request for bucket %s", bucketName)
 		r.DefaultBackingStore.Spec.AWSS3 = &nbv1.AWSS3Spec{
 			TargetBucket: bucketName,
@@ -538,8 +545,8 @@ func (r *Reconciler) ReconcileAWSCredentials() error {
 			return err
 		}
 		// fix creds request according to bucket name
-		awsProviderSpec.StatementEntries[0].Resource = "arn:aws:s3:::" + bucketName
-		awsProviderSpec.StatementEntries[1].Resource = "arn:aws:s3:::" + bucketName + "/*"
+		awsProviderSpec.StatementEntries[0].Resource = arnPrefix + bucketName
+		awsProviderSpec.StatementEntries[1].Resource = arnPrefix + bucketName + "/*"
 		updatedProviderSpec, err := codec.EncodeProviderSpec(awsProviderSpec)
 		if err != nil {
 			r.Logger.Error("error encoding providerSpec for cloud credentials request")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -881,6 +881,8 @@ func GetAWSRegion() (string, error) {
 		"ap-south-1":     "ap-south-1",
 		"me-south-1":     "me-south-1",
 		"sa-east-1":      "sa-east-1",
+		"us-gov-west-1":  "us-gov-west-1",
+		"us-gov-east-1":  "us-gov-east-1",
 	}
 	nodesList := &corev1.NodeList{}
 	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

use a different arn prefix (`arn:aws-us-gov`) for credentials request when running in AWS GovCloud.
Fixes #535 
Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1925533

