### PR TITLE
Auto PVC mount to endpoint deployment

### DIFF
--- a/deploy/crds/noobaa.io_namespacestores_crd.yaml
+++ b/deploy/crds/noobaa.io_namespacestores_crd.yaml
@@ -138,12 +138,16 @@ spec:
                     - GPFS
                     - NFSv4
                     type: string
-                  fsRootPath:
-                    description: FsRootPath is a path to a root directory in a file
+                  pvcName:
+                    description: PvcName is the name of the pvc in which the file
+                      system resides
+                    type: string
+                  subPath:
+                    description: SubPath is a path to a sub directory in the pvc file
                       system
                     type: string
                 required:
-                - fsRootPath
+                - pvcName
                 type: object
               s3Compatible:
                 description: S3Compatible specifies a namespace store of type s3-compatible

--- a/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
+++ b/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
@@ -162,9 +162,12 @@ const (
 
 // NSFSSpec specifies a namespace store of type nsfs
 type NSFSSpec struct {
-
-	// FsRootPath is a path to a root directory in a file system
-	FsRootPath string `json:"fsRootPath"`
+	// PvcName is the name of the pvc in which the file system resides
+	PvcName string `json:"pvcName"`
+	
+	// SubPath is a path to a sub directory in the pvc file system
+	// +optional
+	SubPath string `json:"subPath"`
 
 	// FsBackend is the backend type of the file system
 	// +optional

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -694,7 +694,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_namespacestores_crd_yaml = "f81a4ad7b2829701465af2ad1970706233096b5190fb63bf0361956a65b744cc"
+const Sha256_deploy_crds_noobaa_io_namespacestores_crd_yaml = "75ea24de1ab0e53c7cdebe2e1f55fe7cd0dc28f469920d64a8451d5429967c8f"
 
 const File_deploy_crds_noobaa_io_namespacestores_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -836,12 +836,16 @@ spec:
                     - GPFS
                     - NFSv4
                     type: string
-                  fsRootPath:
-                    description: FsRootPath is a path to a root directory in a file
+                  pvcName:
+                    description: PvcName is the name of the pvc in which the file
+                      system resides
+                    type: string
+                  subPath:
+                    description: SubPath is a path to a sub directory in the pvc file
                       system
                     type: string
                 required:
-                - fsRootPath
+                - pvcName
                 type: object
               s3Compatible:
                 description: S3Compatible specifies a namespace store of type s3-compatible

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -187,8 +187,12 @@ func CmdCreateNSFS() *cobra.Command {
 		"The file system backend type - CEPH_FS | GPFS | NFSv4",
 	)
 	cmd.Flags().String(
-		"fs-root-path", "",
-		"The path to the exported directory in the file system",
+		"sub-path", "",
+		"The path to a sub directory inside the pvc file system",
+	)
+	cmd.Flags().String(
+		"pvc-name", "",
+		"The pvc name in which the file system resides",
 	)
 	return cmd
 }
@@ -417,14 +421,16 @@ func RunCreateAzureBlob(cmd *cobra.Command, args []string) {
 func RunCreateNSFS(cmd *cobra.Command, args []string) {
 	log := util.Logger()
 	createCommon(cmd, args, nbv1.NSStoreTypeNSFS, func(namespaceStore *nbv1.NamespaceStore, secret *corev1.Secret) {
-		fsRootPath := util.GetFlagStringOrPrompt(cmd, "fs-root-path")
+		pvcName := util.GetFlagStringOrPrompt(cmd, "pvc-name")
 		fsBackend, _ := cmd.Flags().GetString("fs-backend")
+		subPath, _ := cmd.Flags().GetString("sub-path")
 
-		if fsRootPath == "" {
-			log.Fatalf(`❌ Missing expected arguments: <fs-root-path> %s`, cmd.UsageString())
+		if pvcName == "" {
+			log.Fatalf(`❌ Missing expected arguments: <pvc-name> %s`, cmd.UsageString())
 		}
 		namespaceStore.Spec.NSFS = &nbv1.NSFSSpec{
-			FsRootPath:    fsRootPath,
+			PvcName: pvcName,
+			SubPath:  subPath,
 			FsBackend: fsBackend,
 		}
 	})

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -438,11 +438,12 @@ func (r *Reconciler) ReadSystemInfo() error {
 
 	// handling namespace fs resource
 	if r.NamespaceStore.Spec.Type == nbv1.NSStoreTypeNSFS {
+		fsRootPath := "/nsfs/" + r.NamespaceStore.Name 
 		r.CreateNamespaceResourceParams = &nb.CreateNamespaceResourceParams{
 			Name: r.NamespaceStore.Name,
 			NSFSConfig: &nb.NSFSConfig{
 				FsBackend: r.NamespaceStore.Spec.NSFS.FsBackend,
-				FsRootPath:    r.NamespaceStore.Spec.NSFS.FsRootPath,
+				FsRootPath: fsRootPath,
 			},
 			NamespaceStore: &nb.NamespaceStoreInfo{
 				Name:      r.NamespaceStore.Name,
@@ -771,5 +772,6 @@ func (r *Reconciler) ReconcileNamespaceStore() error {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -97,7 +97,7 @@ type Reconciler struct {
 	RouteMgmt                 *routev1.Route
 	RouteS3                   *routev1.Route
 	DeploymentEndpoint        *appsv1.Deployment
-	DefaultDeploymentEndpoint *corev1.Container
+	DefaultDeploymentEndpoint *corev1.PodSpec
 	HPAEndpoint               *autoscalingv1.HorizontalPodAutoscaler
 	JoinSecret                *corev1.Secret
 	UpgradeJob                *batchv1.Job
@@ -250,7 +250,7 @@ func NewReconciler(
 	r.SecretRootMasterKey.StringData["cipher_key_b64"] = util.RandomBase64(32)
 
 	r.DefaultCoreApp = r.CoreApp.Spec.Template.Spec.Containers[0].DeepCopy()
-	r.DefaultDeploymentEndpoint = r.DeploymentEndpoint.Spec.Template.Spec.Containers[0].DeepCopy()
+	r.DefaultDeploymentEndpoint = r.DeploymentEndpoint.Spec.Template.Spec.DeepCopy()
 	return r
 }
 


### PR DESCRIPTION
1. cli command and nsstore CRD will now require pvc-name
2. will attach the new pvc to the endpoint pods if needed
3. option to create more than one mount to the same pvc with subPath option
4. removed fsRootPath - will create all the mounts under /nsfs/<namespace_store_name>

Signed-off-by: jackyalbo <jalbo@redhat.com>