### PR TITLE
5.8: Delete Old Service Monitor BZ 1989557

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -48,6 +48,7 @@ rules:
   - update
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3993,7 +3993,7 @@ spec:
                   fieldPath: metadata.namespace
 `
 
-const Sha256_deploy_role_yaml = "eb0941a5e095fa7ac391e05782e6847e419e4d0dc17f6d8151df0032c977c743"
+const Sha256_deploy_role_yaml = "9096949fa4107c5c1b33f78ee97f7595f24c87f4321bc56d2e04658ab0623eb6"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -4045,6 +4045,7 @@ rules:
   - update
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -14,6 +14,7 @@ import (
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/option"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/marstr/randname"
 	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v2/pkg/bundle"
@@ -76,6 +77,9 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 		return err
 	}
 	if err := r.ReconcilePrometheusRule(); err != nil {
+		return err
+	}
+	if err := r.DeleteOldServiceMonitor(); err != nil {
 		return err
 	}
 	if err := r.ReconcileServiceMonitors(); err != nil {
@@ -1106,6 +1110,27 @@ func (r *Reconciler) UpdateBucketClassesPhase(Buckets []nb.BucketInfo) {
 			}
 		}
 	}
+}
+
+// DeleteOldServiceMonitor updates the service monitor by removing old format
+// This function should only be valid after upgrade from 5.6 to 5.7, 
+// it is here in 4.8 to avoid a situation where upgrading to 5.8 from a cluster that didn't 
+// went through this code in 5.7 (upgraded to a 5.7 patch version that does not include this code)  
+func (r *Reconciler) DeleteOldServiceMonitor() error {
+
+	OldMonitor := &monitoringv1.ServiceMonitor {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "noobaa-service-monitor",
+			Namespace: options.Namespace,
+		},
+	}
+	if util.KubeCheck(OldMonitor) {
+		if !util.KubeDelete(OldMonitor) {
+			return fmt.Errorf("Could not delete noobaa-service-monitor")
+		}
+	}
+
+	return nil
 }
 
 // ReconcileDeploymentEndpointStatus creates/updates the endpoints deployment


### PR DESCRIPTION
- DeleteOldServiceMonitor updates the service monitor by removing the old format. This function should only be valid after upgrade from 5.6 to 5.7. it is here in 4.8 to avoid a situation where upgrading to 5.8 from a cluster that didn't went through  this code in 5.7 (upgraded to a 5.7 patch version that does not include this code)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1989557
Signed-off-by: liranmauda <liran.mauda@gmail.com>