### PR TITLE
Added operator debugger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ TIME ?= time -p
 
 VERSION ?= $(shell go run cmd/version/main.go)
 IMAGE ?= noobaa/noobaa-operator:$(VERSION)
+DEV_IMAGE ?= noobaa/noobaa-operator-dev:$(VERSION)
 REPO ?= github.com/noobaa/noobaa-operator
 CATALOG_IMAGE ?= noobaa/noobaa-operator-catalog:$(VERSION)
 
@@ -52,6 +53,12 @@ image: $(OPERATOR_SDK) gen
 	$(OPERATOR_SDK) build $(IMAGE)
 	@echo "✅ image"
 .PHONY: image
+
+dev-image: $(OPERATOR_SDK) gen
+	$(OPERATOR_SDK) build --go-build-args "-gcflags all=-N -gcflags all=-l" $(IMAGE)
+	docker build -f build/DockerfileDev --build-arg base_image=$(IMAGE) -t $(DEV_IMAGE) .
+	@echo "✅ dev image"
+.PHONY: dev-image
 
 vendor:
 	go mod tidy

--- a/build/DockerfileDev
+++ b/build/DockerfileDev
@@ -1,0 +1,20 @@
+ARG base_image
+
+# Compile stage
+FROM golang AS build-env
+
+# Build Delve
+RUN go get github.com/go-delve/delve/cmd/dlv
+
+# Final stage
+FROM ${base_image}
+
+ENV WATCH_NAMESPACE=default
+
+EXPOSE 40000
+
+WORKDIR /
+COPY --from=build-env /go/bin/dlv /
+
+ENTRYPOINT ["/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/usr/local/bin/noobaa-operator"]
+CMD  ["operator", "run"]


### PR DESCRIPTION
Added operator debugger target.
Operator runs from dlv and listens on port 40000 for debugger connection. 

In order to debug the operator process from vscode inside container, perform the following:
1.  Create operator dev image
```
make dev-image
```
2. Edit operator pod or Install noobaa with --operator-image=<dev-image>, for example
```
noobaa install --operator-image=noobaa/noobaa-operator-dev:5.9.0
```
Note the operator will not run and wait for debugger connection.

3. Configure port-forwarder to the operator
```
kubectl port-forward <operator pod> 40000:40000
```
4. Add launch configuration to vscode:
```
{
            "name": "Connect to operator",
            "type": "go",
            "request": "attach",
            "mode": "remote",
            "remotePath": "${workspaceFolder}",
            "port": 40000,
            "host": "127.0.0.1"
},
```
5. Run the launcher


