### PR TITLE
removing auth_token print

### DIFF
--- a/pkg/controller/noobaa/noobaa_controller.go
+++ b/pkg/controller/noobaa/noobaa_controller.go
@@ -124,7 +124,7 @@ func Add(mgr manager.Manager) error {
 
 	// handler for global RPC message and ,simply trigger a reconcile on every message
 	nb.GlobalRPC.Handler = func(req *nb.RPCMessage) (interface{}, error) {
-		logrus.Infof("RPC Handle: %+v", req)
+		logrus.Infof("RPC Handle: {Op: %s, API: %s, Method: %s, Error: %s, Params: %+v}", req.Op, req.API, req.Method, req.Error, req.Params)
 		notificationSource.Queue.AddRateLimited(reconcile.Request{NamespacedName: types.NamespacedName{
 			Name:      options.SystemName,
 			Namespace: options.Namespace,


### PR DESCRIPTION
Fix BZ1935262

Printing only part of the RPCMessage like in following example
```time="2021-03-07T13:02:54Z" level=info msg="RPC Handle: {Op: req, API: server_inter_process_api, Method: load_system_store, Error: <nil>, Params: map[since:1.615122174279e+12]}"```

Signed-off-by: jackyalbo <jalbo@redhat.com>