### PR TITLE
Backport to 5.7: Bumped core image to 5.7.0-20210304

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,7 +29,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.7.0-20210113"
+	ContainerImageTag = "5.7.0-20210304"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
Bumped core image to 5.7.0-20210304

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit 6217b5296abbd1c50e7ac21f25e2aa6a6c4f2d3a)