### PR TITLE
Backport to 5.7: setting upgrade job restartPolicy to never

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -130,3 +130,4 @@ rules:
   - patch
   - list
   - watch
+  - delete

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3936,7 +3936,7 @@ spec:
                   fieldPath: metadata.namespace
 `
 
-const Sha256_deploy_role_yaml = "e7f989b6da9e463a79e9c2fca2c8621f3f2eaf7a9df16b7c3eeb27e140e7089a"
+const Sha256_deploy_role_yaml = "e86edfb70be11ea9af8f0f210bfbbf1bc1a71cc52806adfcf48c7b530425f8ed"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -4070,6 +4070,7 @@ rules:
   - patch
   - list
   - watch
+  - delete
 `
 
 const Sha256_deploy_role_binding_yaml = "59a2627156ed3db9cd1a4d9c47e8c1044279c65e84d79c525e51274329cb16ff"


### PR DESCRIPTION
* setting to never will keep failed pods around so we can examine the failures
* set backoffLimit to 4 (default is 6) to reduce the number of pods that can potentially stay in the NS
* one thing to notice is that failed runs will leave a pod (not running) with ERROR state

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 5838aa641fa131b2994bee6da641f34e93503c69)