### PR TITLE
Checking Service "noobaa-db" status only if we use mongo

### DIFF
--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -272,8 +272,8 @@ func (r *Reconciler) CheckAll() {
 			util.KubeCheck(r.ServiceDbPg)
 		} else {
 			util.KubeCheck(r.NooBaaMongoDB)
+			util.KubeCheck(r.ServiceDb)
 		}
-		util.KubeCheck(r.ServiceDb)
 	}
 	util.KubeCheck(r.SecretServer)
 	util.KubeCheck(r.SecretOp)


### PR DESCRIPTION
### Explain the changes 
- Checking Service "noobaa-db" status only if we use mongo

### Fixes:  
Fixes: BZ1974573

Signed-off-by: liranmauda <liran.mauda@gmail.com>