### PR TITLE
removed tiering creation with default bucket class for namespace bucket

### DIFF
--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -366,19 +366,6 @@ func (r *BucketRequest) CreateBucket(
 		var readResources []nb.NamespaceResourceFullConfig
 		createBucketParams.Namespace = &nb.NamespaceBucketInfo{}
 
-		if r.BucketClass.Spec.PlacementPolicy == nil { // For none-caching will use default bucket class
-			defaultBucketClass, err := GetDefaultBucketClass(p, bucketOptions)
-			if err != nil {
-				return fmt.Errorf("GetDefaultBucketClass for NamespacePolicy failed with error: %v", err)
-			}
-
-			tierName, err := r.CreateTieringStructure(*defaultBucketClass)
-			if err != nil {
-				return fmt.Errorf("CreateTieringStructure for NamespacePolicy failed to create policy %q with error: %v", tierName, err)
-			}
-			createBucketParams.Tiering = tierName
-		}
-
 		if namespacePolicyType == nbv1.NSBucketClassTypeSingle {
 			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{
 				Resource: r.BucketClass.Spec.NamespacePolicy.Single.Resource,

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1230,6 +1230,11 @@ func (r *Reconciler) UpdateBucketClassesPhase(Buckets []nb.BucketInfo) {
 		bc := &bucketclassList.Items[i]
 		for _, bucket := range Buckets {
 
+			// in case of a namespace bucket, we might not have bucket.Tiering. skip
+			if bucket.Tiering == nil {
+				continue
+			}
+
 			bucketTieringPolicyName := ""
 			if bucket.BucketClaim != nil {
 				bucketTieringPolicyName = bucket.BucketClaim.BucketClass


### PR DESCRIPTION
* when creating a namespace bucket with OBC the provisioned created a dummy tiering policy with the default bucket class. this was to work around a bug in noobaa core where the internal resource was assigned to the bucket, but it doesn't exist in OCD DS.
* removed the tiering creation for namespace resource and fixed the issue in noobaa-core - https://github.com/noobaa/noobaa-core/pull/6663

fix for https://bugzilla.redhat.com/show_bug.cgi?id=1981331