### PR TITLE
moved core STS reconciliation to run after migration

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -94,9 +94,7 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 	if err := r.UpgradeSplitDB(); err != nil {
 		return err
 	}
-	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
-		return err
-	}
+
 	// create the mongo db only if mongo db url is not given.
 	if r.NooBaa.Spec.MongoDbURL == "" {
 		if err := r.UpgradeSplitDB(); err != nil {
@@ -126,6 +124,11 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 			return err
 		}
 	}
+
+	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
+		return err
+	}
+
 	if err := r.ReconcileObjectOptional(r.RouteMgmt, nil); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1938557

* noobaa-core is reconciled before we start the migration process
* when changing DB type to postgres, the operator restart noobaa-core and postgres before the migration
* in some cases, noobaa-core starts before the migration starts and it creates a support account (here: https://github.com/noobaa/noobaa-core/blob/c40153e5e4389834ab597fef94ce60615cbeb18a/src/server/web_server.js#L66)
* changed the sequence to reconcile core after migration phase

