### PR TITLE
NooBaa Component Rescheduling

### DIFF
--- a/.github/workflows/run_hac_test.yml
+++ b/.github/workflows/run_hac_test.yml
@@ -1,0 +1,35 @@
+name: HAC on KIND cluster Test
+
+# Run on each new PR and each new push to existing PR
+on: [push, pull_request]
+
+jobs:
+  run-hac-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set environment variables
+        run: |
+          echo PATH=$PATH:$HOME/go/bin                                          >> $GITHUB_ENV
+          echo OPERATOR_IMAGE=localhost:5000/noobaa/noobaa-operator:integration >> $GITHUB_ENV
+
+      - name: Deploy Dependencies
+        run: |
+          bash .travis/install-5nodes-kind-cluster.sh
+          go get -v github.com/onsi/ginkgo/ginkgo
+          ginkgo version
+
+      - name: Build NooBaa
+        run: |
+          make cli
+          make image
+          docker tag noobaa/noobaa-operator:$(go run cmd/version/main.go) $OPERATOR_IMAGE
+          docker push $OPERATOR_IMAGE
+
+      - name: Install NooBaa
+        run: ./build/_output/bin/noobaa-operator-local --mini --operator-image=$OPERATOR_IMAGE install
+
+      - name: Run HAC test
+        run: make test-hac

--- a/.travis/install-5nodes-kind-cluster.sh
+++ b/.travis/install-5nodes-kind-cluster.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -o errexit
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name 5nodes --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker
+- role: worker
+EOF
+
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF

--- a/Makefile
+++ b/Makefile
@@ -169,3 +169,8 @@ test-olm: $(OPERATOR_SDK) gen-olm
 	$(TIME) ./test/test-olm.sh $(CATALOG_IMAGE)
 	@echo "✅ test-olm"
 .PHONY: test-olm
+
+test-hac:
+	ginkgo -v pkg/controller/ha
+	@echo "✅ test-hac"
+.PHONY: test-hac

--- a/doc/high-availability-controller.md
+++ b/doc/high-availability-controller.md
@@ -1,0 +1,68 @@
+### High Availability (HA) controller
+
+## Abstract
+
+Improve NooBaa pods recovery in the case of a node failure. Find NooBaa pods running on the failing node and force to delete them to speed up rescheduling in the healthy node.
+
+## Problem
+
+* In cases where a node is in `NotReady` state, it takes 5 minutes for deployment pods (kubernetes Deployment to failover on a different node.
+* Statefulset pods, such as noobaa-core and noobaa-db pods, are not restarting automatically until the old pod is explicitly force deleted.
+* For pods that are connected to a PV, such as noobaa-db, after the pod is force deleted, it takes more time (~8 minutes) for the PV to detached from the old pod so that the new pod can attach to the PV.
+
+## Solution
+
+To make the pods failover faster to a new node, noobaa-operator [watches](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) the cluster node states. When a node transitions from `Ready` to `NotReady` status, the HA Controller looks for NooBaa pods on that node, these pods will be force deleted. Once deleted the pods will restart on a new `Ready` node.
+
+```
+                            +-----------------+
+                            |  HA Controller  |
+                            +--------+--------+
+                                     |
+                                     |
+                                     |
++--------+     +---------------------+------------------------+
+|  ETCD  +-----+                 API Server                   |
++--------+     +----+----------------+-----------------+------+
+                    |                |                 |
+                    |                |                 |
+                    |                |                 |
+               +----+-----+     +----+-----+      +----+-----+
+               |   Node   |     |   Node   |      |   Node   |
+               +----------+     +----------+      +----------+
+```
+
+## Implementation
+
+[High Availability (HA) controller](https://github.com/noobaa/noobaa-operator/pull/672) is a [controller](https://sdk.operatorframework.io/docs/building-operators/golang/references/client/) defining kubernetes [Nodes](https://pkg.go.dev/k8s.io/api/core/v1#Node) as the source of its [events](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/event).
+
+### Node failure flow
+
+1. Communication between [K8S API server](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) and [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) running on a worker node is severed
+2. API server marks the worker node state as `NotReady`
+3. HA Controller (HAC) watching cluster nodes states, detect a worker node state transition, reconciliation is initiated.
+4. The HAC Reconciler lists NooBaa pods on the failing node and requests API server to delete those pods. The new pod state is committed into ETCD
+5. [The pod controller](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/) (Deployment, StatefulSet, etc) reacts to pod deletion and reschedules the pod on a healthy node
+
+### Node readiness condition
+
+Node is ready, if there is a `NodeReady` [node condition](https://pkg.go.dev/k8s.io/api/core/v1#NodeCondition) in node's status. A worker node becomes not ready if the connection between the worker and the master node was broken, the node rebooted, or any other communication error between the K8S API Server and the kubelet process.
+
+### Predicate
+
+[Predicates](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/predicate) allow controllers to filter events before they are provided to EventHandlers. There are several kinds of events, such as CreateEvents, GenericEvent, DeleteEvent and UpdateEvent. Update event where old Node state is `Ready` and current state is `NotReady` indicates a node goes down event. All other events are filtered out.
+
+### Event handler
+
+`Reconcile()` is called when a node in the cluster transitions from `Ready` to `NotReady` state. High Availability (HA) controller lists all NooBaa pods in the failing node filtering using pods label, namespace, and name of the node conditions:
+
+- Pod is labeled with `app=noobaa`
+- Pod runs in the watched namespace
+- Pod runs on the failed node
+
+All the pods matching the above are force-deleted to allow fast rescheduling on a healthy node.
+
+
+## TODO
+
+For noobaa-db pod which is attached to a PV it may take more time until the new pod can attach to the PV. Add noobaa-db PV handling (?) detach db PV from the failing node.

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/openshift/custom-resource-status v0.0.0-20190801200128-4c95b3a336cd
 	github.com/operator-framework/api v0.3.22
 	github.com/operator-framework/operator-lib v0.2.0
+	github.com/pkg/errors v0.9.1
 	github.com/rook/rook v1.6.5
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20200902155336-f9d5ce5a171a
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20210311161930-4bea5edaff58
 	github.com/marstr/randname v0.0.0-20200428202425-99aca53a2176
+	github.com/onsi/ginkgo v1.16.4
+	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20210716145643-0ee1808fb8ed
 	github.com/openshift/custom-resource-status v0.0.0-20190801200128-4c95b3a336cd

--- a/go.sum
+++ b/go.sum
@@ -588,6 +588,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
@@ -1220,8 +1221,9 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/ncw/swift v1.0.50/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
@@ -1241,8 +1243,9 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1914,6 +1917,7 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201110211018-35f3e6cf4a65/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -2020,6 +2024,7 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20201008025239-9df69603baec/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/controller/add_hac.go
+++ b/pkg/controller/add_hac.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	hac "github.com/noobaa/noobaa-operator/v5/pkg/controller/ha"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, hac.Add)
+}

--- a/pkg/controller/ha/ha_controller.go
+++ b/pkg/controller/ha/ha_controller.go
@@ -1,0 +1,99 @@
+package hac
+
+import (
+	"context"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/hac"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// nodeIsReady checks if a kubernetes node is ready
+func nodeIsReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// deletePodsOnStartup - during start up delete NooBaa pods
+// that might be stuck on a failing node
+func deletePodsOnStartup(client client.Client) error {
+	// fetch the cluster nodes from the api server
+	nodeList := &corev1.NodeList{}
+	if !util.KubeList(nodeList) {
+		return errors.Errorf("failed to list nodes")
+	}
+
+	for _, node := range nodeList.Items {
+		if !nodeIsReady(&node) {
+			pd := hac.PodDeleter{Client: client, NodeName: node.Name}
+			if err := pd.DeletePodsOnNode(); err != nil {
+				return errors.Errorf("failed to delete noobaa pods on the node %v in namespace %v", node.Name, options.Namespace)	
+			}
+		}
+	}
+	return nil
+}
+
+// nodeNotReadyPredicate selects nodes that were ready, but became unreachable
+func nodeNotReadyPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode := e.ObjectOld.(*corev1.Node)
+			newNode := e.ObjectNew.(*corev1.Node)
+			return nodeIsReady(oldNode) && !nodeIsReady(newNode)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// Add creates a nodewatcher Controller and adds it to the Manager.
+func Add(mgr manager.Manager) error {
+
+	opts := controller.Options{
+		MaxConcurrentReconciles: 1,
+		Reconciler: reconcile.Func(
+			func(ctx context.Context,req reconcile.Request) (reconcile.Result, error) {
+				return hac.NewHAC(
+					req.NamespacedName,
+					mgr.GetClient(),
+				).Reconcile()
+			}),
+	}
+
+	c, err := controller.New(hac.Name, mgr, opts)
+	if err != nil {
+		return err
+	}
+
+	// start watching node state transitions
+	if err := c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}, nodeNotReadyPredicate()); err != nil {
+		return err
+	}
+
+	// delete pods that might be stuck on a failing node when operator first starts
+	// handles cases like failure of a node running the operator pod
+	return deletePodsOnStartup(mgr.GetClient())
+}

--- a/pkg/controller/ha/ha_suite_test.go
+++ b/pkg/controller/ha/ha_suite_test.go
@@ -1,0 +1,49 @@
+package hac_test
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+var clientset *kubernetes.Clientset
+var logger *log.Logger
+
+// High Availability (HA) Controller integration test entry point
+func TestHAC(t *testing.T) {
+	// this variable is defined in .github/workflows/run_hac_test.yml
+	// indication of running in integration test environment
+	_, ok := os.LookupEnv("OPERATOR_IMAGE")
+	if !ok {
+		t.Skip() // Not an integration test, skip
+	}
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HAC Suite")
+}
+
+func connectToK8s() (*kubernetes.Clientset, error) {
+    clientset, err := kubernetes.NewForConfig(util.KubeConfig())
+    if err != nil {
+		logger.Printf("failed to create K8s clientset")
+		return nil, err
+    }
+
+    return clientset, nil
+}
+
+var _ = BeforeSuite(func() {
+	By("Connecting to K8S cluster")
+	logger = log.New(GinkgoWriter, "INFO: ", log.Lshortfile)
+
+	var err error
+	clientset, err = connectToK8s()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(clientset).ToNot(BeNil())
+}, 60)

--- a/pkg/controller/ha/hac_test.go
+++ b/pkg/controller/ha/hac_test.go
@@ -1,0 +1,159 @@
+package hac_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+var _ = Describe("High Availability (HA) integration test", func() {
+	// Expect a 5nodes KIND cluster,
+	// see .travis/install-5nodes-kind-cluster.sh
+	const (
+		nodesNum = 5
+	)
+
+	// HAC test variables
+	var (
+		ctx            = context.Background() // TODO context ;)
+		nodes          *v1.NodeList           // Initial cluster nodes list
+		pods           *v1.PodList            // NooBaa pods running in the cluster
+		nodeToKill     *string                // Node selected to be killed
+		podsToEvictMap = map[string]bool{}    // Set of NooBaa pods expected
+		                                      // to be evicted as a result of test
+		err            error                  // Test err
+	)
+
+	// - Verify the integratation test cluster environment
+	// - Choose a cluster node to stop
+	// - Calculate the set of NooBaa pods to be evicted
+	Context("Verify K8S cluster", func() {
+
+		// Verify 5 nodes cluster
+		Specify("Require 5 node cluster", func() {
+			nodes, err = clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodes).ToNot(BeNil())
+
+			for _, n := range nodes.Items {
+				logger.Printf("found node %q", n.Name)
+			}
+
+			Expect(len(nodes.Items)).To(BeIdenticalTo(nodesNum), "kind 5 noodes cluster is expected")
+		})
+
+		// Verify NooBaa installation
+		Specify("Require NooBaa pods", func() {
+			labelOption := metav1.ListOptions{LabelSelector: "app=noobaa"}
+			pods, err = clientset.CoreV1().Pods(metav1.NamespaceDefault).List(ctx, labelOption)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods).ToNot(BeNil())
+
+			for _, p := range pods.Items {
+				logger.Printf("found NooBaa pod %v on node %v", p.Name, p.Spec.NodeName)
+			}
+
+			Expect(len(pods.Items)).ToNot(BeIdenticalTo(0))
+		})
+
+		// Select a node to stop and
+		// calculate list of NooBaa pods expected to be evicted
+		Specify("Require a node to kill", func() {
+			nodeByPodPrefix := func(pref string) string {
+				for _, p := range pods.Items {
+					if strings.HasPrefix(p.Name, pref) {
+						return p.Spec.NodeName
+					}
+				}
+				return ""
+			}
+
+			// Select a node to stop such as:
+			// - populated by NooBaa pod
+			// - operator not running on this node
+			podsToEvictPrefix := []string{
+				"noobaa-core",
+				"noobaa-endpoint",
+				"noobaa-" + metav1.NamespaceDefault + "-backing-store",
+			}
+			operatorPref := "noobaa-operator"
+			for _, pref := range podsToEvictPrefix {
+				candidateNode := nodeByPodPrefix(pref)
+				if len(candidateNode) > 0 && nodeByPodPrefix(operatorPref) != candidateNode {
+					nodeToKill = &candidateNode
+				}
+			}
+			Expect(nodeToKill).ToNot(BeNil())
+			Expect(len(*nodeToKill) > 0).To(BeTrue())
+
+			logger.Printf("node to kill %q", *nodeToKill)
+
+			// Calculate a set of NooBaa pods
+			// expected to be deleted by the operator
+			listOption := metav1.ListOptions{LabelSelector: "app=noobaa", FieldSelector: "spec.nodeName=" + (*nodeToKill)}
+			podsToEvict, err := clientset.CoreV1().Pods(metav1.NamespaceDefault).List(ctx, listOption)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(podsToEvict).ToNot(BeNil())
+
+			logger.Printf("Pods to be evicted")
+			for _, p := range podsToEvict.Items {
+				logger.Printf("   %q", p.Name)
+				podsToEvictMap[p.Name] = true
+			}
+
+			Expect(len(podsToEvictMap)).NotTo(BeIdenticalTo(0))
+		})
+	})
+
+	// Node failure flow:
+	// - Initiate a node failue by stopping worker node container
+	// - Wait for NooBaa pods eviction from the failing node
+	Context("Node Failure", func() {
+
+		// Initiate node failure
+		Specify("Require docker stop success", func() {
+			Expect(nodeToKill).ToNot(BeNil())
+			Expect(len(*nodeToKill) > 0).To(BeTrue())
+
+			cmd := exec.Command("docker", "stop", *nodeToKill)
+			err = cmd.Run()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// Verify NooBaa pods were evicted
+		Specify("Require all pods to be deleted", func() {
+			Expect(nodeToKill).ToNot(BeNil())
+			Expect(len(*nodeToKill) > 0).To(BeTrue())
+
+			listOption := metav1.ListOptions{LabelSelector: "app=noobaa", FieldSelector: "spec.nodeName=" + (*nodeToKill)}
+			w, err := clientset.CoreV1().Pods(metav1.NamespaceDefault).Watch(ctx, listOption)
+			Expect(err).ToNot(HaveOccurred())
+
+			timeoutDuration := 5 * time.Minute
+			timeoutTime := time.Now().Add(timeoutDuration)
+
+			logger.Printf("Waiting for pods to be evicted %v", podsToEvictMap)
+			for len(podsToEvictMap) > 0 && timeoutTime.After(time.Now()) {
+				select {
+				case e := <-w.ResultChan():
+					if e.Type != watch.Deleted {
+						continue
+					}
+					pod := e.Object.(*v1.Pod)
+					delete(podsToEvictMap, pod.Name)
+					logger.Printf("evicted  %q", pod.Name)
+				case <-time.After(time.Until(timeoutTime)):
+				}
+			}
+
+			Expect(len(podsToEvictMap)).To(BeIdenticalTo(0))
+		})
+	})
+})

--- a/pkg/hac/hac.go
+++ b/pkg/hac/hac.go
@@ -1,0 +1,90 @@
+package hac
+
+// NooBaa Component Rescheduling
+// see doc/high-availability-controller.md
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+)
+
+// Name of this controller
+const Name = "high-availability-controller"
+
+// PodDeleter encapsulates an operation of
+// deleting pods on node
+type PodDeleter struct {
+	Client   client.Client
+	NodeName string
+}
+
+// DeletePodsOnNode force delete NooBaa pods on the given node
+func (pd *PodDeleter) DeletePodsOnNode() error {
+	log := logrus.WithField(Name, pd.NodeName)
+
+	// looking for noobaa pods running on the failing node in the watched namespace
+	labelOption := client.MatchingLabels{"app": "noobaa"}
+	namespaceOption := client.InNamespace(options.Namespace)
+	nodeOption := client.MatchingFields{"spec.nodeName": pd.NodeName}
+
+	// fetch the noobaa pods from the api server
+	podList := &corev1.PodList{}
+	if !util.KubeList(podList, labelOption, namespaceOption, nodeOption) {
+		return errors.Errorf("failed to list noobaa pods on the node %v in namespace %v", pd.NodeName, options.Namespace)
+	}
+
+	// delete the found pods
+	var gracePeriod int64 = 0
+	deleteOpts := client.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+	for _, pod := range podList.Items {
+		if err := pd.Client.Delete(context.Background(), &pod, &deleteOpts); err != nil {
+			log.Warningf("❌ pod %v/%v, node %v: deletion failed: %v", pod.Namespace, pod.Name, pd.NodeName, err)
+			return err
+		}
+		log.Infof("✅ pod %v/%v, node %v: deletion succeeded", pod.Namespace, pod.Name, pd.NodeName)
+	}
+
+	return nil
+}
+
+// HAC is a high availability controller that watches the nodes Ready -> NotReady transitions
+// and deletes noobaa pods on the node that became unvailable
+type HAC struct {
+	*PodDeleter
+}
+
+// NewHAC initializes a high availability controller reconciler
+func NewHAC(
+	req types.NamespacedName,
+	client client.Client,
+) *HAC {
+	// k8s client and the node that failed
+	pd := &PodDeleter{client, req.Name}
+
+	return &HAC{pd}
+}
+
+// Reconcile is called when a node in the cluster transitions
+// from Ready to NotReady state
+// go over the noobaa pods running on this node and force their deletion
+func (hac *HAC) Reconcile() (reconcile.Result, error) {
+	res := reconcile.Result{}
+	log := logrus.WithField(Name, hac.NodeName)
+	log.Warningf("❌ node %v became NotReady", hac.NodeName)
+
+	if err := hac.DeletePodsOnNode(); err != nil {
+		return res, errors.Errorf("failed to delete noobaa pods on the node %v in namespace %v", hac.NodeName, options.Namespace)
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
Improve NooBaa pods recovery in case of a node failure. Find noobaa pods
running on the failing node and force delete them to speed up
rescheduling in healthy node.

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>