### PR TITLE
Generate an error if a user wrongly inputs options with –

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -48,8 +48,9 @@ func Cmd() *cobra.Command {
 // CmdCreate returns a CLI command
 func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create backing store",
+		Use:               "create",
+		Short:             "Create backing store",
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	cmd.AddCommand(
 		CmdCreateAWSS3(),
@@ -229,9 +230,10 @@ func CmdCreatePVPool() *cobra.Command {
 // CmdDelete returns a CLI command
 func CmdDelete() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <backing-store-name>",
-		Short: "Delete backing store",
-		Run:   RunDelete,
+		Use:               "delete <backing-store-name>",
+		Short:             "Delete backing store",
+		Run:               RunDelete,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -239,9 +241,10 @@ func CmdDelete() *cobra.Command {
 // CmdStatus returns a CLI command
 func CmdStatus() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status <backing-store-name>",
-		Short: "Status backing store",
-		Run:   RunStatus,
+		Use:               "status <backing-store-name>",
+		Short:             "Status backing store",
+		Run:               RunStatus,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -249,9 +252,10 @@ func CmdStatus() *cobra.Command {
 // CmdRunRemovePendingPods returns a CLI command
 func CmdRunRemovePendingPods() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove_pending <backing-store-name>",
-		Short: "Deletes all the pending pods that failed to connect to server",
-		Run:   RunRemovePendingPods,
+		Use:               "remove_pending <backing-store-name>",
+		Short:             "Deletes all the pending pods that failed to connect to server",
+		Run:               RunRemovePendingPods,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -269,10 +273,11 @@ func CmdList() *cobra.Command {
 // CmdReconcile returns a CLI command
 func CmdReconcile() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "reconcile",
-		Short:  "Runs a reconcile attempt like noobaa-operator",
-		Run:    RunReconcile,
+		Hidden:            true,
+		Use:               "reconcile",
+		Short:             "Runs a reconcile attempt like noobaa-operator",
+		Run:               RunReconcile,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -819,8 +824,8 @@ func RunReconcile(cmd *cobra.Command, args []string) {
 	}
 	backingStoreName := args[0]
 	klient := util.KubeClient()
-	intervalSec := time.Duration(3)
-	util.Panic(wait.PollImmediateInfinite(intervalSec*time.Second, func() (bool, error) {
+	intervalDuration := time.Duration(3)
+	util.Panic(wait.PollImmediateInfinite(intervalDuration*time.Second, func() (bool, error) {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: options.Namespace,
@@ -832,7 +837,7 @@ func RunReconcile(cmd *cobra.Command, args []string) {
 			return false, err
 		}
 		if res.Requeue || res.RequeueAfter != 0 {
-			log.Printf("\nRetrying in %d seconds\n", intervalSec)
+			log.Printf("\nRetrying in %d seconds\n", intervalDuration)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/bucket/bucket.go
+++ b/pkg/bucket/bucket.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 
@@ -29,9 +30,10 @@ func Cmd() *cobra.Command {
 // CmdCreate returns a CLI command
 func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create <bucket-name>",
-		Short: "Create a NooBaa bucket",
-		Run:   RunCreate,
+		Use:               "create <bucket-name>",
+		Short:             "Create a NooBaa bucket",
+		Run:               RunCreate,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -39,9 +41,10 @@ func CmdCreate() *cobra.Command {
 // CmdDelete returns a CLI command
 func CmdDelete() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <bucket-name>",
-		Short: "Delete a NooBaa bucket",
-		Run:   RunDelete,
+		Use:               "delete <bucket-name>",
+		Short:             "Delete a NooBaa bucket",
+		Run:               RunDelete,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -49,9 +52,10 @@ func CmdDelete() *cobra.Command {
 // CmdStatus returns a CLI command
 func CmdStatus() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status <bucket-name>",
-		Short: "Show the status of a NooBaa bucket",
-		Run:   RunStatus,
+		Use:               "status <bucket-name>",
+		Short:             "Show the status of a NooBaa bucket",
+		Run:               RunStatus,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }

--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -41,8 +41,9 @@ func Cmd() *cobra.Command {
 // CmdCreate returns a CLI command
 func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create bucket class",
+		Use:               "create",
+		Short:             "Create bucket class",
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 
 	cmd.AddCommand(
@@ -142,9 +143,10 @@ func CmdCreateCacheNamespaceBucketclass() *cobra.Command {
 // CmdDelete returns a CLI command
 func CmdDelete() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <bucket-class-name>",
-		Short: "Delete bucket class",
-		Run:   RunDelete,
+		Use:               "delete <bucket-class-name>",
+		Short:             "Delete bucket class",
+		Run:               RunDelete,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -152,9 +154,10 @@ func CmdDelete() *cobra.Command {
 // CmdStatus returns a CLI command
 func CmdStatus() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status <bucket-class-name>",
-		Short: "Status bucket class",
-		Run:   RunStatus,
+		Use:               "status <bucket-class-name>",
+		Short:             "Status bucket class",
+		Run:               RunStatus,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -172,10 +175,11 @@ func CmdList() *cobra.Command {
 // CmdReconcile returns a CLI command
 func CmdReconcile() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "reconcile",
-		Short:  "Runs a reconcile attempt like noobaa-operator",
-		Run:    RunReconcile,
+		Hidden:            true,
+		Use:               "reconcile",
+		Short:             "Runs a reconcile attempt like noobaa-operator",
+		Run:               RunReconcile,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -493,8 +497,8 @@ func RunReconcile(cmd *cobra.Command, args []string) {
 	}
 	bucketClassName := args[0]
 	klient := util.KubeClient()
-	intervalSec := time.Duration(3)
-	util.Panic(wait.PollImmediateInfinite(intervalSec*time.Second, func() (bool, error) {
+	intervalDuration := time.Duration(3)
+	util.Panic(wait.PollImmediateInfinite(intervalDuration*time.Second, func() (bool, error) {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: options.Namespace,
@@ -506,7 +510,7 @@ func RunReconcile(cmd *cobra.Command, args []string) {
 			return false, err
 		}
 		if res.Requeue || res.RequeueAfter != 0 {
-			log.Printf("\nRetrying in %d seconds\n", intervalSec)
+			log.Printf("\nRetrying in %d seconds\n", intervalDuration)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -58,6 +59,17 @@ func Run() {
 	}
 }
 
+// PersistentPreRunERoot generate an error if a user wrongly inputs options with –
+// See https://github.com/noobaa/noobaa-operator/issues/484
+func PersistentPreRunERoot(cmd *cobra.Command, args []string) error {
+	flagArgs := cmd.Flags().Args()
+	if len(flagArgs) > 0 {
+		errorText := fmt.Sprint("unknown args: ", flagArgs)
+		return errors.New(errorText)
+	}
+	return nil
+}
+
 // Cmd returns a CLI command
 func Cmd() *cobra.Command {
 
@@ -74,6 +86,10 @@ func Cmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "noobaa",
 		Short: logo,
+		// disallow non-flag args on all noobaa commands
+		// exclude commands requiring arguments by defining
+		// PersistentPreRunE as options.PersistentPreRunEPass
+		PersistentPreRunE: PersistentPreRunERoot,
 	}
 
 	rootCmd.PersistentFlags().AddFlagSet(options.FlagSet)

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -26,8 +26,9 @@ import (
 // Cmd returns a CLI command
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "namespacestore",
-		Short: "Manage namespace stores",
+		Use:               "namespacestore",
+		Short:             "Manage namespace stores",
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	cmd.AddCommand(
 		CmdCreate(),
@@ -42,8 +43,9 @@ func Cmd() *cobra.Command {
 // CmdCreate returns a CLI command
 func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create namespace store",
+		Use:               "create",
+		Short:             "Create namespace store",
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	cmd.AddCommand(
 		CmdCreateAWSS3(),
@@ -200,9 +202,10 @@ func CmdCreateNSFS() *cobra.Command {
 // CmdDelete returns a CLI command
 func CmdDelete() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <namespace-store-name>",
-		Short: "Delete namespace store",
-		Run:   RunDelete,
+		Use:               "delete <namespace-store-name>",
+		Short:             "Delete namespace store",
+		Run:               RunDelete,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -210,9 +213,10 @@ func CmdDelete() *cobra.Command {
 // CmdStatus returns a CLI command
 func CmdStatus() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status <namespace-store-name>",
-		Short: "Status namespace store",
-		Run:   RunStatus,
+		Use:               "status <namespace-store-name>",
+		Short:             "Status namespace store",
+		Run:               RunStatus,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -230,10 +234,11 @@ func CmdList() *cobra.Command {
 // CmdReconcile returns a CLI command
 func CmdReconcile() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "reconcile",
-		Short:  "Runs a reconcile attempt like noobaa-operator",
-		Run:    RunReconcile,
+		Hidden:            true,
+		Use:               "reconcile",
+		Short:             "Runs a reconcile attempt like noobaa-operator",
+		Run:               RunReconcile,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }
@@ -429,8 +434,8 @@ func RunCreateNSFS(cmd *cobra.Command, args []string) {
 			log.Fatalf(`❌ Missing expected arguments: <pvc-name> %s`, cmd.UsageString())
 		}
 		namespaceStore.Spec.NSFS = &nbv1.NSFSSpec{
-			PvcName: pvcName,
-			SubPath:  subPath,
+			PvcName:   pvcName,
+			SubPath:   subPath,
 			FsBackend: fsBackend,
 		}
 	})
@@ -627,8 +632,8 @@ func RunReconcile(cmd *cobra.Command, args []string) {
 	}
 	namespaceStoreName := args[0]
 	klient := util.KubeClient()
-	intervalSec := time.Duration(3)
-	util.Panic(wait.PollImmediateInfinite(intervalSec*time.Second, func() (bool, error) {
+	intervalDuration := time.Duration(3)
+	util.Panic(wait.PollImmediateInfinite(intervalDuration*time.Second, func() (bool, error) {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: options.Namespace,
@@ -640,7 +645,7 @@ func RunReconcile(cmd *cobra.Command, args []string) {
 			return false, err
 		}
 		if res.Requeue || res.RequeueAfter != 0 {
-			log.Printf("\nRetrying in %d seconds\n", intervalSec)
+			log.Printf("\nRetrying in %d seconds\n", intervalDuration)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -22,8 +22,9 @@ import (
 // Cmd returns a CLI command
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "obc",
-		Short: "Manage object bucket claims",
+		Use:               "obc",
+		Short:             "Manage object bucket claims",
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	cmd.AddCommand(
 		CmdCreate(),
@@ -37,9 +38,10 @@ func Cmd() *cobra.Command {
 // CmdCreate returns a CLI command
 func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create <bucket-claim-name>",
-		Short: "Create an OBC",
-		Run:   RunCreate,
+		Use:               "create <bucket-claim-name>",
+		Short:             "Create an OBC",
+		Run:               RunCreate,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	cmd.Flags().Bool("exact", false,
 		"Request an exact bucketName instead of the default generateBucketName")
@@ -55,9 +57,10 @@ func CmdCreate() *cobra.Command {
 // CmdDelete returns a CLI command
 func CmdDelete() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <bucket-claim-name>",
-		Short: "Delete an OBC",
-		Run:   RunDelete,
+		Use:               "delete <bucket-claim-name>",
+		Short:             "Delete an OBC",
+		Run:               RunDelete,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	cmd.Flags().String("app-namespace", "",
 		"Set the namespace of the application where the OBC should be created")
@@ -67,9 +70,10 @@ func CmdDelete() *cobra.Command {
 // CmdStatus returns a CLI command
 func CmdStatus() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status <bucket-claim-name>",
-		Short: "Status of an OBC",
-		Run:   RunStatus,
+		Use:               "status <bucket-claim-name>",
+		Short:             "Status of an OBC",
+		Run:               RunStatus,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	cmd.Flags().String("app-namespace", "",
 		"Set the namespace of the application where the OBC should be created")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -113,6 +113,14 @@ func ObjectBucketProvisionerName() string {
 	return SubDomainNS() + "/obc"
 }
 
+// PersistentPreRunEPass do not generate on args
+// for the commands that require one, such as
+// noobaa bucket create <bucket-name> [flags] [options]...
+// See https://github.com/noobaa/noobaa-operator/issues/484
+func PersistentPreRunEPass(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
 // FlagSet defines the
 var FlagSet = pflag.NewFlagSet("noobaa", pflag.ContinueOnError)
 

--- a/pkg/pvstore/pvstore.go
+++ b/pkg/pvstore/pvstore.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 
@@ -13,8 +14,9 @@ import (
 // Cmd creates a CLI command
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "pvstore",
-		Short: "Manage noobaa pv store",
+		Use:               "pvstore",
+		Short:             "Manage noobaa pv store",
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	cmd.AddCommand(
 		CmdCreate(),
@@ -27,9 +29,10 @@ func Cmd() *cobra.Command {
 // CmdCreate creates a CLI command
 func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create <store-name>",
-		Short: "Create a NooBaa PV Store",
-		Run:   RunCreate,
+		Use:               "create <store-name>",
+		Short:             "Create a NooBaa PV Store",
+		Run:               RunCreate,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 
 	cmd.Flags().Uint32(
@@ -47,9 +50,10 @@ func CmdCreate() *cobra.Command {
 // CmdDelete creates a CLI command
 func CmdDelete() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <store-name>",
-		Short: "Deletes a NooBaa PV Store",
-		Run:   RunDelete,
+		Use:               "delete <store-name>",
+		Short:             "Deletes a NooBaa PV Store",
+		Run:               RunDelete,
+		PersistentPreRunE: options.PersistentPreRunEPass,
 	}
 	return cmd
 }


### PR DESCRIPTION
Issue #484
=========

Execute pre-run check and generate an error if there are elements in the command flag args list, 
which indicate wrong inputs options. The general rule is that all noobaa commands would generate
an error on non-flag arguments due to the PersistentPreRunE implementation at the root Cmd.
Children of the root command will inherit and execute PersistentPreRunE.

Defined a shared Pass function at options, i.e. this implementation never returns
an error for the commands that require non-flag argument, such as for instance
-> noobaa bucket create <bucket-name> [flags] [options]...
Those commands should define their PersistentPreRunE as Pass function.

Tests:
====

Rejecting non-flag arguments
------------------------------

```
➜  noobaa install --image-pull-secret='myregistrykey' --db-storage-class='<storage class>' –pv-pool-default-storage-class='<storage class>' 
Error: unknown args: [–pv-pool-default-storage-class=<storage class>]
➜  noobaa install yaml  –pv-pool-default-storage-class='<storage class>'
Error: unknown args: [–pv-pool-default-storage-class=<storage class>]
```

Accepting non-flag arguments
------------------------------
```
➜  noobaa bucket create                  
FATA[0000] Missing expected arguments: <bucket-name> 

Usage:
  noobaa bucket create <bucket-name> [flags] [options]

Use "noobaa options" for a list of global command-line options (applies to all commands). 
➜  noobaa bucket create second.bucket
INFO[0000] ✅ Exists: NooBaa "noobaa"                    
INFO[0000] ✅ Exists: Service "noobaa-mgmt"
...
```