### PR TITLE
backport to 5.7 - moved core STS reconciliation to run after migration

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -87,12 +87,11 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 	if err := r.UpgradeSplitDB(); err != nil {
 		return err
 	}
-	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
-		return err
-	}
+
 	if err := r.ReconcileDB(); err != nil {
 		return err
 	}
+
 	if err := r.ReconcileObject(r.ServiceMgmt, r.SetDesiredServiceMgmt); err != nil {
 		return err
 	}
@@ -110,6 +109,11 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 			return err
 		}
 	}
+
+	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
+		return err
+	}
+
 	if err := r.ReconcileObjectOptional(r.RouteMgmt, nil); err != nil {
 		return err
 	}


### PR DESCRIPTION
cherry picked from bbf07c11f64c0627fe1cac5de6ef5dbee0561e7b