### PR TITLE
Backport to 5.8 - Disable huge_pages in Postgres config

### DIFF
--- a/deploy/internal/configmap-postgres-db.yaml
+++ b/deploy/internal/configmap-postgres-db.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noobaa-postgres-config
+  labels:
+    app: noobaa
+data:
+  noobaa-postgres.conf: |
+    # disable huge_pages trial
+    # see https://bugzilla.redhat.com/show_bug.cgi?id=1946792
+    huge_pages = off

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -49,7 +49,7 @@ spec:
             value: nbcore
           - name: POSTGRESQL_USER
           - name: POSTGRESQL_PASSWORD
-        magePullPolicy: "IfNotPresent"
+        imagePullPolicy: "IfNotPresent"
         ports:
           - containerPort: 5432
         resources:
@@ -62,6 +62,12 @@ spec:
         volumeMounts:
           - name: db
             mountPath: /var/lib/pgsql
+          - name: noobaa-postgres-config-volume
+            mountPath: /opt/app-root/src/postgresql-cfg
+      volumes:
+      - name: noobaa-postgres-config-volume
+        configMap:
+          name: noobaa-postgres-config
       securityContext: 
         runAsUser: 10001
         runAsGroup: 0

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -317,14 +317,14 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 
 	// Create backing store CR
 	util.Panic(controllerutil.SetControllerReference(sys, backStore, scheme.Scheme))
-	if !util.KubeCreateSkipExisting(backStore) {
+	if !util.KubeCreateFailExisting(backStore) {
 		log.Fatalf(`❌ Could not create BackingStore %q in Namespace %q (conflict)`, backStore.Name, backStore.Namespace)
 	}
 
 	if GetBackingStoreSecret(backStore) != nil && secretName == "" {
 		// Create secret
 		util.Panic(controllerutil.SetControllerReference(backStore, secret, scheme.Scheme))
-		if !util.KubeCreateSkipExisting(secret) {
+		if !util.KubeCreateFailExisting(secret) {
 			log.Fatalf(`❌ Could not create Secret %q in Namespace %q (conflict)`, secret.Name, secret.Namespace)
 		}
 	}

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -267,7 +267,7 @@ func (r *Reconciler) LoadBackingStoreSecret() error {
 
 			if !util.KubeCheck(r.Secret) {
 				r.Own(r.Secret)
-				if !util.KubeCreateSkipExisting(r.Secret) {
+				if !util.KubeCreateFailExisting(r.Secret) {
 					return util.NewPersistentError("EmptySecretName",
 						fmt.Sprintf("Could not create Secret %q in Namespace %q (conflict)", r.Secret.Name, r.Secret.Namespace))
 				}

--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -334,7 +334,7 @@ func createCommonBucketclass(cmd *cobra.Command, args []string, bucketClassType 
 
 	// Create bucket class CR
 	util.Panic(controllerutil.SetControllerReference(sys, bucketClass, scheme.Scheme))
-	if !util.KubeCreateSkipExisting(bucketClass) {
+	if !util.KubeCreateFailExisting(bucketClass) {
 		log.Fatalf(`❌ Could not create BucketClass %q in Namespace %q (conflict)`, bucketClass.Name, bucketClass.Namespace)
 	}
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2307,6 +2307,21 @@ metadata:
 data: {}
 `
 
+const Sha256_deploy_internal_configmap_postgres_db_yaml = "d1e0721ff0214b5ed8af9c9f189d70173f934bfcf4710d2826c61f05cad9b152"
+
+const File_deploy_internal_configmap_postgres_db_yaml = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noobaa-postgres-config
+  labels:
+    app: noobaa
+data:
+  noobaa-postgres.conf: |
+    # disable huge_pages trial
+    # see https://bugzilla.redhat.com/show_bug.cgi?id=1946792
+    huge_pages = off
+`
+
 const Sha256_deploy_internal_deployment_endpoint_yaml = "73ca3e7d4d3d2e8b3143946d2c92cdf2f7380a3f0700b9fda2fb736cd18f0d02"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
@@ -3070,7 +3085,7 @@ spec:
           storage: 50Gi
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "b50f93974700793f98f409849e3519522ba729d54b5a32a0b1565876f71c85b7"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "eedfd246f622f56f1b99e9ce7d0e6d30cbe3e1fc64f83e5a2349e76ce6a6d015"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -3123,7 +3138,7 @@ spec:
             value: nbcore
           - name: POSTGRESQL_USER
           - name: POSTGRESQL_PASSWORD
-        magePullPolicy: "IfNotPresent"
+        imagePullPolicy: "IfNotPresent"
         ports:
           - containerPort: 5432
         resources:
@@ -3136,6 +3151,12 @@ spec:
         volumeMounts:
           - name: db
             mountPath: /var/lib/pgsql
+          - name: noobaa-postgres-config-volume
+            mountPath: /opt/app-root/src/postgresql-cfg
+      volumes:
+      - name: noobaa-postgres-config-volume
+        configMap:
+          name: noobaa-postgres-config
       securityContext: 
         runAsUser: 10001
         runAsGroup: 0

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -274,14 +274,14 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.NSType, popu
 
 	// Create namespace store CR
 	util.Panic(controllerutil.SetControllerReference(sys, namespaceStore, scheme.Scheme))
-	if !util.KubeCreateSkipExisting(namespaceStore) {
+	if !util.KubeCreateFailExisting(namespaceStore) {
 		log.Fatalf(`❌ Could not create NamespaceStore %q in Namespace %q (conflict)`, namespaceStore.Name, namespaceStore.Namespace)
 	}
 
 	if GetNamespaceStoreSecret(namespaceStore) != nil && secretName == "" {
 		// Create secret
 		util.Panic(controllerutil.SetControllerReference(namespaceStore, secret, scheme.Scheme))
-		if !util.KubeCreateSkipExisting(secret) {
+		if !util.KubeCreateFailExisting(secret) {
 			log.Fatalf(`❌ Could not create Secret %q in Namespace %q (conflict)`, secret.Name, secret.Namespace)
 		}
 	}

--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -138,7 +138,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 		obc.Spec.AdditionalConfig["bucketclass"] = bucketClassName
 	}
 
-	if !util.KubeCreateSkipExisting(obc) {
+	if !util.KubeCreateFailExisting(obc) {
 		log.Fatalf(`❌ Could not create OBC %q in namespace %q (conflict)`, obc.Name, obc.Namespace)
 	}
 

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v2/pkg/bundle"
 	"github.com/noobaa/noobaa-operator/v2/pkg/options"
 	"github.com/noobaa/noobaa-operator/v2/pkg/util"
 	cloudcredsv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
@@ -191,16 +192,20 @@ func (r *Reconciler) SetDesiredServiceDBForPostgres() error {
 // SetDesiredNooBaaDB updates the NooBaaDB as desired for reconciling
 func (r *Reconciler) SetDesiredNooBaaDB() error {
 	var NooBaaDB *appsv1.StatefulSet = nil
+	var NooBaaDBTemplate *appsv1.StatefulSet = nil
+
 	if r.NooBaa.Spec.DBType == "postgres" {
 		NooBaaDB = r.NooBaaPostgresDB
 		NooBaaDB.Spec.Template.Labels["noobaa-db"] = "postgres"
 		NooBaaDB.Spec.Selector.MatchLabels["noobaa-db"] = "postgres"
 		NooBaaDB.Spec.ServiceName = r.ServiceDbPg.Name
+		NooBaaDBTemplate = util.KubeObject(bundle.File_deploy_internal_statefulset_postgres_db_yaml).(*appsv1.StatefulSet)
 	} else {
 		NooBaaDB = r.NooBaaMongoDB
 		NooBaaDB.Spec.Template.Labels["noobaa-db"] = r.Request.Name
 		NooBaaDB.Spec.Selector.MatchLabels["noobaa-db"] = r.Request.Name
 		NooBaaDB.Spec.ServiceName = r.ServiceDb.Name
+		NooBaaDBTemplate = util.KubeObject(bundle.File_deploy_internal_statefulset_db_yaml).(*appsv1.StatefulSet)
 	}
 
 	podSpec := &NooBaaDB.Spec.Template.Spec
@@ -292,6 +297,12 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 		}
 
 	} else {
+		// upgrade path add new resources,
+		// merge the volumes & volumeMounts from the template
+		util.MergeVolumeList(&NooBaaDB.Spec.Template.Spec.Volumes, &NooBaaDBTemplate.Spec.Template.Spec.Volumes)
+		for i := range NooBaaDB.Spec.Template.Spec.Containers {
+			util.MergeVolumeMountList(&NooBaaDB.Spec.Template.Spec.Containers[i].VolumeMounts, &NooBaaDBTemplate.Spec.Template.Spec.Containers[i].VolumeMounts)
+		}
 
 		// when already exists we check that there is no update requested to the volumes
 		// otherwise we report that volume update is unsupported
@@ -740,6 +751,14 @@ func (r *Reconciler) ReconcileRootSecret() error {
 func (r *Reconciler) ReconcileDB() error {
 	var err error
 	if r.NooBaa.Spec.DBType == "postgres" {
+		// this config map is required by the NooBaaPostgresDB StatefulSet,
+		// if the configMap was not created at this step, NooBaaPostgresDB
+		// would fail to start.
+		r.Own(r.PostgresDBConf)
+		if !util.KubeCreateSkipExisting(r.PostgresDBConf) {
+			return fmt.Errorf("could not create Postgres DB configMap %q in Namespace %q", r.PostgresDBConf.Name, r.PostgresDBConf.Namespace)
+		}
+
 		err = r.ReconcileObject(r.NooBaaPostgresDB, r.SetDesiredNooBaaDB)
 		// Making sure that previous CRs without the value will deploy MongoDB
 	} else if r.NooBaa.Spec.DBType == "" || r.NooBaa.Spec.DBType == "mongodb" {

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1244,7 +1244,7 @@ func (r *Reconciler) ReconcileNamespaceStores(namespaceResources []nb.NamespaceR
 
 			// Create namespace store CR
 			util.Panic(controllerutil.SetControllerReference(r.NooBaa, nsStore, scheme.Scheme))
-			if !util.KubeCreateSkipExisting(nsStore) {
+			if !util.KubeCreateFailExisting(nsStore) {
 				logrus.Errorf(`❌ Could not create NamespaceStore %q in Namespace %q (conflict)`, nsStore.Name, nsStore.Namespace)
 				continue
 			}
@@ -1252,7 +1252,7 @@ func (r *Reconciler) ReconcileNamespaceStores(namespaceResources []nb.NamespaceR
 			if !util.KubeCheck(secret) {
 				// Create secret
 				util.Panic(controllerutil.SetControllerReference(nsStore, secret, scheme.Scheme))
-				if !util.KubeCreateSkipExisting(secret) {
+				if !util.KubeCreateFailExisting(secret) {
 					logrus.Errorf(`❌ Could not create Secret %q in Namespace %q (conflict)`, secret.Name, secret.Namespace)
 					continue
 				}

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -69,6 +69,7 @@ type Reconciler struct {
 	CoreApp                   *appsv1.StatefulSet
 	DefaultCoreApp            *corev1.Container
 	NooBaaMongoDB             *appsv1.StatefulSet
+	PostgresDBConf            *corev1.ConfigMap
 	NooBaaPostgresDB          *appsv1.StatefulSet
 	ServiceMgmt               *corev1.Service
 	ServiceS3                 *corev1.Service
@@ -124,6 +125,7 @@ func NewReconciler(
 		ServiceAccount:      util.KubeObject(bundle.File_deploy_service_account_yaml).(*corev1.ServiceAccount),
 		CoreApp:             util.KubeObject(bundle.File_deploy_internal_statefulset_core_yaml).(*appsv1.StatefulSet),
 		NooBaaMongoDB:       util.KubeObject(bundle.File_deploy_internal_statefulset_db_yaml).(*appsv1.StatefulSet),
+		PostgresDBConf:      util.KubeObject(bundle.File_deploy_internal_configmap_postgres_db_yaml).(*corev1.ConfigMap),
 		NooBaaPostgresDB:    util.KubeObject(bundle.File_deploy_internal_statefulset_postgres_db_yaml).(*appsv1.StatefulSet),
 		ServiceDb:           util.KubeObject(bundle.File_deploy_internal_service_db_yaml).(*corev1.Service),
 		ServiceDbPg:         util.KubeObject(bundle.File_deploy_internal_service_db_yaml).(*corev1.Service),
@@ -160,6 +162,7 @@ func NewReconciler(
 	r.ServiceAccount.Namespace = r.Request.Namespace
 	r.CoreApp.Namespace = r.Request.Namespace
 	r.NooBaaMongoDB.Namespace = r.Request.Namespace
+	r.PostgresDBConf.Namespace = r.Request.Namespace
 	r.NooBaaPostgresDB.Namespace = r.Request.Namespace
 	r.ServiceMgmt.Namespace = r.Request.Namespace
 	r.ServiceS3.Namespace = r.Request.Namespace
@@ -264,6 +267,7 @@ func (r *Reconciler) CheckAll() {
 	if r.NooBaa.Spec.MongoDbURL == "" {
 		if r.NooBaa.Spec.DBType == "postgres" {
 			util.KubeCheck(r.SecretDB)
+			util.KubeCheck(r.PostgresDBConf)
 			util.KubeCheck(r.NooBaaPostgresDB)
 			util.KubeCheck(r.ServiceDbPg)
 		} else {


### PR DESCRIPTION
Issue:
  https://bugzilla.redhat.com/show_bug.cgi?id=1946792

Test:
  Verify in the postgress DB container in two scenarios, (a) clean
  install and (b) operator upgrade:

    - existence and content of /opt/app-root/src/postgresql-cfg/noobaa-postgres.conf file:

        bash-4.2$ pwd
        /opt/app-root/src
        bash-4.2$ cat postgresql-cfg/noobaa-postgres.conf
        # disable huge_pages trial
        # see https://bugzilla.redhat.com/show_bug.cgi?id=1946792
        huge_pages = off

    - openshift-custom-postgresql.conf includes the noobaa-postgres.conf file

        bash-4.2$ grep noobaa-postgres /var/lib/pgsql/openshift-custom-postgresql.conf
        include '/opt/app-root/src/postgresql-cfg/noobaa-postgres.conf'

    Verify the postgres DB is up and running with huge pages enabled in
    kernel.

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>
(cherry picked from commit 462a265ddf238fc334e60937c45355845cf73ce3)