### PR TITLE
fixed manual-build.yml OPERATOR_BUNDLE_TAGS

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -37,7 +37,7 @@ jobs:
           echo "::warning ${VERSION}"
           echo ::set-output name=version::${VERSION}
           OPERATOR_TAGS="${DOCKER_OPERATOR_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          OPERATOR_BUNDLE_TAGS="${DOCKER_OPERATOR_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
+          OPERATOR_BUNDLE_TAGS="${DOCKER_OPERATOR_BUNDLE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
           echo "::warning ${CORE_TAGS}"
           echo ::set-output name=operatortags::${OPERATOR_TAGS}
           echo ::set-output name=operatorbundletags::${OPERATOR_BUNDLE_TAGS}


### PR DESCRIPTION
bundle image used the same name as operator image. fixed to use `DOCKER_OPERATOR_BUNDLE_IMAGE`

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

