### PR TITLE
Fixing an upgrade 5.8 to 4.9 flow where we are not setting the correct SCC to the endpoint.

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -271,6 +271,7 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 	rootUIDGid := int64(0)
 	podSpec.SecurityContext.RunAsUser = &rootUIDGid
 	podSpec.SecurityContext.RunAsGroup = &rootUIDGid
+	podSpec.ServiceAccountName = "noobaa-endpoint"
 
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]


### PR DESCRIPTION
- Fixing an upgrade 5.8 to 4.9 flow where we are not setting the correct SCC to the endpoint.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1991256

Signed-off-by: liranmauda <liran.mauda@gmail.com>