### PR TITLE
setting upgrade job restartPolicy to never

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -130,3 +130,4 @@ rules:
   - patch
   - list
   - watch
+  - delete

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3956,7 +3956,7 @@ spec:
                   fieldPath: metadata.namespace
 `
 
-const Sha256_deploy_role_yaml = "e7f989b6da9e463a79e9c2fca2c8621f3f2eaf7a9df16b7c3eeb27e140e7089a"
+const Sha256_deploy_role_yaml = "e86edfb70be11ea9af8f0f210bfbbf1bc1a71cc52806adfcf48c7b530425f8ed"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -4090,6 +4090,7 @@ rules:
   - patch
   - list
   - watch
+  - delete
 `
 
 const Sha256_deploy_role_binding_yaml = "59a2627156ed3db9cd1a4d9c47e8c1044279c65e84d79c525e51274329cb16ff"

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const upgradeJobBackoffLimit = int32(4)
+
 // ReconcilePhaseCreating runs the reconcile phase
 func (r *Reconciler) ReconcilePhaseCreating() error {
 
@@ -939,6 +941,9 @@ func (r *Reconciler) UpgradeMigrateDB() error {
 		if r.UpgradeJob.Status.Succeeded > 0 {
 			r.Logger.Infof("UpgradeMigrateDB:: migration completed successfuly. setting phase to %s", nbv1.UpgradePhaseClean)
 			phase = nbv1.UpgradePhaseClean
+		} else if r.UpgradeJob.Status.Failed > upgradeJobBackoffLimit {
+			r.Logger.Errorf("migration failed. upgrade job exceeded the backoff limit of %d. manually delete the job %q to retry",
+				upgradeJobBackoffLimit, r.UpgradeJob.Name)
 		} else {
 			r.Logger.Infof("UpgradeMigrateDB:: migration not finished yet")
 			return fmt.Errorf("job didn't finish yet")
@@ -948,8 +953,7 @@ func (r *Reconciler) UpgradeMigrateDB() error {
 		r.Logger.Infof("UpgradeMigrateDB:: cleanup phase")
 
 		r.Logger.Infof("UpgradeMigrateDB:: deleting mongodb STS")
-		err := r.Client.Delete(r.Ctx, mongoSts)
-		if err != nil && !errors.IsNotFound(err) {
+		if err := r.Client.Delete(r.Ctx, mongoSts); err != nil && !errors.IsNotFound(err) {
 			r.Logger.Errorf("got error on mongo sts deletion: %v", err)
 			return err
 		}
@@ -972,8 +976,11 @@ func (r *Reconciler) UpgradeMigrateDB() error {
 			return err
 		}
 
-		r.Logger.Infof("UpgradeMigrateDB:: Completed migration to postgres. setting upgrade phase to DoneUpgrade")
+		if err := r.CleanupMigrationJob(); err != nil {
+			return err
+		}
 
+		r.Logger.Infof("UpgradeMigrateDB:: Completed migration to postgres. setting upgrade phase to DoneUpgrade")
 		phase = nbv1.UpgradePhaseFinished
 
 	}
@@ -985,11 +992,50 @@ func (r *Reconciler) UpgradeMigrateDB() error {
 	return nil
 }
 
+// CleanupMigrationJob deletes the migration job and all its pods
+func (r *Reconciler) CleanupMigrationJob() error {
+
+	// delete the migration job
+	r.Logger.Infof("UpgradeMigrateDB:: deleting migration job")
+	if err := r.Client.Delete(r.Ctx, r.UpgradeJob); err != nil {
+		r.Logger.Errorf("UpgradeMigrateDB:: got error on migration job deletion: %v", err)
+		return err
+	}
+
+	// it seems that completed pods are not delete after job deletion. delete all job pods explicitly
+	r.Logger.Infof("UpgradeMigrateDB:: deleting migration job pods")
+	jobPods := &corev1.PodList{}
+	jobPodsSelector, _ := labels.Parse("job-name=" + r.UpgradeJob.Name)
+	if !util.KubeList(jobPods, &client.ListOptions{Namespace: options.Namespace, LabelSelector: jobPodsSelector}) {
+		return nil
+	}
+
+	hadErrors := false
+	for _, pod := range jobPods.Items {
+		if err := r.Client.Delete(r.Ctx, &pod); err != nil && !errors.IsNotFound(err) {
+			r.Logger.Errorf("got error on pod %v deletion. %v", pod.Name, err)
+			hadErrors = true
+		}
+	}
+	if hadErrors {
+		return fmt.Errorf("had errors in migration job pods deletion")
+	}
+
+	return nil
+
+}
+
 // SetDesiredJobUpgradeDB updates the UpgradeJob as desired for reconciling
 func (r *Reconciler) SetDesiredJobUpgradeDB() error {
+	backoffLimit := upgradeJobBackoffLimit
 	r.UpgradeJob.Spec.Template.Spec.Containers[0].Image = r.NooBaa.Status.ActualImage
 	r.UpgradeJob.Spec.Template.Spec.Containers[0].Command = []string{"/noobaa_init_files/noobaa_init.sh", "db_migrate"}
 	r.setDesiredCoreEnv(&r.UpgradeJob.Spec.Template.Spec.Containers[0])
+
+	// setting the restart policy to never to keep the pods around after failed migrations
+	// also reducing the backoff limit to avoid to many pods staying around in case of an issue
+	r.UpgradeJob.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+	r.UpgradeJob.Spec.BackoffLimit = &backoffLimit
 	return nil
 }
 


### PR DESCRIPTION
* setting `restartPolicy` to never will keep failed pods around so we can examine the failures
* setting `backoffLimit` to 4 (default is 6) to reduce the number of pods that can potentially stay in the NS
* one thing to notice is that failed runs will leave a pod (not running) with ERROR state. This can lead to support cases, but maybe these are cases we want to know about

related to BZ https://bugzilla.redhat.com/show_bug.cgi?id=1938557

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>