### PR TITLE
Delete OBC storage class on delete system

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -45,6 +45,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2,7 +2,7 @@ package bundle
 
 const Version = "5.9.0"
 
-const Sha256_deploy_cluster_role_yaml = "349e613915ed288629c4926e22cd42f4a3776ed38dfbc9e814a9b28211a67b3c"
+const Sha256_deploy_cluster_role_yaml = "b3be23b51cbfad068dcf49bffa5f6af04c99dfc9623e2656f872e5f0643a8aeb"
 
 const File_deploy_cluster_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -51,6 +51,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,7 +272,12 @@ func RunDelete(cmd *cobra.Command, args []string) {
 
 		} else {
 			log.Infof("Deleting All object buckets in namespace %q", options.Namespace)
-
+			// deletion of OBCSC 
+			sc := &storagev1.StorageClass{}
+			sc.Name = options.SubDomainNS()
+			if  err := util.DeleteStorageClass(sc); err != nil {
+				log.Errorf("failed to delete storageclass %q", sc.Name)
+			}
 			util.RemoveFinalizer(sys, nbv1.GracefulFinalizer)
 			if !util.KubeUpdate(sys) {
 				log.Errorf("NooBaa %q failed to remove finalizer %q", options.SystemName, nbv1.GracefulFinalizer)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -1623,4 +1624,14 @@ func writeCrtsToFile(secretName string, namespace string, secretValue []byte, en
 		return "", fmt.Errorf("can not set env var %v %v", envVarKey, envVarValue)
 	}
 	return envVarValue, nil
+}
+
+// DeleteStorageClass deletes storage class
+func DeleteStorageClass(sc *storagev1.StorageClass) error{
+	log.Infof("storageclass %v found, deleting..", sc.Name)
+	if !KubeDelete(sc) {
+		return fmt.Errorf("storageclass %q failed to delete", sc)
+	}
+	log.Infof("deleted storageclass %v successfully", sc.Name)
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

1. deletes OBC storageclass on CLI uninstall/system delete or regular deletion of noobaa CR.
2. Fixed #631 