### PR TITLE
Support building noobaa-operator on ARM64 and other architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export GO111MODULE=on
 export GOPROXY:=https://proxy.golang.org
 
 TIME ?= time -p
+ARCH ?= $(shell uname -m)
 
 VERSION ?= $(shell go run cmd/version/main.go)
 IMAGE ?= noobaa/noobaa-operator:$(VERSION)

--- a/build/install-operator-sdk.sh
+++ b/build/install-operator-sdk.sh
@@ -21,12 +21,13 @@ then
 fi
 
 PLATFORM="$(uname)"
+ARCHITECTURE="$(uname -m)"
 if [ "${PLATFORM}" == "Darwin" ] 
 then 
-    SDK_RELEASE="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-apple-darwin"
+    SDK_RELEASE="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-${ARCHITECTURE}-apple-darwin"
 else 
     # Assuming that if not darwin then running on linux
-    SDK_RELEASE="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu"
+    SDK_RELEASE="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-${ARCHITECTURE}-linux-gnu"
 fi
 
 echo "installing version ${OPERATOR_SDK_VERSION}"


### PR DESCRIPTION
As of now NooBaa Operator cannot compile on architectures different from AMD64 at the moment due to two reasons:

- `x86_64` being hardcoded in [install-operator-sdk.sh](https://github.com/noobaa/noobaa-operator/blob/master/build/install-operator-sdk.sh).
- `operator-framework/operator-registry` only providing AMD64 images.

Both of these issues cause an `exec format error`. 

This PR allows `install-operator-sdk.sh` to download the binary for the correct architecture when launching the build process and updates the `Makefile` to include building locally the `operator-registry` image. With these changes, the operator can successfully compile on different architectures, such as `aarch64`.

Note that the installation with `nb install` will still hang due to `nooba-core` not supporting other architectures yet.