### PR TITLE
Replacing the default DBType from mongo to postgres

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -77,7 +77,7 @@ var DBMongoImage = "centos/mongodb-36-centos7"
 
 // DBType is the default db image type
 // it can be overridden for testing or different types.
-var DBType = "mongodb"
+var DBType = "postgres"
 
 // DBVolumeSizeGB can be used to override the default database volume size
 var DBVolumeSizeGB = 0


### PR DESCRIPTION
Replacing the default DBType from mongo to postgres

This change is only relevant for the NooBaa CLI.

Signed-off-by: liranmauda <liran.mauda@gmail.com>