### PR TITLE
[Backport to 5.9] - fixed annotation for hiding noobaa operator in OCP ui

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -207,7 +207,7 @@ func GenerateCSV(opConf *operator.Conf) *operv1.ClusterServiceVersion {
 	csv.Annotations["containerImage"] = options.OperatorImage
 	// this annotation hides the operator in OCP console
 	if opConf.HideOperator {
-		csv.Annotations["operators.operatorframework.io/internal-objects"] = ""
+		csv.Annotations["operators.operatorframework.io/operator-type"] = "non-standalone"
 	}
 	// csv.Annotations["createdAt"] = ???
 	csv.Annotations["alm-examples"] = string(almExamples)


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 0451dfd66a9cbb5f5ddeefa62197d706f7e2f092)