### PR TITLE
Adding timeout to RGW S3 https client

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -983,9 +983,10 @@ func (r *Reconciler) prepareCephBackingStore() error {
 
 	region := "us-east-1"
 	forcePathStyle := true
-	// temp solution
-	disableSSL := true
-	insecureClient := &http.Client{Transport: util.InsecureHTTPTransport}
+	insecureClient := &http.Client{
+		Transport: util.InsecureHTTPTransport,
+		Timeout: 10 * time.Second, 
+	}
 
 	s3Config := &aws.Config{
 		Credentials: credentials.NewStaticCredentials(
@@ -996,7 +997,6 @@ func (r *Reconciler) prepareCephBackingStore() error {
 		Endpoint:         &endpoint,
 		Region:           &region,
 		S3ForcePathStyle: &forcePathStyle,
-		DisableSSL:       &disableSSL,
 		HTTPClient:       insecureClient,
 	}
 


### PR DESCRIPTION
Seems to fix issue of x509: certificate signed by unknown authority
based on this:
https://community.ory.sh/t/problem-with-tls-certificate-signed-by-unknown-authority-using-hydra-client-go/2053

Signed-off-by: jackyalbo <jalbo@redhat.com>