### PR TITLE
Restrict the max number of characters, for namespaceStore name, to 63

### DIFF
--- a/pkg/namespacestore/validation.go
+++ b/pkg/namespacestore/validation.go
@@ -68,6 +68,13 @@ func validateNsStoreNSFS(nsStore *nbv1.NamespaceStore) error {
 		}
 	}
 
+	//Check the mountPath
+	mountPath := "/nsfs/" + nsStore.Name
+	if len(mountPath) > 63 {
+		return util.NewPersistentError("InvalidMountPath",
+		fmt.Sprintf(" MountPath %v must be no more than 63 characters", mountPath))
+	}
+
 	return nil
 }
 

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -470,6 +470,12 @@ func (r *Reconciler) validateNsStoreNSFS(nsStore *nbv1.NamespaceStore) bool {
 		return false
 	}
 
+	//Check the mountPath
+	mountPath := "/nsfs/" + nsStore.Name
+	if len(mountPath) > 63 {		
+		return false
+	}
+
 	//SubPath validation
 	if nsfs.SubPath != "" {
 		path := nsfs.SubPath


### PR DESCRIPTION
Restrict the max number of characters, for namespaceStore name, to 63

```
$ build/_output/bin/noobaa-operator-local namespacestore create nsfs 1234567890123456789012345678901234567890123456789012345678901111 --fs-backend=GPFS --pvc-name='nsfs-vol'
INFO[0000] ✅ Exists: NooBaa "noobaa"
FATA[0000] ❌  MountPath /nsfs/1234567890123456789012345678901234567890123456789012345678901111 must be no more than 63 characters

Options:
      --fs-backend='': The file system backend type - CEPH_FS | GPFS | NFSv4
      --pvc-name='': The pvc name in which the file system resides
      --sub-path='': The path to a sub directory inside the pvc file system

Usage:
  noobaa namespacestore create nsfs <namespace-store-name> [flags] [options]

Use "noobaa options" for a list of global command-line options (applies to all commands).
```

Fixes: https://github.com/noobaa/noobaa-core/issues/6684

Signed-off-by: liranmauda <liran.mauda@gmail.com>