### PR TITLE
Bucket Replication - Operator side

### DIFF
--- a/deploy/crds/noobaa.io_bucketclasses_crd.yaml
+++ b/deploy/crds/noobaa.io_bucketclasses_crd.yaml
@@ -125,6 +125,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              replicationPolicy:
+                description: ReplicationPolicy specifies a json of replication rules
+                  for the bucketclass
+                type: string
             type: object
           status:
             description: Most recently observed status of the noobaa BackingStore.

--- a/pkg/apis/noobaa/v1alpha1/bucketclass_types.go
+++ b/pkg/apis/noobaa/v1alpha1/bucketclass_types.go
@@ -64,6 +64,10 @@ type BucketClassSpec struct {
 	// NamespacePolicy specifies the namespace policy for the bucket class
 	// +optional
 	NamespacePolicy *NamespacePolicy `json:"namespacePolicy,omitempty"`
+
+	// ReplicationPolicy specifies a json of replication rules for the bucketclass
+	// +optional
+	ReplicationPolicy string `json:"replicationPolicy,omitempty"`
 }
 
 // BucketClassStatus defines the observed state of BucketClass

--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -49,6 +49,7 @@ func CmdCreate() *cobra.Command {
 		CmdCreateNamespaceBucketclass(),
 		CmdCreatePlacementBucketClass(),
 	)
+
 	return cmd
 }
 
@@ -65,6 +66,8 @@ func CmdCreatePlacementBucketClass() *cobra.Command {
 		"Set first tier placement policy - Mirror | Spread | \"\" (empty defaults to single backing store)")
 	cmd.Flags().StringSlice("backingstores", nil,
 		"Set first tier backing stores (use commas or multiple flags)")
+	cmd.Flags().String("replication-policy", "",
+		"Set the json file name that contains the replication rules")
 
 	return cmd
 }
@@ -96,6 +99,8 @@ func CmdCreateSingleNamespaceBucketclass() *cobra.Command {
 	// single namespace policy
 	cmd.Flags().String("resource", "",
 		"Set the namespace read and write resource")
+	cmd.Flags().String("replication-policy", "",
+		"Set the json file name that contains replication rules")
 
 	return cmd
 }
@@ -113,6 +118,8 @@ func CmdCreateMultiNamespaceBucketclass() *cobra.Command {
 		"Set the namespace write resource")
 	cmd.Flags().StringSlice("read-resources", nil,
 		"Set the namespace read resources")
+	cmd.Flags().String("replication-policy", "",
+		"Set the json file name that contains replication rules")
 
 	return cmd
 }
@@ -136,6 +143,9 @@ func CmdCreateCacheNamespaceBucketclass() *cobra.Command {
 		"Set first tier placement policy - Mirror | Spread | \"\" (empty defaults to single backing store)")
 	cmd.Flags().StringSlice("backingstores", nil,
 		"Set first tier backing stores (use commas or multiple flags)")
+	cmd.Flags().String("replication-policy", "",
+		"Set the json file name that contains replication rules")
+
 	return cmd
 }
 
@@ -333,6 +343,14 @@ func createCommonBucketclass(cmd *cobra.Command, args []string, bucketClassType 
 		}
 	}
 
+	replicationPolicyJSON, _ := cmd.Flags().GetString("replication-policy")
+	if replicationPolicyJSON != "" {
+		replication, err := util.LoadBucketReplicationJSON(replicationPolicyJSON)
+		if err != nil {
+			log.Fatalf(`❌ %q`, err)
+		}
+		bucketClass.Spec.ReplicationPolicy = replication
+	}
 	// Create bucket class CR
 	util.Panic(controllerutil.SetControllerReference(sys, bucketClass, scheme.Scheme))
 	if !util.KubeCreateFailExisting(bucketClass) {

--- a/pkg/bucketclass/reconciler.go
+++ b/pkg/bucketclass/reconciler.go
@@ -229,7 +229,7 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 				}
 			}
 		}
-	} 
+	}
 	if r.BucketClass.Spec.NamespacePolicy != nil {
 		nspType := r.BucketClass.Spec.NamespacePolicy.Type
 		var namespaceStoresArr []string
@@ -261,7 +261,7 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 			if nsStore.Status.Phase != nbv1.NamespaceStorePhaseReady {
 				return fmt.Errorf("NooBaa NamespaceStore %q is not yet ready", name)
 			}
-			if nsStore.Spec.Type == nbv1.NSStoreTypeNSFS && nspType != nbv1.NSBucketClassTypeSingle{
+			if nsStore.Spec.Type == nbv1.NSStoreTypeNSFS && nspType != nbv1.NSBucketClassTypeSingle {
 				return util.NewPersistentError("InvalidNamespaceStoreTypes", fmt.Sprintf("NSFS NamespaceStore %q is allowed on bucketclass of type Single", name))
 			}
 		}
@@ -389,7 +389,6 @@ func (r *Reconciler) updateNamespaceBucketClass(bucketNames []string) error {
 		}
 
 		for i := range bucketNames {
-
 			createBucketParams.Name = bucketNames[i]
 			err := r.NBClient.UpdateBucketAPI(*createBucketParams)
 
@@ -409,6 +408,7 @@ func (r *Reconciler) UpdateBucketClass(bucketNames []string) error {
 	if r.BucketClass == nil {
 		return fmt.Errorf("BucketClass not loaded %#v", r)
 	}
+
 
 	if r.BucketClass.Spec.PlacementPolicy == nil &&
 		r.BucketClass.Spec.NamespacePolicy != nil {
@@ -456,6 +456,8 @@ func (r *Reconciler) UpdateBucketClass(bucketNames []string) error {
 		return util.NewPersistentError("InvalidConfReverting", fmt.Sprintf("Unable to change bucketclass due to error: %v", result.ErrorMessage))
 		// return fmt.Errorf("Failed to update bucket class %q with error: %v - Reverting back", r.BucketClass.Name, result.ErrorMessage)
 	}
+
+
 
 	log.Infof("✅ Successfully updated bucket class %q", r.BucketClass.Name)
 	return nil

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -455,7 +455,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_bucketclasses_crd_yaml = "f8103950e9d3f6a0a8b61c32d26201799310268dd67a2673e4c2035679397c42"
+const Sha256_deploy_crds_noobaa_io_bucketclasses_crd_yaml = "4fe0737b2fe7ab77e80ca6518cd6e9ce7fa4f4c3ff18990142f4ffd7bc7db4c1"
 
 const File_deploy_crds_noobaa_io_bucketclasses_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -584,6 +584,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              replicationPolicy:
+                description: ReplicationPolicy specifies a json of replication rules
+                  for the bucketclass
+                type: string
             type: object
           status:
             description: Most recently observed status of the noobaa BackingStore.

--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -55,6 +55,9 @@ type Client interface {
 	UpdateEndpointGroupAPI(UpdateEndpointGroupParams) error
 
 	RegisterToCluster() error
+
+	PutBucketReplicationAPI(BucketReplicationParams) error
+	ValidateReplicationAPI(BucketReplicationParams) error
 }
 
 // ReadAuthAPI calls auth_api.read_auth()
@@ -378,5 +381,17 @@ func (c *RPCClient) UpdateEndpointGroupAPI(params UpdateEndpointGroupParams) err
 // RegisterToCluster calls redirector_api.RegisterToCluster()
 func (c *RPCClient) RegisterToCluster() error {
 	req := &RPCMessage{API: "redirector_api", Method: "register_to_cluster"}
+	return c.Call(req, nil)
+}
+
+// PutBucketReplicationAPI calls bucket_api.put_bucket_replication()
+func (c *RPCClient) PutBucketReplicationAPI(params BucketReplicationParams) error {
+	req := &RPCMessage{API: "bucket_api", Method: "put_bucket_replication", Params: params}
+	return c.Call(req, nil)
+}
+
+// ValidateReplicationAPI calls bucket_api.validate_replication()
+func (c *RPCClient) ValidateReplicationAPI(params BucketReplicationParams) error {
+	req := &RPCMessage{API: "bucket_api", Method: "validate_replication", Params: params}
 	return c.Call(req, nil)
 }

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -316,15 +316,15 @@ type CreateBucketParams struct {
 
 // NamespaceBucketInfo is the information needed for creating namespace bucket
 type NamespaceBucketInfo struct {
-	WriteResource NamespaceResourceFullConfig     `json:"write_resource"`
-	ReadResources []NamespaceResourceFullConfig   `json:"read_resources,omitempty"`
-	Caching       *CacheSpec `json:"caching,omitempty"`
+	WriteResource NamespaceResourceFullConfig   `json:"write_resource"`
+	ReadResources []NamespaceResourceFullConfig `json:"read_resources,omitempty"`
+	Caching       *CacheSpec                    `json:"caching,omitempty"`
 }
 
-// NamespaceResourceFullConfig is the resource configuration for creating namespace bucket 
+// NamespaceResourceFullConfig is the resource configuration for creating namespace bucket
 type NamespaceResourceFullConfig struct {
-	Resource string     `json:"resource"`
-	Path string   `json:"path,omitempty"`
+	Resource string `json:"resource"`
+	Path     string `json:"path,omitempty"`
 }
 
 // CacheSpec specifies the cache specifications for the bucket class
@@ -420,14 +420,14 @@ type CreateNamespaceResourceParams struct {
 	Name           string              `json:"name"`
 	Connection     string              `json:"connection"`
 	TargetBucket   string              `json:"target_bucket"`
-	NSFSConfig     *NSFSConfig          `json:"nsfs_config,omitempty"`
+	NSFSConfig     *NSFSConfig         `json:"nsfs_config,omitempty"`
 	NamespaceStore *NamespaceStoreInfo `json:"namespace_store,omitempty"`
 }
 
 // NSFSConfig is the namespace fs config needed for creating namespace resource of type fs()
 type NSFSConfig struct {
-	FsBackend string `json:"fs_backend,omitempty"`
-	FsRootPath    string `json:"fs_root_path,omitempty"`
+	FsBackend  string `json:"fs_backend,omitempty"`
+	FsRootPath string `json:"fs_root_path,omitempty"`
 }
 
 // CreateTierParams is the reply of tier_api.create_tier()
@@ -508,6 +508,12 @@ type UpdateBucketClassParams struct {
 	Name   string            `json:"name"`
 	Policy TieringPolicyInfo `json:"policy"`
 	Tiers  []TierInfo        `json:"tiers"`
+}
+
+// BucketReplicationParams is the params of bucket_api.put_bucket_replication()
+type BucketReplicationParams struct {
+	Name              string        `json:"name"`
+	ReplicationPolicy []interface{} `json:"replication_policy"`
 }
 
 // BucketClassInfo is the is the reply of tiering_policy_api.update_bucket_class()

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.8.0-20210519"
+	ContainerImageTag = "5.9.0-20210722"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -564,7 +564,7 @@ func GetPodLogs(pod corev1.Pod) (map[string]io.ReadCloser, error) {
 			podLogs, err := req.Stream(ctx)
 			if err != nil {
 				// do not warn about lack of additional previous logs, i.e. when nameSuffix is set
-				if  nameSuffix == nil {
+				if nameSuffix == nil {
 					log.Printf(`Could not read logs %s container %s, reason: %s`, pod.Name, container.Name, err)
 				}
 				return
@@ -1651,4 +1651,23 @@ func DeleteStorageClass(sc *storagev1.StorageClass) error {
 	}
 	log.Infof("deleted storageclass %v successfully", sc.Name)
 	return nil
+}
+
+// LoadBucketReplicationJSON loads the bucket replication from a json file
+func LoadBucketReplicationJSON(replicationJSONFilePath string) (string, error) {
+
+	logrus.Infof("loading bucket replication %v", replicationJSONFilePath)
+	bytes, err := ioutil.ReadFile(replicationJSONFilePath)
+	if err != nil {
+		return "", fmt.Errorf("Failed to read file %q: %v", replicationJSONFilePath, err)
+	}
+	var replicationJSON []interface{}
+	err = json.Unmarshal(bytes, &replicationJSON)
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse json file %q: %v", replicationJSONFilePath, err)
+	}
+
+	logrus.Infof("✅ Successfully loaded bucket replication %v", string(bytes))
+
+	return string(bytes), nil
 }


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Added bucket replication to bucketclass create cli command (both namespace and placement bucketsclasses types)
2. Added to bucketclass CRD replication policy - it's a name of a config map with a  replicationPolicyJSON property which contains a json with a replication_policy root field.
3. Added to util a function which loads the json and is used in both bucketclass reconciler and in provisioner.
4. Added an rpc call to put_bucket_replication in provisioner (after creation of an obc).
5. Added an rpc call to update_bucket_class_replication in bucketclass reconciler.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1.  tests shouldn't pass until i'll update the core version