### PR TITLE
added make target to generate CSV for ODF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ GOHOSTOS ?= $(shell go env GOHOSTOS)
 OUTPUT ?= build/_output
 BIN ?= $(OUTPUT)/bin
 OLM ?= $(OUTPUT)/olm
+MANIFESTS ?= $(OUTPUT)/manifests
 VENV ?= $(OUTPUT)/venv
 
 # OPERATOR_SDK_VERSION is for build perpuse only, the dependencies themself are 
@@ -128,6 +129,12 @@ gen-olm: $(OPERATOR_SDK) gen
 	@echo "✅ gen-olm"
 .PHONY: gen-olm
 
+
+gen-odf-package: cli
+	rm -rf $(MANIFESTS)
+	MANIFESTS=$(MANIFESTS) CSV_NAME=$(csv-name) CORE_IMAGE=$(core-image) DB_IMAGE=$(db-image) OPERATOR_IMAGE=$(operator-image) build/gen-odf-package.sh
+	@echo "✅ gen-odf-package"
+.PHONY: gen-odf-package
 
 #-----------#
 #- Testing -#

--- a/build/gen-odf-package.sh
+++ b/build/gen-odf-package.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ "${MANIFESTS}" == "" ] || [ "${CSV_NAME}" == "" ] || [ "${CORE_IMAGE}" == "" ] || [ "${DB_IMAGE}" == "" ] || [ "${OPERATOR_IMAGE}" == "" ]
+then
+  echo "gen-odf-package.sh: not all required envs were supplied"
+  exit 1
+fi
+
+./build/_output/bin/noobaa-operator-local olm catalog -n openshift-storage --dir ${MANIFESTS} --odf --csv-name ${CSV_NAME} --noobaa-image ${CORE_IMAGE} --db-image ${DB_IMAGE} --operator-image ${OPERATOR_IMAGE}
+
+temp_csv=$(mktemp)
+
+grep -v "status: {}" ${MANIFESTS}/${CSV_NAME} > ${temp_csv}
+cat >> ${temp_csv} << EOF
+  relatedImages:
+  - image: ${CORE_IMAGE}
+    name: noboaa-core
+  - image: ${DB_IMAGE}
+    name: noobaa-db
+  - image: ${OPERATOR_IMAGE}
+    name: noobaa-operator
+EOF
+
+cp -f ${temp_csv} ${MANIFESTS}/${CSV_NAME}
+
+
+

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -210,6 +210,7 @@ type Conf struct {
 	SecurityContextConstraints *secv1.SecurityContextConstraints
 	SCCEndpoint                *secv1.SecurityContextConstraints
 	Deployment                 *appsv1.Deployment
+	HideOperator               bool
 }
 
 // LoadOperatorConf loads and initializes all the objects needed to install the operator
@@ -228,6 +229,7 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.SecurityContextConstraints = util.KubeObject(bundle.File_deploy_scc_yaml).(*secv1.SecurityContextConstraints)
 	c.SCCEndpoint = util.KubeObject(bundle.File_deploy_scc_endpoint_yaml).(*secv1.SecurityContextConstraints)
 	c.Deployment = util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
+	c.HideOperator = false
 
 	c.NS.Name = options.Namespace
 	c.SA.Namespace = options.Namespace


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

* added `gen-odf-package` make target to generate CSV and CRDs for ODF builds
* this target should be used with these required envs: 
```
csv-name=[csv yaml file name] core-image=[noobaa core image] operator-image=[noobaa operator image] db-image=[postgres db image]
```
* The files are generated under `build/_output/manifests`
