### PR TITLE
Adding confirmation check for uninstall command

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -107,6 +107,24 @@ func RunInstall(cmd *cobra.Command, args []string) {
 // RunUninstall runs a CLI command
 func RunUninstall(cmd *cobra.Command, args []string) {
 	log := util.Logger()
+	cleanup, _ := cmd.Flags().GetBool("cleanup")
+
+	if cleanup {
+		var decision string
+		
+		for {
+			log.Printf("--cleanup removes the CRDs and affecting all noobaa instances, are you sure? y/n ")
+			fmt.Scanln(&decision)
+
+			if (decision == "y") {
+				log.Printf("Will remove CRD (cluster scope)")
+				break
+			} else if (decision == "n") {
+				return
+			}
+		}
+	}
+
 	system.RunSystemVersionsStatus(cmd, args)
 	log.Printf("Namespace: %s", options.Namespace)
 	log.Printf("")
@@ -116,7 +134,6 @@ func RunUninstall(cmd *cobra.Command, args []string) {
 	log.Printf("Operator Delete:")
 	operator.RunUninstall(cmd, args)
 	log.Printf("")
-	cleanup, _ := cmd.Flags().GetBool("cleanup")
 	if cleanup {
 		log.Printf("CRD Delete:")
 		crd.RunDelete(cmd, args)

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -534,7 +534,7 @@ function noobaa_uninstall {
     [ ${check_cleanup_data_flag} -eq 0 ] && cleanup_data="--cleanup_data"
 
     echo_time "💬  Running uninstall ${cleanup} ${cleanup_data}"
-    test_noobaa --timeout uninstall ${cleanup} ${cleanup_data}
+    yes | test_noobaa --timeout uninstall ${cleanup} ${cleanup_data}
     if [ ${check_cleanflag} -eq 0 ]
     then
         check_if_cleanup


### PR DESCRIPTION
Since executing unintall command with --cleanup flag removes all CRDs
and affecting all noobaa instances, a confirmation check is added in
order to inform the user and verify that the above is the intended
action.

Fixed: #689

Signed-off-by: Barak Sason Rofman <sason922@gmail.com>