### PR TITLE
NSFS path / default_reosurce changes in operator

### DIFF
--- a/deploy/crds/noobaa.io_namespacestores_crd.yaml
+++ b/deploy/crds/noobaa.io_namespacestores_crd.yaml
@@ -138,11 +138,12 @@ spec:
                     - GPFS
                     - NFSv4
                     type: string
-                  fsPath:
-                    description: FsPath is a path to a directory in a file system
+                  fsRootPath:
+                    description: FsRootPath is a path to a root directory in a file
+                      system
                     type: string
                 required:
-                - fsPath
+                - fsRootPath
                 type: object
               s3Compatible:
                 description: S3Compatible specifies a namespace store of type s3-compatible

--- a/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
+++ b/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
@@ -163,8 +163,8 @@ const (
 // NSFSSpec specifies a namespace store of type nsfs
 type NSFSSpec struct {
 
-	// FsPath is a path to a directory in a file system
-	FsPath string `json:"fsPath"`
+	// FsRootPath is a path to a root directory in a file system
+	FsRootPath string `json:"fsRootPath"`
 
 	// FsBackend is the backend type of the file system
 	// +optional

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -415,7 +415,7 @@ func (r *Reconciler) ReconcileDeletion() error {
 		}
 		for i := range r.SystemInfo.Accounts {
 			account := &r.SystemInfo.Accounts[i]
-			if account.DefaultPool == r.PoolInfo.Name {
+			if account.DefaultResource == r.PoolInfo.Name {
 				allowedBuckets := account.AllowedBuckets
 				if allowedBuckets.PermissionList == nil {
 					allowedBuckets.PermissionList = []string{}
@@ -423,7 +423,7 @@ func (r *Reconciler) ReconcileDeletion() error {
 				err := r.NBClient.UpdateAccountS3Access(nb.UpdateAccountS3AccessParams{
 					Email:        account.Email,
 					S3Access:     account.HasS3Access,
-					DefaultPool:  &internalPoolName,
+					DefaultResource:  &internalPoolName,
 					AllowBuckets: &allowedBuckets,
 				})
 				if err != nil {
@@ -918,7 +918,7 @@ func (r *Reconciler) ReconcilePool() error {
 			r.Secret.StringData["AGENT_CONFIG"] = res
 			util.KubeUpdate(r.Secret)
 		}
-		err = r.NBClient.UpdateAllBucketsDefaultPool(nb.UpdateDefaultPoolParams{
+		err = r.NBClient.UpdateAllBucketsDefaultPool(nb.UpdateDefaultResourceParams{
 			PoolName: r.CreateHostsPoolParams.Name,
 		})
 		if err != nil {
@@ -955,7 +955,7 @@ func (r *Reconciler) ReconcilePool() error {
 	}
 
 	if poolName != "" {
-		err := r.NBClient.UpdateAllBucketsDefaultPool(nb.UpdateDefaultPoolParams{
+		err := r.NBClient.UpdateAllBucketsDefaultPool(nb.UpdateDefaultResourceParams{
 			PoolName: poolName,
 		})
 		if err != nil {

--- a/pkg/bucketclass/reconciler.go
+++ b/pkg/bucketclass/reconciler.go
@@ -229,7 +229,8 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 				}
 			}
 		}
-	} else if r.BucketClass.Spec.NamespacePolicy != nil {
+	} 
+	if r.BucketClass.Spec.NamespacePolicy != nil {
 		nspType := r.BucketClass.Spec.NamespacePolicy.Type
 		var namespaceStoresArr []string
 		if nspType == nbv1.NSBucketClassTypeSingle {

--- a/pkg/bucketclass/reconciler.go
+++ b/pkg/bucketclass/reconciler.go
@@ -260,6 +260,9 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 			if nsStore.Status.Phase != nbv1.NamespaceStorePhaseReady {
 				return fmt.Errorf("NooBaa NamespaceStore %q is not yet ready", name)
 			}
+			if nsStore.Spec.Type == nbv1.NSStoreTypeNSFS && nspType != nbv1.NSBucketClassTypeSingle{
+				return util.NewPersistentError("InvalidNamespaceStoreTypes", fmt.Sprintf("NSFS NamespaceStore %q is allowed on bucketclass of type Single", name))
+			}
 		}
 	}
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -694,7 +694,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_namespacestores_crd_yaml = "08e32df6c91fa995d30c3a0981e6079c104d87a039092886fbc8648cf62d6172"
+const Sha256_deploy_crds_noobaa_io_namespacestores_crd_yaml = "f81a4ad7b2829701465af2ad1970706233096b5190fb63bf0361956a65b744cc"
 
 const File_deploy_crds_noobaa_io_namespacestores_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -836,11 +836,12 @@ spec:
                     - GPFS
                     - NFSv4
                     type: string
-                  fsPath:
-                    description: FsPath is a path to a directory in a file system
+                  fsRootPath:
+                    description: FsRootPath is a path to a root directory in a file
+                      system
                     type: string
                 required:
-                - fsPath
+                - fsRootPath
                 type: object
               s3Compatible:
                 description: S3Compatible specifies a namespace store of type s3-compatible

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -187,7 +187,7 @@ func CmdCreateNSFS() *cobra.Command {
 		"The file system backend type - CEPH_FS | GPFS | NFSv4",
 	)
 	cmd.Flags().String(
-		"fs-path", "",
+		"fs-root-path", "",
 		"The path to the exported directory in the file system",
 	)
 	return cmd
@@ -417,14 +417,14 @@ func RunCreateAzureBlob(cmd *cobra.Command, args []string) {
 func RunCreateNSFS(cmd *cobra.Command, args []string) {
 	log := util.Logger()
 	createCommon(cmd, args, nbv1.NSStoreTypeNSFS, func(namespaceStore *nbv1.NamespaceStore, secret *corev1.Secret) {
-		fsPath := util.GetFlagStringOrPrompt(cmd, "fs-path")
+		fsRootPath := util.GetFlagStringOrPrompt(cmd, "fs-root-path")
 		fsBackend, _ := cmd.Flags().GetString("fs-backend")
 
-		if fsPath == "" {
-			log.Fatalf(`❌ Missing expected arguments: <fs-path> %s`, cmd.UsageString())
+		if fsRootPath == "" {
+			log.Fatalf(`❌ Missing expected arguments: <fs-root-path> %s`, cmd.UsageString())
 		}
 		namespaceStore.Spec.NSFS = &nbv1.NSFSSpec{
-			FsPath:    fsPath,
+			FsRootPath:    fsRootPath,
 			FsBackend: fsBackend,
 		}
 	})

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -342,6 +342,33 @@ func (r *Reconciler) ReconcileDeletion() error {
 	}
 
 	if r.NamespaceResourceinfo != nil {
+
+		internalPoolName := ""
+		for i := range r.SystemInfo.Pools {
+			pool := &r.SystemInfo.Pools[i]
+			if pool.ResourceType == "INTERNAL" {
+				internalPoolName = pool.Name
+				break
+			}
+		}
+		for i := range r.SystemInfo.Accounts {
+			account := &r.SystemInfo.Accounts[i]
+			if account.DefaultResource == r.NamespaceResourceinfo.Name {
+				allowedBuckets := account.AllowedBuckets
+				if allowedBuckets.PermissionList == nil {
+					allowedBuckets.PermissionList = []string{}
+				}
+				err := r.NBClient.UpdateAccountS3Access(nb.UpdateAccountS3AccessParams{
+					Email:        account.Email,
+					S3Access:     account.HasS3Access,
+					DefaultResource:  &internalPoolName,
+					AllowBuckets: &allowedBuckets,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
 		err := r.NBClient.DeleteNamespaceResourceAPI(nb.DeleteNamespaceResourceParams{Name: r.NamespaceResourceinfo.Name})
 		if err != nil {
 			if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
@@ -415,7 +442,7 @@ func (r *Reconciler) ReadSystemInfo() error {
 			Name: r.NamespaceStore.Name,
 			NSFSConfig: &nb.NSFSConfig{
 				FsBackend: r.NamespaceStore.Spec.NSFS.FsBackend,
-				FsPath:    r.NamespaceStore.Spec.NSFS.FsPath,
+				FsRootPath:    r.NamespaceStore.Spec.NSFS.FsRootPath,
 			},
 			NamespaceStore: &nb.NamespaceStoreInfo{
 				Name:      r.NamespaceStore.Name,

--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -44,7 +44,7 @@ type Client interface {
 	DeleteNamespaceResourceAPI(DeleteNamespaceResourceParams) error
 
 	UpdateAccountS3Access(UpdateAccountS3AccessParams) error
-	UpdateAllBucketsDefaultPool(UpdateDefaultPoolParams) error
+	UpdateAllBucketsDefaultPool(UpdateDefaultResourceParams) error
 	UpdateBucketClass(UpdateBucketClassParams) (BucketClassInfo, error)
 
 	AddExternalConnectionAPI(AddExternalConnectionParams) error
@@ -335,7 +335,7 @@ func (c *RPCClient) UpdateBucketClass(params UpdateBucketClassParams) (BucketCla
 }
 
 // UpdateAllBucketsDefaultPool calls bucket_api.update_all_buckets_default_pool()
-func (c *RPCClient) UpdateAllBucketsDefaultPool(params UpdateDefaultPoolParams) error {
+func (c *RPCClient) UpdateAllBucketsDefaultPool(params UpdateDefaultResourceParams) error {
 	req := &RPCMessage{API: "bucket_api", Method: "update_all_buckets_default_pool", Params: params}
 	return c.Call(req, nil)
 }

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -29,7 +29,7 @@ type AccountInfo struct {
 	HasS3Access        bool           `json:"has_s3_access"`
 	CanCreateBuckets   bool           `json:"can_create_buckets"`
 	NextPasswordChange int64          `json:"next_password_change"`
-	DefaultPool        string         `json:"default_pool"`
+	DefaultResource    string         `json:"default_resource"`
 	AccessKeys         []S3AccessKeys `json:"access_keys"`
 	AllowedIPs         []struct {
 		Start string `json:"start"`
@@ -353,7 +353,7 @@ type CreateAccountParams struct {
 	S3Access          bool                  `json:"s3_access"`
 	AllowBucketCreate bool                  `json:"allow_bucket_creation"`
 	AllowedBuckets    AccountAllowedBuckets `json:"allowed_buckets"`
-	DefaultPool       string                `json:"default_pool,omitempty"`
+	DefaultResource   string                `json:"default_resource,omitempty"`
 	BucketClaimOwner  string                `json:"bucket_claim_owner,omitempty"`
 }
 
@@ -427,7 +427,7 @@ type CreateNamespaceResourceParams struct {
 // NSFSConfig is the namespace fs config needed for creating namespace resource of type fs()
 type NSFSConfig struct {
 	FsBackend string `json:"fs_backend,omitempty"`
-	FsPath    string `json:"fs_path,omitempty"`
+	FsRootPath    string `json:"fs_root_path,omitempty"`
 }
 
 // CreateTierParams is the reply of tier_api.create_tier()
@@ -493,13 +493,13 @@ type DeleteNamespaceResourceParams struct {
 type UpdateAccountS3AccessParams struct {
 	Email               string          `json:"email"`
 	S3Access            bool            `json:"s3_access"`
-	DefaultPool         *string         `json:"default_pool,omitempty"`
+	DefaultResource     *string         `json:"default_resource,omitempty"`
 	AllowBucketCreation *bool           `json:"allow_bucket_creation,omitempty"`
 	AllowBuckets        *AllowedBuckets `json:"allowed_buckets,omitempty"`
 }
 
-// UpdateDefaultPoolParams is the params of bucket_api.update_all_buckets_default_pool()
-type UpdateDefaultPoolParams struct {
+// UpdateDefaultResourceParams is the params of bucket_api.update_all_buckets_default_pool()
+type UpdateDefaultResourceParams struct {
 	PoolName string `json:"pool_name"`
 }
 

--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -47,6 +47,8 @@ func CmdCreate() *cobra.Command {
 		"Set bucket class to specify the bucket policy")
 	cmd.Flags().String("app-namespace", "",
 		"Set the namespace of the application where the OBC should be created")
+	cmd.Flags().String("path", "",
+		"Set path to specify inner directory in namespace store target path - can be used only while specifing a namespace bucketclass")
 	return cmd
 }
 
@@ -95,6 +97,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 
 	exact, _ := cmd.Flags().GetBool("exact")
 	bucketClassName, _ := cmd.Flags().GetString("bucketclass")
+	path, _ := cmd.Flags().GetString("path")
 	appNamespace, _ := cmd.Flags().GetString("app-namespace")
 	if appNamespace == "" {
 		appNamespace = options.Namespace
@@ -135,7 +138,13 @@ func RunCreate(cmd *cobra.Command, args []string) {
 			log.Fatalf(`❌ Could not get BucketClass %q in namespace %q`,
 				bucketClass.Name, bucketClass.Namespace)
 		}
+		if bucketClass.Spec.NamespacePolicy == nil && path != "" {
+			log.Fatalf(`❌ Could not create OBC %q with inner path while missing namespace bucketclass`, obc.Name)
+		}
 		obc.Spec.AdditionalConfig["bucketclass"] = bucketClassName
+		obc.Spec.AdditionalConfig["path"] = path
+	} else if path != "" {
+		log.Fatalf(`❌ Could not create OBC %q with inner path while missing namespace bucketclass`, obc.Name)
 	}
 
 	if !util.KubeCreateSkipExisting(obc) {

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -340,6 +340,9 @@ func (r *BucketRequest) CreateBucket(
 		},
 	}
 	if r.BucketClass.Spec.PlacementPolicy != nil {
+		if r.OBC.Spec.AdditionalConfig["path"] != "" {
+			return fmt.Errorf("Could not create OBC %q with inner path while missing namespace bucketclass", r.OBC.Name)
+		}
 		tierName, err := r.CreateTieringStructure(*r.BucketClass)
 		if err != nil {
 			return fmt.Errorf("CreateTieringStructure for PlacementPolicy failed to create policy %q with error: %v", tierName, err)
@@ -367,13 +370,17 @@ func (r *BucketRequest) CreateBucket(
 		}
 
 		if namespacePolicyType == nbv1.NSBucketClassTypeSingle {
-			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{
-				Resource: r.BucketClass.Spec.NamespacePolicy.Single.Resource}
-			createBucketParams.Namespace.ReadResources = append(readResources, nb.NamespaceResourceFullConfig{
-				Resource: r.BucketClass.Spec.NamespacePolicy.Single.Resource})
+			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{ 
+				Resource: r.BucketClass.Spec.NamespacePolicy.Single.Resource,
+				Path:  r.OBC.Spec.AdditionalConfig["path"],
+			}
+			createBucketParams.Namespace.ReadResources = append(readResources, nb.NamespaceResourceFullConfig{ 
+				Resource: r.BucketClass.Spec.NamespacePolicy.Single.Resource })
 		} else if namespacePolicyType == nbv1.NSBucketClassTypeMulti {
-			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{
-				Resource: r.BucketClass.Spec.NamespacePolicy.Multi.WriteResource}
+			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{ 
+				Resource: r.BucketClass.Spec.NamespacePolicy.Multi.WriteResource,
+				Path:  r.OBC.Spec.AdditionalConfig["path"],
+			}
 			for i := range r.BucketClass.Spec.NamespacePolicy.Multi.ReadResources {
 				rr := r.BucketClass.Spec.NamespacePolicy.Multi.ReadResources[i]
 				readResources = append(readResources, nb.NamespaceResourceFullConfig{Resource: rr})
@@ -475,14 +482,14 @@ func (r *BucketRequest) CreateTieringStructure(BucketClass nbv1.BucketClass) (st
 func (r *BucketRequest) CreateAccount() error {
 
 	log := r.Provisioner.Logger
-	var defaultPool string
+	var defaultResource string
 	if r.BucketClass.Spec.PlacementPolicy != nil {
-		defaultPool = r.BucketClass.Spec.PlacementPolicy.Tiers[0].BackingStores[0]
+		defaultResource = r.BucketClass.Spec.PlacementPolicy.Tiers[0].BackingStores[0]
 	}
 	accountInfo, err := r.SysClient.NBClient.CreateAccountAPI(nb.CreateAccountParams{
 		Name:              r.AccountName,
 		Email:             r.AccountName,
-		DefaultPool:       defaultPool,
+		DefaultResource:   defaultResource,
 		HasLogin:          false,
 		S3Access:          true,
 		AllowBucketCreate: false,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,7 +29,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.8.0-20210418"
+	ContainerImageTag = "5.8.0-20210519"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

1. in nsfs namespacestore renamed fsPath to fsRootPath as the current core version.
2. renamed default_pool to default_resource as in the current core version.
3. in namespacestore deletion - iterate over all accounts - if account's default resource is the deleted namespacestore - put the internal pool as its default_resource (same behaviour as in backingstore) 
3. Added path option for namespace OBCs creation


** Need to build core and update here the image