### PR TITLE
Added namespacestore validation

### DIFF
--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -277,6 +277,11 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.NSType, popu
 
 	populate(namespaceStore, secret)
 
+	validationErr := ValidateNamespaceStore(namespaceStore)
+	if validationErr != nil {
+		log.Fatalf(`❌ %s %s`, validationErr, cmd.UsageString())
+	}
+
 	// Create namespace store CR
 	util.Panic(controllerutil.SetControllerReference(sys, namespaceStore, scheme.Scheme))
 	if !util.KubeCreateFailExisting(namespaceStore) {
@@ -420,18 +425,14 @@ func RunCreateAzureBlob(cmd *cobra.Command, args []string) {
 
 // RunCreateNSFS runs a CLI command
 func RunCreateNSFS(cmd *cobra.Command, args []string) {
-	log := util.Logger()
 	createCommon(cmd, args, nbv1.NSStoreTypeNSFS, func(namespaceStore *nbv1.NamespaceStore, secret *corev1.Secret) {
 		pvcName := util.GetFlagStringOrPrompt(cmd, "pvc-name")
 		fsBackend, _ := cmd.Flags().GetString("fs-backend")
 		subPath, _ := cmd.Flags().GetString("sub-path")
 
-		if pvcName == "" {
-			log.Fatalf(`❌ Missing expected arguments: <pvc-name> %s`, cmd.UsageString())
-		}
 		namespaceStore.Spec.NSFS = &nbv1.NSFSSpec{
-			PvcName: pvcName,
-			SubPath:  subPath,
+			PvcName:   pvcName,
+			SubPath:   subPath,
 			FsBackend: fsBackend,
 		}
 	})

--- a/pkg/namespacestore/validation.go
+++ b/pkg/namespacestore/validation.go
@@ -1,0 +1,156 @@
+package namespacestore
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+)
+
+const (
+	defaultEndPointURI = "https://127.0.0.1:6443"
+)
+
+// ValidateNamespaceStore validates namespacestore configuration
+func ValidateNamespaceStore(nsStore *nbv1.NamespaceStore) error {
+	switch nsStore.Spec.Type {
+
+	case nbv1.NSStoreTypeNSFS:
+		return validateNsStoreNSFS(nsStore)
+
+	case nbv1.NSStoreTypeAWSS3:
+		return nil
+
+	case nbv1.NSStoreTypeS3Compatible:
+		return validateNsStoreS3Compatible(nsStore)
+
+	case nbv1.NSStoreTypeIBMCos:
+		return validateNsStoreIBMCos(nsStore)
+
+	case nbv1.NSStoreTypeAzureBlob:
+		return nil
+
+	default:
+		return util.NewPersistentError("ConfigurationError",
+			fmt.Sprintf("Invalid namespace store type %q", nsStore.Spec.Type))
+	}
+}
+
+// validateNamespaceStoreNSFS validates namespacestore nsfs type configuration
+func validateNsStoreNSFS(nsStore *nbv1.NamespaceStore) error {
+	nsfs := nsStore.Spec.NSFS
+
+	if nsfs == nil {
+		return nil
+	}
+
+	//pvcName validation
+	if nsfs.PvcName == "" {
+		return util.NewPersistentError("InvalidPvcName", "PvcName must not be empty")
+	}
+
+	//SubPath validation
+	if nsfs.SubPath != "" {
+		path := nsfs.SubPath
+		if len(path) > 0 && path[0] == '/' {
+			return util.NewPersistentError("InvalidSubPath",
+				fmt.Sprintf("SubPath %s must be a relative path", path))
+		}
+		parts := strings.Split(path, "/")
+		for _, item := range parts {
+			if item == ".." {
+				return util.NewPersistentError("InvalidSubPath",
+					fmt.Sprintf("SubPath %s must not contain '..'", path))
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateNsStoreS3Compatible validates namespacestore S3Compatible type configuration
+func validateNsStoreS3Compatible(nsStore *nbv1.NamespaceStore) error {
+	s3Compatible := nsStore.Spec.S3Compatible
+
+	if s3Compatible == nil {
+		return nil
+	}
+
+	err := validateSignatureVersion(s3Compatible.SignatureVersion, nsStore.Name)
+	if err != nil {
+		return err
+	}
+
+	err = validateEndPoint(&s3Compatible.Endpoint)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateNsStoreIBMCos validates namespacestore IBMCos type configuration
+func validateNsStoreIBMCos(nsStore *nbv1.NamespaceStore) error {
+	IBMCos := nsStore.Spec.IBMCos
+
+	if IBMCos == nil {
+		return nil
+	}
+
+	err := validateSignatureVersion(IBMCos.SignatureVersion, nsStore.Name)
+	if err != nil {
+		return err
+	}
+
+	err = validateEndPoint(&IBMCos.Endpoint)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//SignatureVersion validation, must be empty or v2 or v4
+func validateSignatureVersion(signature nbv1.S3SignatureVersion, nsStoreName string) error {
+	if signature != "" &&
+		signature != nbv1.S3SignatureVersionV2 &&
+		signature != nbv1.S3SignatureVersionV4 {
+		return util.NewPersistentError("InvalidSignatureVersion",
+			fmt.Sprintf("Invalid s3 signature version %q for namespace store %q",
+				signature, nsStoreName))
+	}
+	return nil
+}
+
+//Endpoint validation and sets default
+func validateEndPoint(endPointPointer *string) error {
+	endPoint := *endPointPointer
+
+	if endPoint == "" {
+		endPoint = defaultEndPointURI
+	}
+
+	match, err := regexp.MatchString(`^\w+://`, endPoint)
+	if err != nil {
+		return util.NewPersistentError("InvalidEndpoint",
+			fmt.Sprintf("Invalid endpoint url %q: %v", endPoint, err))
+	}
+	if !match {
+		endPoint = "https://" + endPoint
+	}
+	u, err := url.Parse(endPoint)
+	if err != nil {
+		return util.NewPersistentError("InvalidEndpoint",
+			fmt.Sprintf("Invalid endpoint url %q: %v", endPoint, err))
+	}
+	if u.Scheme == "" {
+		u.Scheme = "https"
+	}
+
+	*endPointPointer = u.String()
+
+	return nil
+}

--- a/pkg/namespacestore/validation_test.go
+++ b/pkg/namespacestore/validation_test.go
@@ -1,0 +1,184 @@
+package namespacestore
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNamespaceStoreNSFS(t *testing.T) {
+
+	//Valid namespacestore
+	defaultNs := getDefaultNSFSNsStore()
+	err := ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Valid namespacestore validation is failed")
+
+	//Pvcname is empty
+	defaultNs = getDefaultNSFSNsStore()
+	defaultNs.Spec.NSFS.PvcName = ""
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Validation empty pvcName is failed")
+
+	//SubPath is not relative
+	defaultNs = getDefaultNSFSNsStore()
+	defaultNs.Spec.NSFS.SubPath = "/"
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Validation relative subPath %s is failed", defaultNs.Spec.NSFS.SubPath)
+
+	//SubPath contains '..'
+	defaultNs = getDefaultNSFSNsStore()
+	defaultNs.Spec.NSFS.SubPath = "test/../test2"
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Validation relative subPath %s is failed", defaultNs.Spec.NSFS.SubPath)
+
+}
+
+func TestNamespaceStoreS3Compatible(t *testing.T) {
+
+	//Valid namespacestore
+	defaultNs := getDefaultS3CompatibleNsStore()
+	err := ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Valid namespacestore validation is failed")
+
+	//Signature version is empty
+	defaultNs = getDefaultS3CompatibleNsStore()
+	defaultNs.Spec.S3Compatible.SignatureVersion = ""
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Empty sugnature version validation is failed")
+
+	//Valid v2 signature version
+	defaultNs = getDefaultS3CompatibleNsStore()
+	defaultNs.Spec.S3Compatible.SignatureVersion = "v2"
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Valid sugnature version %s validation is failed", defaultNs.Spec.S3Compatible.SignatureVersion)
+
+	//Ivalid signature version
+	defaultNs = getDefaultS3CompatibleNsStore()
+	defaultNs.Spec.S3Compatible.SignatureVersion = "v5"
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Invalid sugnature version %s validation is failed", defaultNs.Spec.S3Compatible.SignatureVersion)
+
+	//Empty endPoint
+	defaultNs = getDefaultS3CompatibleNsStore()
+	defaultNs.Spec.S3Compatible.Endpoint = ""
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Empty endPoint validation is failed")
+	AssertEqual(t, defaultEndPointURI, defaultNs.Spec.S3Compatible.Endpoint,
+		"EndPoint has no the default value, %s : %s", defaultNs.Spec.S3Compatible.Endpoint, defaultEndPointURI)
+
+	//Invalid endPoint
+	defaultNs = getDefaultS3CompatibleNsStore()
+	defaultNs.Spec.S3Compatible.Endpoint = "hostname:port"
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Invalid endPoint %s validation is failed", defaultNs.Spec.S3Compatible.Endpoint)
+
+}
+
+func TestNamespaceStoreIBMCos(t *testing.T) {
+
+	//Valid namespacestore
+	defaultNs := getDefaultIBMCosNsStore()
+	err := ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Valid namespacestore validation is failed")
+
+	//Signature version is empty
+	defaultNs = getDefaultIBMCosNsStore()
+	defaultNs.Spec.IBMCos.SignatureVersion = ""
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Empty sugnature version validation is failed")
+
+	//Valid v2 signature version
+	defaultNs = getDefaultIBMCosNsStore()
+	defaultNs.Spec.IBMCos.SignatureVersion = "v2"
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Valid sugnature version %s validation is failed", defaultNs.Spec.IBMCos.SignatureVersion)
+
+	//Ivalid signature version
+	defaultNs = getDefaultIBMCosNsStore()
+	defaultNs.Spec.IBMCos.SignatureVersion = "v5"
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Invalid sugnature version %s validation is failed", defaultNs.Spec.IBMCos.SignatureVersion)
+
+	//Empty endPoint
+	defaultNs = getDefaultIBMCosNsStore()
+	defaultNs.Spec.IBMCos.Endpoint = ""
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Empty endPoint validation is failed")
+	AssertEqual(t, defaultEndPointURI, defaultNs.Spec.IBMCos.Endpoint,
+		"EndPoint has no the default value, %s : %s", defaultNs.Spec.IBMCos.Endpoint, defaultEndPointURI)
+
+	//Invalid endPoint
+	defaultNs = getDefaultIBMCosNsStore()
+	defaultNs.Spec.IBMCos.Endpoint = "hostname:port"
+	err = ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Invalid endPoint %s validation is failed", defaultNs.Spec.IBMCos.Endpoint)
+
+}
+
+func AssertNotError(t *testing.T, err error, format string, a ...interface{}) {
+	if err != nil {
+		msg := fmt.Sprintf(format, a...)
+		t.Errorf("%s: %s", msg, err)
+	}
+}
+
+func AssertError(t *testing.T, err error, format string, a ...interface{}) {
+	if err == nil {
+		msg := fmt.Sprintf(format, a...)
+		t.Errorf("%s", msg)
+	}
+}
+
+func AssertEqual(t *testing.T, actual, expected interface{}, format string, a ...interface{}) {
+	msg := fmt.Sprintf(format, a...)
+
+	if (actual == nil || expected == nil) && actual != expected {
+		t.Errorf("%s", msg)
+		return
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("%s", msg)
+	}
+}
+
+func getDefaultIBMCosNsStore() nbv1.NamespaceStore {
+	return nbv1.NamespaceStore{
+		Spec: nbv1.NamespaceStoreSpec{
+			Type: nbv1.NSStoreTypeIBMCos,
+			IBMCos: &nbv1.IBMCosSpec{
+				SignatureVersion: nbv1.S3SignatureVersionV4,
+				Endpoint:         defaultEndPointURI,
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+	}
+}
+
+func getDefaultS3CompatibleNsStore() nbv1.NamespaceStore {
+	return nbv1.NamespaceStore{
+		Spec: nbv1.NamespaceStoreSpec{
+			Type: nbv1.NSStoreTypeS3Compatible,
+			S3Compatible: &nbv1.S3CompatibleSpec{
+				SignatureVersion: nbv1.S3SignatureVersionV4,
+				Endpoint:         defaultEndPointURI,
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+	}
+}
+
+func getDefaultNSFSNsStore() nbv1.NamespaceStore {
+	return nbv1.NamespaceStore{
+		Spec: nbv1.NamespaceStoreSpec{
+			Type: nbv1.NSStoreTypeNSFS,
+			NSFS: &nbv1.NSFSSpec{
+				PvcName: "pv-pool",
+				SubPath: "subpath/",
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+	}
+}

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -397,29 +397,36 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 }
 
 func (r *Reconciler) setDesiredEndpointMounts(podSpec *corev1.PodSpec, container *corev1.Container) error {
+
+	log := r.Logger.WithField("source", "SystemReconciler:setDesiredEndpointMounts")
+
 	namespaceStoreList := &nbv1.NamespaceStoreList{}
 	if !util.KubeList(namespaceStoreList, client.InNamespace(options.Namespace)) {
 		return fmt.Errorf("Error: Cant list namespacestores")
 	}
-	podSpec.Volumes = r.DefaultDeploymentEndpoint.Volumes 
+	podSpec.Volumes = r.DefaultDeploymentEndpoint.Volumes
 	container.VolumeMounts = r.DefaultDeploymentEndpoint.Containers[0].VolumeMounts
 
 	for _, nsStore := range namespaceStoreList.Items {
+		if nsStore.Status.Phase == nbv1.NamespaceStorePhaseRejected {
+			log.Warnf("namespacestore %s is in rejected phase", nsStore.Name)
+			continue
+		}
 		if nsStore.Spec.NSFS != nil {
 			pvcName := nsStore.Spec.NSFS.PvcName
 			isPvcExist := false
 			volumeName := "nsfs-" + nsStore.Name
 			for _, volume := range podSpec.Volumes {
 				if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvcName {
-						isPvcExist = true // PVC already attached to the pods - no need to add
-						volumeName = volume.Name
-						break;
+					isPvcExist = true // PVC already attached to the pods - no need to add
+					volumeName = volume.Name
+					break
 				}
 			}
-			if (!isPvcExist) {
-				podSpec.Volumes = append(podSpec.Volumes, corev1.Volume {
+			if !isPvcExist {
+				podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 					Name: volumeName,
-					VolumeSource: corev1.VolumeSource {
+					VolumeSource: corev1.VolumeSource{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 							ClaimName: pvcName,
 						},
@@ -431,15 +438,15 @@ func (r *Reconciler) setDesiredEndpointMounts(podSpec *corev1.PodSpec, container
 			isMountExist := false
 			for _, volumeMount := range container.VolumeMounts {
 				if volumeMount.Name == volumeName && volumeMount.SubPath == subPath {
-						isMountExist = true // volumeMount already created - no need to add
-						break;
+					isMountExist = true // volumeMount already created - no need to add
+					break
 				}
 			}
-			if (!isMountExist) {
+			if !isMountExist {
 				container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-					Name: volumeName,
+					Name:      volumeName,
 					MountPath: mountPath,
-					SubPath: subPath,
+					SubPath:   subPath,
 				})
 			}
 		}

--- a/test/cli/resources/nsfs-local-class.yaml
+++ b/test/cli/resources/nsfs-local-class.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nsfs-local
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/test/cli/resources/nsfs-local-pv.yaml
+++ b/test/cli/resources/nsfs-local-pv.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nsfs-vol
+spec:
+  storageClassName: nsfs-local
+  volumeMode: Filesystem
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: /nsfs/
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadWriteMany
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/os
+              operator: Exists

--- a/test/cli/resources/nsfs-local-pvc.yaml
+++ b/test/cli/resources/nsfs-local-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nsfs-vol
+spec:
+  storageClassName: nsfs-local
+  resources:
+    requests:
+      storage: 1Ti
+  accessModes:
+    - ReadWriteMany


### PR DESCRIPTION
Link to issue:  
https://github.com/noobaa/noobaa-operator/issues/677

1. Added validation to the namespacestore reconciler and noobaa cli
  * Validate if Spec.NSFS.SubPath must be a relative path
  * Validate if Spec.NSFS.SubPath must not contain '..'
  * Validate if Spec.NSFS.PvcName must not be empty

2. Move all config validations from MakeExternalConnectionParams to the validator

3. Skip DesiredEndpointMounts when namespacestore is in rejected phase

4. Added the validator automation tests

Tests:
```
$noobaa namespacestore create nsfs fs1 --pvc-name='nsfs-vol' --fs-backend='GPFS' --sub-path='/'
INFO[0000] ✅ Exists: NooBaa "noobaa"
FATA[0000] ❌ SubPath / must be a relative path

Options:
      --fs-backend='': The file system backend type - CEPH_FS | GPFS | NFSv4
      --pvc-name='': The pvc name in which the file system resides
      --sub-path='': The path to a sub directory inside the pvc file system

Usage:
  noobaa namespacestore create nsfs <namespace-store-name> [flags] [options]

Use "noobaa options" for a list of global command-line options (applies to all commands).
```

```
$kubectl apply -f namespacestore.yaml
namespacestore.noobaa.io/fs1 created

time="2021-07-07T09:26:27Z" level=info msg="SetPhase: Rejected" namespace=noobaa/fs1
time="2021-07-07T09:26:27Z" level=error msg="❌ Persistent Error: SubPath / must be a relative path" namespace=noobaa/fs1
time="2021-07-07T09:26:27Z" level=info msg="SetPhase: Rejected" namespace=noobaa/fs1
time="2021-07-07T09:26:27Z" level=error msg="❌ Persistent Error: SubPath / must be a relative path" namespace=noobaa/fs1
time="2021-07-07T09:26:34Z" level=warning msg="namespacestore fs1 is in rejected phase" source="SystemReconciler:setDesiredEndpointMounts" sys=noobaa/noobaa
time="2021-07-07T09:26:45Z" level=warning msg="namespacestore fs1 is in rejected phase" source="SystemReconciler:setDesiredEndpointMounts" sys=noobaa/noobaa
```

