### PR TITLE
handle the cases where securityContext is not set on the container

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -377,7 +377,12 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 					}
 				}
 			}
-			c.SecurityContext.Capabilities.Add = []corev1.Capability{"SETUID", "SETGID"}
+
+			c.SecurityContext = &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"SETUID", "SETGID"},
+				},
+			}
 
 			util.ReflectEnvVariable(&c.Env, "HTTP_PROXY")
 			util.ReflectEnvVariable(&c.Env, "HTTPS_PROXY")


### PR DESCRIPTION
- when reconciling endpoint deployment we try to set capabilities in the securityContext.
- if SecurityContext is null on the container (like after upgrade) the operator is crashing