### PR TITLE
5.7: Delete the Old Service Monitor 

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -48,6 +48,7 @@ rules:
   - update
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3958,7 +3958,7 @@ spec:
                   fieldPath: metadata.namespace
 `
 
-const Sha256_deploy_role_yaml = "e86edfb70be11ea9af8f0f210bfbbf1bc1a71cc52806adfcf48c7b530425f8ed"
+const Sha256_deploy_role_yaml = "10f3aaa1472040cb33928ea5d042aa10b2075510dd5796765e4beb810243c1ed"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -4010,6 +4010,7 @@ rules:
   - update
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
- DeleteOldServiceMonitor updates the service monitor by removing the old format. This function should only be valid after upgrade from 5.6 to 5.7

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1973179
Signed-off-by: liranmauda <liran.mauda@gmail.com>