### PR TITLE
Add the debug-level flag functionality as install option

### DIFF
--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -756,6 +756,9 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
+              debugLevel:
+                description: DebugLevel (optional) sets the debug level
+                type: integer
               endpoints:
                 description: Endpoints (optional) sets configuration info for the
                   noobaa endpoint deployment.

--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -68,6 +68,8 @@ spec:
             - name: LOCAL_N2N_AGENT
             - name: JWT_SECRET
             - name: NOOBAA_ROOT_SECRET
+            - name: NOOBAA_LOG_LEVEL
+              value: "0"
             - name: NOOBAA_DISABLE_COMPRESSION
               value: "false"
             - name: NOOBAA_AUTH_TOKEN

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -73,6 +73,8 @@ spec:
               value: mongodb
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
+            - name: NOOBAA_LOG_LEVEL
+              value: "0"
             - name: NOOBAA_DISABLE_COMPRESSION
               value: "false"
             - name: JWT_SECRET

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -101,6 +101,10 @@ type NooBaaSpec struct {
 	// +optional
 	MongoDbURL string `json:"mongoDbURL,omitempty"`
 
+	// DebugLevel (optional) sets the debug level
+	// +optional
+	DebugLevel int `json:"debugLevel,omitempty"`
+
 	// PVPoolDefaultStorageClass (optional) overrides the default cluster StorageClass for the pv-pool volumes.
 	// This affects where the system stores data chunks (encrypted).
 	// Updates to this field will only affect new pv-pools,

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1001,7 +1001,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "a7a87b507e0d7ca2ee52f440e86b1d7383123d14c5e9265ca5b837345175aca8"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "a77ff65531f26c4361ca51ba1f38c0076da1ab24403007641a131ce63f2065cd"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1761,6 +1761,9 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
+              debugLevel:
+                description: DebugLevel (optional) sets the debug level
+                type: integer
               endpoints:
                 description: Endpoints (optional) sets configuration info for the
                   noobaa endpoint deployment.

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2312,7 +2312,7 @@ metadata:
 data: {}
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "e64afa3c079c6ee43c063b66a15b9146ca33b1d4eb9643d86438b9e151443cf2"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "6769a038678b5d5d41a3a731e1cfd63acf113c45aef2855f790cbe6e2fc91b9a"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -2384,6 +2384,8 @@ spec:
             - name: LOCAL_N2N_AGENT
             - name: JWT_SECRET
             - name: NOOBAA_ROOT_SECRET
+            - name: NOOBAA_LOG_LEVEL
+              value: "0"
             - name: NOOBAA_DISABLE_COMPRESSION
               value: "false"
             - name: NOOBAA_AUTH_TOKEN
@@ -2880,7 +2882,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "f827660bdd01d915dbaf8305ef2ad8bbfcd7b62c83b62fa9c0dc2738c7553540"
+const Sha256_deploy_internal_statefulset_core_yaml = "758e83226e32791df7c5199203122def00d5df31d46eab3f0daddbf62ab1a068"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -2957,6 +2959,8 @@ spec:
               value: mongodb
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
+            - name: NOOBAA_LOG_LEVEL
+              value: "0"
             - name: NOOBAA_DISABLE_COMPRESSION
               value: "false"
             - name: JWT_SECRET

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -90,6 +90,9 @@ var DBStorageClass = ""
 // it can be overridden for testing or different url.
 var MongoDbURL = ""
 
+//DebugLevel can be used to override the default debug level
+var DebugLevel = 0
+
 // PVPoolDefaultStorageClass is used for PVC's allocation for the noobaa server data
 // it can be overridden for testing or different PV providers.
 var PVPoolDefaultStorageClass = ""
@@ -163,6 +166,10 @@ func init() {
 	FlagSet.StringVar(
 		&MongoDbURL, "mongodb-url",
 		MongoDbURL, "url for mongodb",
+	)
+	FlagSet.IntVar(
+		&DebugLevel, "debug-level",
+		DebugLevel, "Sets debug level prints of the system, affects the install spec",
 	)
 	FlagSet.StringVar(
 		&PVPoolDefaultStorageClass, "pv-pool-default-storage-class",

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -341,6 +342,9 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			} else {
 				c.Env[j].Value = "mongodb://" + r.NooBaaMongoDB.Name + "-0." + r.NooBaaMongoDB.Spec.ServiceName + "/nbcore"
 			}
+
+		case "NOOBAA_LOG_LEVEL":
+				c.Env[j].Value = strconv.Itoa(r.NooBaa.Spec.DebugLevel)
 
 		case "POSTGRES_HOST":
 			c.Env[j].Value = r.NooBaaPostgresDB.Name + "-0." + r.NooBaaPostgresDB.Spec.ServiceName

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -318,6 +318,8 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 					if r.JoinSecret == nil {
 						c.Env[j].Value = r.MongoConnectionString
 					}
+				case "NOOBAA_LOG_LEVEL":
+					c.Env[j].Value = strconv.Itoa(r.NooBaa.Spec.DebugLevel)
 				case "LOCAL_MD_SERVER":
 					if r.JoinSecret == nil {
 						c.Env[j].Value = "true"

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -122,6 +122,7 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 	sys.Finalizers = []string{nbv1.GracefulFinalizer}
 	dbType := options.DBType
 	sys.Spec.DBType = nbv1.DBTypes(dbType)
+	sys.Spec.DebugLevel = options.DebugLevel
 
 	if options.NooBaaImage != "" {
 		image := options.NooBaaImage


### PR DESCRIPTION
### Functionality
- Add NOOBAA_LOG_LEVEL as env variable in deployment-endpoint.yaml and statefulset-core.yaml and into noobaa CR
- Adding the debug-level flag to the options
- Add the debug-level flag functionality in the install command

### Gap
- Need to add a CLI command that changes the NOOBAA_LOG_LEVEL in noobaa CR for running clusters

### Testing
- Run `noobaa install --debug-level <number>` and see that the appropriate logs are being printed