### PR TITLE
In IBM Cloud if COS cred secret is missing use pv-pool for default backing store

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -634,7 +634,11 @@ func (r *Reconciler) ReconcileIBMCredentials() error {
 	// Currently IBM Cloud is not supported by cloud credential operator
 	// In IBM Cloud, the COS Creds will be provided through Secret.
 	r.Logger.Info("Running in IBM Cloud")
-	r.IsIBMCloud = true
+	util.KubeCheck(r.IBMCloudCOSCreds)
+	if r.IBMCloudCOSCreds.UID == "" {
+		r.Logger.Infof("%q secret is not present", r.IBMCloudCOSCreds.Name)
+		return nil
+	}
 	return nil
 }
 

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -475,8 +475,8 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 		if err := r.prepareGCPBackingStore(); err != nil {
 			return err
 		}
-	} else if r.IsIBMCloud {
-		log.Infof("Running in IBM Cloud. Creating default backing store on IBM objectstore")
+	} else if r.IBMCloudCOSCreds.UID != "" {
+		log.Infof("IBM objectstore credentials %q created. Creating default backing store on IBM objectstore", r.IBMCloudCOSCreds.Name)
 		if err := r.prepareIBMBackingStore(); err != nil {
 			return err
 		}

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -85,7 +85,6 @@ type Reconciler struct {
 	AzureContainerCreds       *corev1.Secret
 	GCPBucketCreds            *corev1.Secret
 	GCPCloudCreds             *cloudcredsv1.CredentialsRequest
-	IsIBMCloud                bool
 	IBMCloudCOSCreds          *corev1.Secret
 	DefaultBackingStore       *nbv1.BackingStore
 	DefaultBucketClass        *nbv1.BucketClass
@@ -218,7 +217,6 @@ func NewReconciler(
 	r.GCPCloudCreds.Name = r.Request.Name + "-gcp-cloud-creds"
 	r.GCPCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-gcp-cloud-creds-secret"
 	r.CephObjectStoreUser.Name = r.Request.Name + "-ceph-objectstore-user"
-	r.IsIBMCloud = false
 	r.IBMCloudCOSCreds.Name = ibmCOSCred
 	r.DefaultBackingStore.Name = r.Request.Name + "-default-backing-store"
 	r.DefaultBucketClass.Name = r.Request.Name + "-default-bucket-class"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -837,7 +837,7 @@ func IsIBMPlatform() bool {
 	isIBM := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "ibm")
 	if isIBM {
 		// Incase of Satellite cluster is deplyed in user provided infrastructure
-		if strings.Contains(nodesList.Items[0].Spec.ProviderID, "sat-ibm") {
+		if strings.Contains(nodesList.Items[0].Spec.ProviderID, "/sat-") {
 			isIBM = false
 		}
 	}


### PR DESCRIPTION

Signed-off-by: Ambika Nair <ambiknai@in.ibm.com>
This PR enables to use pv-pool for default backing store in IBM Cloud if COS cred secret is missing