### PR TITLE
Adding needed changes for NSFS for noobaa-endpoint deployment

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -20,7 +20,7 @@ spec:
         noobaa-s3: noobaa
         app: noobaa
     spec:
-      serviceAccountName: noobaa
+      serviceAccountName: noobaa-endpoint
       volumes:
         - name: mgmt-secret
           secret:
@@ -43,6 +43,9 @@ spec:
             limits:
               cpu: "1"
               memory: "2Gi"
+          securityContext:
+            capabilities:
+              add: ["SETUID", "SETGID"]
           ports:
             - containerPort: 6001
             - containerPort: 6443
@@ -101,3 +104,6 @@ spec:
             tcpSocket:
               port: 6001 # ready when s3 port is open
             timeoutSeconds: 5
+      securityContext: 
+        runAsUser: 0
+        runAsGroup: 0

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -131,3 +131,11 @@ rules:
   - list
   - watch
   - delete
+- apiGroups:
+  - security.openshift.io 
+  resourceNames:
+  - noobaa 
+  resources:
+  - securitycontextconstraints 
+  verbs: 
+  - use

--- a/deploy/role_binding_endpoint.yaml
+++ b/deploy/role_binding_endpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: noobaa-endpoint
+subjects:
+  - kind: ServiceAccount
+    name: noobaa-endpoint
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: noobaa-endpoint

--- a/deploy/role_endpoint.yaml
+++ b/deploy/role_endpoint.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: noobaa-endpoint
+rules:
+- apiGroups:
+  - noobaa.io
+  resources:
+  - '*'
+  - noobaas
+  - backingstores
+  - bucketclasses
+  - noobaas/finalizers
+  - backingstores/finalizers
+  - bucketclasses/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - security.openshift.io 
+  resourceNames:
+  - noobaa-endpoint 
+  resources:
+  - securitycontextconstraints 
+  verbs: 
+  - use

--- a/deploy/scc_endpoint.yaml
+++ b/deploy/scc_endpoint.yaml
@@ -1,0 +1,38 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: noobaa-endpoint
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETUID
+- SETGID
+defaultAddCapabilities: []
+fsGroup:
+  type: MustRunAs
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:openshift-storage:noobaa-endpoint
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/deploy/service_account_endpoint.yaml
+++ b/deploy/service_account_endpoint.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: noobaa-endpoint

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -193,6 +193,11 @@ func GenerateCSV(opConf *operator.Conf) *operv1.ClusterServiceVersion {
 			ServiceAccountName: opConf.SA.Name,
 			Rules:              opConf.Role.Rules,
 		})
+	csv.Spec.InstallStrategy.StrategySpec.Permissions = append(csv.Spec.InstallStrategy.StrategySpec.Permissions,
+		operv1.StrategyDeploymentPermissions{
+			ServiceAccountName: opConf.SAEndpoint.Name,
+			Rules:              opConf.RoleEndpoint.Rules,
+		})
 	csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = []operv1.StrategyDeploymentSpec{}
 	csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = append(csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs,
 		operv1.StrategyDeploymentSpec{

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -263,6 +263,10 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 		podSpec.ImagePullSecrets =
 			[]corev1.LocalObjectReference{*r.NooBaa.Spec.ImagePullSecret}
 	}
+	rootUIDGid := int64(0)
+	podSpec.SecurityContext.RunAsUser = &rootUIDGid
+	podSpec.SecurityContext.RunAsGroup = &rootUIDGid
+
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]
 		switch c.Name {
@@ -373,6 +377,7 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 					}
 				}
 			}
+			c.SecurityContext.Capabilities.Add = []corev1.Capability{"SETUID", "SETGID"}
 
 			util.ReflectEnvVariable(&c.Env, "HTTP_PROXY")
 			util.ReflectEnvVariable(&c.Env, "HTTPS_PROXY")


### PR DESCRIPTION
Adding the needed caps for noobaa-endpoints deployment: set-uid and set-gid, as well as running as root
Also creating a new service account, role and rolebinding for noobaa-endpoints
Adding the use option to both roles for future use instead of the sccs' users list

Signed-off-by: jackyalbo <jalbo@redhat.com>