### PR TITLE
if dbtype is not provided try to infer it from the db image name

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -3,7 +3,6 @@ package system
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -227,14 +226,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 		c := &podSpec.Containers[i]
 		if c.Name == "db" {
 
-			c.Image = options.DBImage
-			if os.Getenv("NOOBAA_DB_IMAGE") != "" {
-				c.Image = os.Getenv("NOOBAA_DB_IMAGE")
-			}
-			if r.NooBaa.Spec.DBImage != nil {
-				c.Image = *r.NooBaa.Spec.DBImage
-			}
-
+			c.Image = GetDesiredDBImage(r.NooBaa)
 			if r.NooBaa.Spec.DBResources != nil {
 				c.Resources = *r.NooBaa.Spec.DBResources
 			}
@@ -302,7 +294,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 	} else {
 		// upgrade path add new resources,
 		// merge the volumes & volumeMounts from the template
-		util.MergeVolumeList( &NooBaaDB.Spec.Template.Spec.Volumes, &NooBaaDBTemplate.Spec.Template.Spec.Volumes)
+		util.MergeVolumeList(&NooBaaDB.Spec.Template.Spec.Volumes, &NooBaaDBTemplate.Spec.Template.Spec.Volumes)
 		for i := range NooBaaDB.Spec.Template.Spec.Containers {
 			util.MergeVolumeMountList(&NooBaaDB.Spec.Template.Spec.Containers[i].VolumeMounts, &NooBaaDBTemplate.Spec.Template.Spec.Containers[i].VolumeMounts)
 		}
@@ -355,7 +347,7 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			}
 
 		case "NOOBAA_LOG_LEVEL":
-				c.Env[j].Value = strconv.Itoa(r.NooBaa.Spec.DebugLevel)
+			c.Env[j].Value = strconv.Itoa(r.NooBaa.Spec.DebugLevel)
 
 		case "POSTGRES_HOST":
 			c.Env[j].Value = r.NooBaaPostgresDB.Name + "-0." + r.NooBaaPostgresDB.Spec.ServiceName

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -278,10 +278,10 @@ func RunDelete(cmd *cobra.Command, args []string) {
 
 		} else {
 			log.Infof("Deleting All object buckets in namespace %q", options.Namespace)
-			// deletion of OBCSC 
+			// deletion of OBCSC
 			sc := &storagev1.StorageClass{}
 			sc.Name = options.SubDomainNS()
-			if  err := util.DeleteStorageClass(sc); err != nil {
+			if err := util.DeleteStorageClass(sc); err != nil {
 				log.Errorf("failed to delete storageclass %q", sc.Name)
 			}
 			util.RemoveFinalizer(sys, nbv1.GracefulFinalizer)
@@ -893,8 +893,22 @@ func Connect(isExternal bool) (*Client, error) {
 	}, nil
 }
 
+// GetDesiredDBImage returns the desired DB image according to spec or env or default (in options)
+func GetDesiredDBImage(sys *nbv1.NooBaa) string {
+	if sys.Spec.DBImage != nil {
+		return *sys.Spec.DBImage
+	}
+
+	if os.Getenv("NOOBAA_DB_IMAGE") != "" {
+		return os.Getenv("NOOBAA_DB_IMAGE")
+	}
+
+	return options.DBImage
+}
+
 // CheckSystem checks the state of the system and initializes its status fields
 func CheckSystem(sys *nbv1.NooBaa) bool {
+	log := util.Logger()
 	found := util.KubeCheck(sys)
 	if sys.Status.Accounts == nil {
 		sys.Status.Accounts = &nbv1.AccountsStatus{}
@@ -902,11 +916,24 @@ func CheckSystem(sys *nbv1.NooBaa) bool {
 	if sys.Status.Services == nil {
 		sys.Status.Services = &nbv1.ServicesStatus{}
 	}
-	// load defaults
-	// TODO: This is a temp patch it can be overriden by actually loading from the CR this is just a patch in memory
+
+	// a hack to better set the DBType in cases where DBType is not set.
+	// if dbtype is not set, try to infer it from the db image. this only update dbtype in memory
 	if sys.Spec.DBType == "" {
-		sys.Spec.DBType = "mongodb" // = defaults.DBType
+		dbImage := GetDesiredDBImage(sys)
+		if strings.Contains(dbImage, "postgres") {
+			log.Infof("dbType was not supplied. according to image (%s) setting dbType to postgres", dbImage)
+			sys.Spec.DBType = "postgres"
+		} else {
+			if strings.Contains(dbImage, "mongo") {
+				log.Infof("dbType was not supplied. according to image (%s) setting dbType to mongodb", dbImage)
+			} else {
+				log.Warnf("dbType was not supplied and it cannot be guessed from from the dbImage (%s). setting dbType to mongodb", dbImage)
+			}
+			sys.Spec.DBType = "mongodb"
+		}
 	}
+
 	return found && sys.UID != ""
 }
 


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

since dbType is optional in our CRD it is sometimes omitted in the CR. if it is not supplied then try to infer it from the DB image so it will match

fix for https://bugzilla.redhat.com/show_bug.cgi?id=1969677

