### PR TITLE
fixed annotation for hiding noobaa operator in OCP UI

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -207,7 +207,7 @@ func GenerateCSV(opConf *operator.Conf) *operv1.ClusterServiceVersion {
 	csv.Annotations["containerImage"] = options.OperatorImage
 	// this annotation hides the operator in OCP console
 	if opConf.HideOperator {
-		csv.Annotations["operators.operatorframework.io/internal-objects"] = ""
+		csv.Annotations["operators.operatorframework.io/operator-type"] = "non-standalone"
 	}
 	// csv.Annotations["createdAt"] = ???
 	csv.Annotations["alm-examples"] = string(almExamples)


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

the wrong annotation was used before. 

these are the correct values: 
https://github.com/openshift/console/blob/22c6951efe7c4bca87f3f934063b9f4dcb0a4058/frontend/packages/operator-lifecycle-manager/src/const.ts#L22-L23

This will trigger the following behavior in the console: 
https://github.com/openshift/console/blob/71167b267da5907553a88f588b8f16b38cda5585/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx#L81-L87

