### PR TITLE
Load env vars to noobaa core from config map

### DIFF
--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -756,9 +756,6 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
-              debugLevel:
-                description: DebugLevel (optional) sets the debug level
-                type: integer
               endpoints:
                 description: Endpoints (optional) sets configuration info for the
                   noobaa endpoint deployment.

--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     app: noobaa
   name: noobaa-endpoint
+  annotations:
+    ConfigMapHash: ""
 spec:
   replicas: 1
   selector:
@@ -50,6 +52,16 @@ spec:
             - containerPort: 6001
             - containerPort: 6443
           env:
+            - name: NOOBAA_DISABLE_COMPRESSION
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_DISABLE_COMPRESSION
+            - name: NOOBAA_LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_LOG_LEVEL
             - name: MGMT_ADDR
             - name: BG_ADDR
             - name: MD_ADDR
@@ -68,10 +80,6 @@ spec:
             - name: LOCAL_N2N_AGENT
             - name: JWT_SECRET
             - name: NOOBAA_ROOT_SECRET
-            - name: NOOBAA_LOG_LEVEL
-              value: "0"
-            - name: NOOBAA_DISABLE_COMPRESSION
-              value: "false"
             - name: NOOBAA_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -4,6 +4,8 @@ metadata:
   name: noobaa-core
   labels:
     app: noobaa
+  annotations:
+    ConfigMapHash: ""
 spec:
   replicas: 1
   selector:
@@ -61,6 +63,21 @@ spec:
             - containerPort: 8446
             - containerPort: 60100
           env:
+            - name: NOOBAA_DISABLE_COMPRESSION
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_DISABLE_COMPRESSION
+            - name: DISABLE_DEV_RANDOM_SEED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: DISABLE_DEV_RANDOM_SEED
+            - name: NOOBAA_LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_LOG_LEVEL
             - name: MONGODB_URL
               value: "mongodb://noobaa-db-0.noobaa-db/nbcore"
             - name: POSTGRES_HOST
@@ -73,10 +90,6 @@ spec:
               value: mongodb
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
-            - name: NOOBAA_LOG_LEVEL
-              value: "0"
-            - name: NOOBAA_DISABLE_COMPRESSION
-              value: "false"
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -90,8 +103,6 @@ spec:
             - name: NOOBAA_ROOT_SECRET
             - name: AGENT_PROFILE
               value: VALUE_AGENT_PROFILE
-            - name: DISABLE_DEV_RANDOM_SEED
-              value: "true"
             - name: OAUTH_AUTHORIZATION_ENDPOINT
               value: ""
             - name: OAUTH_TOKEN_ENDPOINT
@@ -100,8 +111,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-            - name: container_dbg
-              value: "" # any non-empty value will set the container to dbg mode
             - name: CONTAINER_CPU_REQUEST
               valueFrom:
                 resourceFieldRef:

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -101,10 +101,6 @@ type NooBaaSpec struct {
 	// +optional
 	MongoDbURL string `json:"mongoDbURL,omitempty"`
 
-	// DebugLevel (optional) sets the debug level
-	// +optional
-	DebugLevel int `json:"debugLevel,omitempty"`
-
 	// PVPoolDefaultStorageClass (optional) overrides the default cluster StorageClass for the pv-pool volumes.
 	// This affects where the system stores data chunks (encrypted).
 	// Updates to this field will only affect new pv-pools,

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1006,7 +1006,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "a77ff65531f26c4361ca51ba1f38c0076da1ab24403007641a131ce63f2065cd"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "a7a87b507e0d7ca2ee52f440e86b1d7383123d14c5e9265ca5b837345175aca8"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1766,9 +1766,6 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
-              debugLevel:
-                description: DebugLevel (optional) sets the debug level
-                type: integer
               endpoints:
                 description: Endpoints (optional) sets configuration info for the
                   noobaa endpoint deployment.
@@ -2350,7 +2347,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "6769a038678b5d5d41a3a731e1cfd63acf113c45aef2855f790cbe6e2fc91b9a"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "d0b3248e8751fd5dc0827d9ec526b6a9a31bb7014940c5a86b0519b523f48af3"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -2358,6 +2355,8 @@ metadata:
   labels:
     app: noobaa
   name: noobaa-endpoint
+  annotations:
+    ConfigMapHash: ""
 spec:
   replicas: 1
   selector:
@@ -2404,6 +2403,16 @@ spec:
             - containerPort: 6001
             - containerPort: 6443
           env:
+            - name: NOOBAA_DISABLE_COMPRESSION
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_DISABLE_COMPRESSION
+            - name: NOOBAA_LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_LOG_LEVEL
             - name: MGMT_ADDR
             - name: BG_ADDR
             - name: MD_ADDR
@@ -2422,10 +2431,6 @@ spec:
             - name: LOCAL_N2N_AGENT
             - name: JWT_SECRET
             - name: NOOBAA_ROOT_SECRET
-            - name: NOOBAA_LOG_LEVEL
-              value: "0"
-            - name: NOOBAA_DISABLE_COMPRESSION
-              value: "false"
             - name: NOOBAA_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -2920,7 +2925,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "758e83226e32791df7c5199203122def00d5df31d46eab3f0daddbf62ab1a068"
+const Sha256_deploy_internal_statefulset_core_yaml = "4fcda72e3d5e4ce1e46cd1c5c324a2dbc748df155733dea8ec06ef6d6183424c"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -2928,6 +2933,8 @@ metadata:
   name: noobaa-core
   labels:
     app: noobaa
+  annotations:
+    ConfigMapHash: ""
 spec:
   replicas: 1
   selector:
@@ -2985,6 +2992,21 @@ spec:
             - containerPort: 8446
             - containerPort: 60100
           env:
+            - name: NOOBAA_DISABLE_COMPRESSION
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_DISABLE_COMPRESSION
+            - name: DISABLE_DEV_RANDOM_SEED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: DISABLE_DEV_RANDOM_SEED
+            - name: NOOBAA_LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_LOG_LEVEL
             - name: MONGODB_URL
               value: "mongodb://noobaa-db-0.noobaa-db/nbcore"
             - name: POSTGRES_HOST
@@ -2997,10 +3019,6 @@ spec:
               value: mongodb
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
-            - name: NOOBAA_LOG_LEVEL
-              value: "0"
-            - name: NOOBAA_DISABLE_COMPRESSION
-              value: "false"
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -3014,8 +3032,6 @@ spec:
             - name: NOOBAA_ROOT_SECRET
             - name: AGENT_PROFILE
               value: VALUE_AGENT_PROFILE
-            - name: DISABLE_DEV_RANDOM_SEED
-              value: "true"
             - name: OAUTH_AUTHORIZATION_ENDPOINT
               value: ""
             - name: OAUTH_TOKEN_ENDPOINT
@@ -3024,8 +3040,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-            - name: container_dbg
-              value: "" # any non-empty value will set the container to dbg mode
             - name: CONTAINER_CPU_REQUEST
               valueFrom:
                 resourceFieldRef:

--- a/pkg/controller/noobaa/noobaa_controller.go
+++ b/pkg/controller/noobaa/noobaa_controller.go
@@ -98,6 +98,10 @@ func Add(mgr manager.Manager) error {
 	if err != nil {
 		return err
 	}
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, ownerHandler, &filterForOwnerPredicate, &logEventsPredicate)
+	if err != nil {
+		return err
+	}
 
 	storageClassHandler := handler.EnqueueRequestsFromMapFunc(func(mo client.Object) []reconcile.Request {
 			sc, ok := mo.(*storagev1.StorageClass)

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -86,6 +87,9 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 		return err
 	}
 	if err := r.ReconcileDeploymentEndpointStatus(); err != nil {
+		return err
+	}
+	if err := r.ReconcileSystemConfigMap(); err != nil {
 		return err
 	}
 	return nil
@@ -319,8 +323,6 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 					if r.JoinSecret == nil {
 						c.Env[j].Value = r.MongoConnectionString
 					}
-				case "NOOBAA_LOG_LEVEL":
-					c.Env[j].Value = strconv.Itoa(r.NooBaa.Spec.DebugLevel)
 				case "LOCAL_MD_SERVER":
 					if r.JoinSecret == nil {
 						c.Env[j].Value = "true"
@@ -390,6 +392,8 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 			util.ReflectEnvVariable(&c.Env, "HTTP_PROXY")
 			util.ReflectEnvVariable(&c.Env, "HTTPS_PROXY")
 			util.ReflectEnvVariable(&c.Env, "NO_PROXY")
+
+			r.SetConfigMapAnnotation(r.DeploymentEndpoint.ObjectMeta.Annotations)
 
 			return r.setDesiredEndpointMounts(podSpec, c)
 		}
@@ -1410,5 +1414,49 @@ func (r *Reconciler) ReconcileNamespaceStores(namespaceResources []nb.NamespaceR
 			}
 		}
 	}
+	return nil
+}
+
+// ReconcileSystemConfigMap restarts the core and endpoint pods to recive updates from config map
+func (r *Reconciler) ReconcileSystemConfigMap() error {
+	sha256Hex := util.GetCmDataHash(r.CoreAppConfig.Data)
+
+	if (r.DeploymentEndpoint.ObjectMeta.Annotations["ConfigMapHash"] != sha256Hex) {
+		epPodList := &corev1.PodList{}
+		epPodSelector, _ := labels.Parse("noobaa-s3=" + r.Request.Name)
+		if !util.KubeList(epPodList, &client.ListOptions{Namespace: options.Namespace, LabelSelector: epPodSelector}) {
+			r.Logger.Errorf("failed to list to endpoint pods")
+		}
+		r.DeploymentEndpoint.ObjectMeta.Annotations["ConfigMapHash"] = sha256Hex
+
+		if !util.KubeUpdate(r.DeploymentEndpoint) {
+			r.Logger.Infof("NooBaa %q failed to update Deployment Endpoint Config Map Hash", options.SystemName)
+		}
+		for _, pod := range epPodList.Items {
+			util.KubeDeleteNoPolling(&pod)
+		}
+	}
+
+	corePodList := &corev1.PodList{}
+	corePodSelector, _ := labels.Parse("noobaa-core=" + r.Request.Name)
+	if !util.KubeList(corePodList, &client.ListOptions{Namespace: options.Namespace, LabelSelector: corePodSelector}) {
+		r.Logger.Errorf("failed to list to core pods")
+	}
+
+	if (r.CoreApp.ObjectMeta.Annotations["ConfigMapHash"] != sha256Hex){
+		r.CoreApp.ObjectMeta.Annotations["ConfigMapHash"] = sha256Hex
+		
+		if !util.KubeUpdate(r.CoreApp) {
+			r.Logger.Infof("NooBaa %q failed to update Core STS Config Map Hash", options.SystemName)
+		}	
+
+		for _, pod := range corePodList.Items {
+			if (pod.DeletionTimestamp == nil){
+				util.KubeDeleteNoPolling(&pod)
+			}
+		}
+
+	}
+
 	return nil
 }

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -67,6 +67,7 @@ type Reconciler struct {
 	NooBaa                    *nbv1.NooBaa
 	ServiceAccount            *corev1.ServiceAccount
 	CoreApp                   *appsv1.StatefulSet
+	CoreAppConfig             *corev1.ConfigMap
 	DefaultCoreApp            *corev1.Container
 	NooBaaMongoDB             *appsv1.StatefulSet
 	PostgresDBConf            *corev1.ConfigMap
@@ -124,6 +125,7 @@ func NewReconciler(
 		NooBaa:              util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml).(*nbv1.NooBaa),
 		ServiceAccount:      util.KubeObject(bundle.File_deploy_service_account_yaml).(*corev1.ServiceAccount),
 		CoreApp:             util.KubeObject(bundle.File_deploy_internal_statefulset_core_yaml).(*appsv1.StatefulSet),
+		CoreAppConfig:       util.KubeObject(bundle.File_deploy_internal_configmap_empty_yaml).(*corev1.ConfigMap),
 		NooBaaMongoDB:       util.KubeObject(bundle.File_deploy_internal_statefulset_db_yaml).(*appsv1.StatefulSet),
 		PostgresDBConf:      util.KubeObject(bundle.File_deploy_internal_configmap_postgres_db_yaml).(*corev1.ConfigMap),
 		NooBaaPostgresDB:    util.KubeObject(bundle.File_deploy_internal_statefulset_postgres_db_yaml).(*appsv1.StatefulSet),
@@ -161,6 +163,7 @@ func NewReconciler(
 	r.NooBaa.Namespace = r.Request.Namespace
 	r.ServiceAccount.Namespace = r.Request.Namespace
 	r.CoreApp.Namespace = r.Request.Namespace
+	r.CoreAppConfig.Namespace = r.Request.Namespace
 	r.NooBaaMongoDB.Namespace = r.Request.Namespace
 	r.PostgresDBConf.Namespace = r.Request.Namespace
 	r.NooBaaPostgresDB.Namespace = r.Request.Namespace
@@ -199,6 +202,7 @@ func NewReconciler(
 	r.NooBaa.Name = r.Request.Name
 	r.ServiceAccount.Name = r.Request.Name
 	r.CoreApp.Name = r.Request.Name + "-core"
+	r.CoreAppConfig.Name = "noobaa-config"
 	r.NooBaaMongoDB.Name = r.Request.Name + "-db"
 	r.NooBaaPostgresDB.Name = r.Request.Name + "-db-pg"
 	r.ServiceMgmt.Name = r.Request.Name + "-mgmt"
@@ -262,6 +266,7 @@ func (r *Reconciler) CheckAll() {
 
 	CheckSystem(r.NooBaa)
 	util.KubeCheck(r.CoreApp)
+	util.KubeCheck(r.CoreAppConfig)
 	util.KubeCheck(r.ServiceMgmt)
 	util.KubeCheck(r.ServiceS3)
 	if r.NooBaa.Spec.MongoDbURL == "" {

--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -52,6 +52,7 @@ NAMESPACE='test'
 # AWS_ACCESS_KEY_ID=XXX AWS_SECRET_ACCESS_KEY=YYY aws s3 --endpoint-url XXX ls BUCKETNAME ❌
 
 function post_install_tests {
+    check_core_config_map
     aws_credentials
     check_S3_compatible
     check_namespacestore


### PR DESCRIPTION
Signed-off-by: Kfir <kfirpayne@gmail.com>

related to https://github.com/noobaa/noobaa-operator/issues/426

### Explain the changes
1. Added `envFrom: configMapRef` and `annotations: ConfigMapMD5` to the core and endpoint deployment.
2. The `ConfigMapMD5` annotation referencing to an up-to-date hash of the data array of the `noobaa-config`.
3. Added validation on changes to the configmap, triggering a restart on the core and endpoint pods.
4. Reduced the time interval in the `wait.PollImmediateInfinite()` in the `util.KubeDelete()` to cope with the STS creating the core pod before the `wait.Poll` checking if the pod got deleted, reduced from 1 second to 10 milliseconds.

### Work Needed:
1. Decide which env vars from the endpoint we can move to the configmap.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #426

### Testing Instructions:
1. 
