### PR TITLE
specify mongo db image when reconciling old mongo sts

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -71,6 +71,10 @@ var DBImage = "centos/mongodb-36-centos7"
 // currently it can not be overridden.
 var DBPostgresImage = "centos/postgresql-12-centos7"
 
+// DBMongoImage is the default mongo db image url
+// this is used during migration to solve issues where mongo STS referencing to postgres image
+var DBMongoImage = "centos/mongodb-36-centos7"
+
 // DBType is the default db image type
 // it can be overridden for testing or different types.
 var DBType = "mongodb"


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1945450

* when reconciling mongo STS in migrate flow we no longer have the mong image stored in the spec (dbImage is used for postgres image).
* explicitly set the mongo image when reconciling mongo STS since in some cases the STS could have been reconciled with the posters image.