### PR TITLE
Added ability to update BackingStore external connection

### DIFF
--- a/build/gen-odf-package.sh
+++ b/build/gen-odf-package.sh
@@ -27,7 +27,7 @@ head -n ${n} ${MANIFESTS}/${CSV_NAME} > ${temp_csv}
 cat >> ${temp_csv} << EOF
   relatedImages:
   - image: ${CORE_IMAGE}
-    name: noboaa-core
+    name: noobaa-core
   - image: ${DB_IMAGE}
     name: noobaa-db
   - image: ${OPERATOR_IMAGE}

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 	k8s.io/kubectl v0.21.3
+	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471
 	nhooyr.io/websocket v1.7.4
 	sigs.k8s.io/controller-runtime v0.9.5
 	sigs.k8s.io/yaml v1.2.0

--- a/pkg/admission/test/integ/admission_integ_test.go
+++ b/pkg/admission/test/integ/admission_integ_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Admission server integration tests", func() {
 				testNamespacestore.Spec = nbv1.NamespaceStoreSpec{
 					Type: nbv1.NSStoreTypeS3Compatible,
 					S3Compatible: &nbv1.S3CompatibleSpec{
-						TargetBucket: "test.bucket",
+						TargetBucket: "first.bucket",
 						Endpoint:     "s3." + namespace + ".svc.cluster.local:443",
 						Secret: corev1.SecretReference{
 							Name:      "noobaa-admin",

--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -584,7 +584,7 @@ func MapBackingstoreToBucketclasses(backingstore types.NamespacedName) []reconci
 		TypeMeta: metav1.TypeMeta{Kind: "BucketClassList"},
 	}
 	if !util.KubeList(bucketclassList, &client.ListOptions{Namespace: backingstore.Namespace}) {
-		log.Infof("did not find backing stores in namespace %q", backingstore.Namespace)
+		log.Infof("Could not found bucketClasses in namespace %q", backingstore.Namespace)
 		return nil
 	}
 

--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -48,8 +48,8 @@ type Client interface {
 	UpdateBucketClass(UpdateBucketClassParams) (BucketClassInfo, error)
 
 	AddExternalConnectionAPI(AddExternalConnectionParams) error
-	CheckExternalConnectionAPI(AddExternalConnectionParams) (CheckExternalConnectionReply, error)
-	EditExternalConnectionCredentialsAPI(EditExternalConnectionCredentialsParams) error
+	CheckExternalConnectionAPI(CheckExternalConnectionParams) (CheckExternalConnectionReply, error)
+	UpdateExternalConnectionAPI(UpdateExternalConnectionParams) error
 	DeleteExternalConnectionAPI(DeleteExternalConnectionParams) error
 
 	UpdateEndpointGroupAPI(UpdateEndpointGroupParams) error
@@ -354,7 +354,7 @@ func (c *RPCClient) AddExternalConnectionAPI(params AddExternalConnectionParams)
 }
 
 // CheckExternalConnectionAPI calls account_api.check_external_connection()
-func (c *RPCClient) CheckExternalConnectionAPI(params AddExternalConnectionParams) (CheckExternalConnectionReply, error) {
+func (c *RPCClient) CheckExternalConnectionAPI(params CheckExternalConnectionParams) (CheckExternalConnectionReply, error) {
 	req := &RPCMessage{API: "account_api", Method: "check_external_connection", Params: params}
 	res := &struct {
 		RPCMessage `json:",inline"`
@@ -364,9 +364,9 @@ func (c *RPCClient) CheckExternalConnectionAPI(params AddExternalConnectionParam
 	return res.Reply, err
 }
 
-// EditExternalConnectionCredentialsAPI calls account_api.edit_external_connection_credentials()
-func (c *RPCClient) EditExternalConnectionCredentialsAPI(params EditExternalConnectionCredentialsParams) error {
-	req := &RPCMessage{API: "account_api", Method: "edit_external_connection_credentials", Params: params}
+// UpdateExternalConnectionAPI calls account_api.update_external_connection()
+func (c *RPCClient) UpdateExternalConnectionAPI(params UpdateExternalConnectionParams) error {
+	req := &RPCMessage{API: "account_api", Method: "update_external_connection", Params: params}
 	return c.Call(req, nil)
 }
 

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -62,7 +62,7 @@ type AccountInfo struct {
 	// NsfsAccountConfig specifies the configurations on Namespace FS
 	// +nullable
 	// +optional
-	NsfsAccountConfig *nbv1.AccountNsfsConfig	`json:"nsfs_account_config,omitempty"`
+	NsfsAccountConfig *nbv1.AccountNsfsConfig `json:"nsfs_account_config,omitempty"`
 }
 
 // BucketInfo is a struct of bucket info returned by the API
@@ -399,15 +399,15 @@ type AccountAllowedBuckets struct {
 
 // CreateAccountParams is the params of account_api.create_account()
 type CreateAccountParams struct {
-    Name              string                    `json:"name"`
-    Email             string                    `json:"email"`
-    HasLogin          bool                      `json:"has_login"`
-    S3Access          bool                      `json:"s3_access"`
-    AllowBucketCreate bool                      `json:"allow_bucket_creation"`
-    AllowedBuckets    AccountAllowedBuckets     `json:"allowed_buckets"`
-    DefaultResource   string                    `json:"default_resource,omitempty"`
-    BucketClaimOwner  string                    `json:"bucket_claim_owner,omitempty"`
-    NsfsAccountConfig *nbv1.AccountNsfsConfig   `json:"nsfs_account_config,omitempty"`
+	Name              string                  `json:"name"`
+	Email             string                  `json:"email"`
+	HasLogin          bool                    `json:"has_login"`
+	S3Access          bool                    `json:"s3_access"`
+	AllowBucketCreate bool                    `json:"allow_bucket_creation"`
+	AllowedBuckets    AccountAllowedBuckets   `json:"allowed_buckets"`
+	DefaultResource   string                  `json:"default_resource,omitempty"`
+	BucketClaimOwner  string                  `json:"bucket_claim_owner,omitempty"`
+	NsfsAccountConfig *nbv1.AccountNsfsConfig `json:"nsfs_account_config,omitempty"`
 }
 
 // CreateAccountReply is the reply of account_api.create_account()
@@ -418,7 +418,7 @@ type CreateAccountReply struct {
 
 // GenerateAccountKeysParams is the params of account_api.generate_account_keys()
 type GenerateAccountKeysParams struct {
-	Email             string                `json:"email"`
+	Email string `json:"email"`
 }
 
 // ResetPasswordParams is the params of account_api.reset_password()
@@ -556,12 +556,12 @@ type DeleteNamespaceResourceParams struct {
 
 // UpdateAccountS3AccessParams is the params of account_api.update_account_s3_access()
 type UpdateAccountS3AccessParams struct {
-    Email               string                  `json:"email"`
-    S3Access            bool                    `json:"s3_access"`
-    DefaultResource     *string                 `json:"default_resource,omitempty"`
-    AllowBucketCreation *bool                   `json:"allow_bucket_creation,omitempty"`
-    AllowBuckets        *AllowedBuckets         `json:"allowed_buckets,omitempty"`
-    NsfsAccountConfig   *nbv1.AccountNsfsConfig `json:"nsfs_account_config,omitempty"`
+	Email               string                  `json:"email"`
+	S3Access            bool                    `json:"s3_access"`
+	DefaultResource     *string                 `json:"default_resource,omitempty"`
+	AllowBucketCreation *bool                   `json:"allow_bucket_creation,omitempty"`
+	AllowBuckets        *AllowedBuckets         `json:"allowed_buckets,omitempty"`
+	NsfsAccountConfig   *nbv1.AccountNsfsConfig `json:"nsfs_account_config,omitempty"`
 }
 
 // UpdateDefaultResourceParams is the params of bucket_api.update_all_buckets_default_pool()
@@ -670,6 +670,17 @@ type AddExternalConnectionParams struct {
 	Region       string          `json:"region,omitempty"`
 }
 
+// CheckExternalConnectionParams is the params of account_api.check_external_connection()
+type CheckExternalConnectionParams struct {
+	Name                   string          `json:"name"`
+	EndpointType           EndpointType    `json:"endpoint_type"`
+	Endpoint               string          `json:"endpoint"`
+	Identity               string          `json:"identity"`
+	Secret                 string          `json:"secret"`
+	AuthMethod             CloudAuthMethod `json:"auth_method,omitempty"`
+	IgnoreNameAlreadyExist bool            `json:"ignore_name_already_exist,omitempty"`
+}
+
 // CheckExternalConnectionReply is the reply of account_api.check_external_connection()
 type CheckExternalConnectionReply struct {
 	Status ExternalConnectionStatus `json:"status"`
@@ -679,8 +690,8 @@ type CheckExternalConnectionReply struct {
 	} `json:"error,omitempty"`
 }
 
-// EditExternalConnectionCredentialsParams is the params of account_api.edit_external_connection_credentials()
-type EditExternalConnectionCredentialsParams struct {
+// UpdateExternalConnectionParams is the params of account_api.update_external_connection()
+type UpdateExternalConnectionParams struct {
 	Name     string `json:"name"`
 	Identity string `json:"identity"`
 	Secret   string `json:"secret"`

--- a/test/cli/resources/empty-secret.yaml
+++ b/test/cli/resources/empty-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: empty-secret
+type: Opaque
+stringData:

--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -7,50 +7,6 @@ export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} 
 
 NAMESPACE='test'
 
-#FLOW TODO:
-# # AWS-S3 ❌
-# nb backingstore create aws-s3 aws1 --target-bucket znoobaa --access-key $AWS_ACCESS_KEY_ID --secret-key $AWS_SECRET_ACCESS_KEY ❌
-# nb backingstore create aws-s3 aws2 --target-bucket noobaa-qa --access-key $AWS_ACCESS_KEY_ID --secret-key $AWS_SECRET_ACCESS_KEY ❌
-# nb backingstore status aws1 ❌
-# nb backingstore status aws2 ❌
-# nb backingstore list ❌
-# nb status ❌
-# kubectl get backingstore ❌
-# kubectl describe backingstore ❌
-
-# # Google - TODO ❌
-# nb backingstore create azure-blob blob1 --target-blob-container jacky-container --account-name $AZURE_ACCOUNT_NAME --account-key $AZURE_ACCOUNT_KEY
-
-# # Azure - TODO ❌
-# nb backingstore create google-cloud-storage google1 --target-bucket jacky-bucket --private-key-json-file ~/Downloads/noobaa-test-1-d462775d1e1a.json
-
-# # BucketClass ❌
-# nb bucketclass create class1 --backingstores nb1 ✅
-# nb bucketclass create class2 --placement Mirror --backingstores nb1,aws1 ❌
-# nb bucketclass create class3 --placement Spread --backingstores aws1,aws2 ❌
-# nb bucketclass create class4 --backingstores nb1,nb2 ✅
-# nb bucketclass status class1 ✅
-# nb bucketclass status class2 ✅
-# nb bucketclass list ✅
-# nb status ✅
-# kubectl get bucketclass ✅
-# kubectl describe bucketclass ✅
-
-# # OBC ❌
-# nb obc create buck1 --bucketclass class1 ✅
-# nb obc create buck2 --bucketclass class2 ❌
-# nb obc create buck3 --bucketclass class3 --app-namespace default ❌
-# nb obc create buck4 --bucketclass class4 ✅
-# nb obc list ✅
-# # nb obc status buck1 ✅
-# # nb obc status buck2 ✅
-# # nb obc status buck3 ✅
-# kubectl get obc ✅
-# kubectl describe obc ✅
-# kubectl get obc,ob,secret,cm -l noobaa-obc ✅
-
-# AWS_ACCESS_KEY_ID=XXX AWS_SECRET_ACCESS_KEY=YYY aws s3 --endpoint-url XXX ls BUCKETNAME ❌
-
 function post_install_tests {
     aws_credentials
     check_pv_pool_resources


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

related to https://github.com/noobaa/noobaa-operator/issues/684

### Explain the changes
1. Added a Watch on backing-store Secret events to detect a change in the secret and trigger  a reconcile.
2. Changed `EditExternalConnectionCredentialsAPI` (seems unused) to `UpdateExternalConnectionAPI` to call the relevant  RPC call when needed.
3. Added detection of a mismatch in the used connection by the operator and trying to update the connection.
4. the mismatch found on the reconciler will be based on secret key mismatch and will not detect a mismatch in the access key.

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=1992090

### Testing Instructions:
1. Create two backingstores with the same cloud credentials.
2. Create two namespacestores with the same cloud credentials.
