### PR TITLE
Backport to 5.9 initdb huge_pages

### DIFF
--- a/deploy/internal/configmap-postgres-initdb.yaml
+++ b/deploy/internal/configmap-postgres-initdb.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noobaa-postgres-initdb-sh
+  labels:
+    app: noobaa
+data:
+  initdb.sh: |
+          # If the config file is present, the DB is initiazed
+          # and we're out of here
+          export PGDATA=$HOME/data/userdata
+          if [ -f $PGDATA/postgresql.conf ]; then
+            echo postgresql.conf file is found
+            exit 0
+          fi
+
+          # Wrap the postgres binary, force huge_pages=off for initdb
+          # see https://bugzilla.redhat.com/show_bug.cgi?id=1946792
+          p=/opt/rh/rh-postgresql12/root/usr/bin/postgres
+          mv $p $p.orig
+          echo exec $p.orig \"\$@\" -c huge_pages=off > $p
+          chmod 755 $p
+
+          # The NooBaa DB runs with UID 10001 GID 0
+          sed -i -e 's/^\(postgres:[^:]\):[0-9]*:[0-9]*:/\1:10001:0:/' /etc/passwd
+
+          # Init the DB and exit once the DB is ready to run
+          sed -i -e 's/^exec.*$/exit 0/' \
+                 -e 's/^pg_ctl\sstart.*/pg_ctl start || true/'                                   \
+                    /usr/bin/run-postgresql
+          su postgres -c "bash -x /usr/bin/run-postgresql"

--- a/deploy/internal/statefulset-db.yaml
+++ b/deploy/internal/statefulset-db.yaml
@@ -18,7 +18,7 @@ spec:
         app: noobaa
         noobaa-db: noobaa
     spec:
-      serviceAccountName: noobaa
+      serviceAccountName: noobaa-endpoint
       terminationGracePeriodSeconds: 60
       initContainers:
       #----------------#

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -18,11 +18,11 @@ spec:
         app: noobaa
         noobaa-db: postgres
     spec:
-      serviceAccountName: noobaa
+      serviceAccountName: noobaa-endpoint
       initContainers:
-      #----------------#
-      # INIT CONTAINER #
-      #----------------#
+      #-----------------#
+      # INIT CONTAINERS #
+      #-----------------#
       - name: init
         image: NOOBAA_CORE_IMAGE
         command:
@@ -38,6 +38,32 @@ spec:
         volumeMounts:
         - name: db
           mountPath: /var/lib/pgsql
+      - name: initialize-database
+        image: NOOBAA_DB_IMAGE
+        env:
+          - name: POSTGRESQL_DATABASE
+            value: nbcore
+          - name: POSTGRESQL_USER
+          - name: POSTGRESQL_PASSWORD
+        command:
+        - sh
+        - -x
+        - /init/initdb.sh
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "500Mi"
+          limits:
+            cpu: "500m"
+            memory: "500Mi"
+        volumeMounts:
+        - name: db
+          mountPath: /var/lib/pgsql
+        - name: noobaa-postgres-initdb-sh-volume
+          mountPath: /init
       containers:
       #--------------------#
       # Postgres CONTAINER #
@@ -64,10 +90,15 @@ spec:
             mountPath: /var/lib/pgsql
           - name: noobaa-postgres-config-volume
             mountPath: /opt/app-root/src/postgresql-cfg
+          - name: noobaa-postgres-initdb-sh-volume
+            mountPath: /init
       volumes:
       - name: noobaa-postgres-config-volume
         configMap:
           name: noobaa-postgres-config
+      - name: noobaa-postgres-initdb-sh-volume
+        configMap:
+          name: noobaa-postgres-initdb-sh
       securityContext: 
         runAsUser: 10001
         runAsGroup: 0

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2355,6 +2355,41 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
+const Sha256_deploy_internal_configmap_postgres_initdb_yaml = "4d18ac61f52f46c0764b8ae4f1a17912c3afda2f1655406ae338579cc3821bed"
+
+const File_deploy_internal_configmap_postgres_initdb_yaml = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noobaa-postgres-initdb-sh
+  labels:
+    app: noobaa
+data:
+  initdb.sh: |
+          # If the config file is present, the DB is initiazed
+          # and we're out of here
+          export PGDATA=$HOME/data/userdata
+          if [ -f $PGDATA/postgresql.conf ]; then
+            echo postgresql.conf file is found
+            exit 0
+          fi
+
+          # Wrap the postgres binary, force huge_pages=off for initdb
+          # see https://bugzilla.redhat.com/show_bug.cgi?id=1946792
+          p=/opt/rh/rh-postgresql12/root/usr/bin/postgres
+          mv $p $p.orig
+          echo exec $p.orig \"\$@\" -c huge_pages=off > $p
+          chmod 755 $p
+
+          # The NooBaa DB runs with UID 10001 GID 0
+          sed -i -e 's/^\(postgres:[^:]\):[0-9]*:[0-9]*:/\1:10001:0:/' /etc/passwd
+
+          # Init the DB and exit once the DB is ready to run
+          sed -i -e 's/^exec.*$/exit 0/' \
+                 -e 's/^pg_ctl\sstart.*/pg_ctl start || true/'                                   \
+                    /usr/bin/run-postgresql
+          su postgres -c "bash -x /usr/bin/run-postgresql"
+`
+
 const Sha256_deploy_internal_deployment_endpoint_yaml = "d0b3248e8751fd5dc0827d9ec526b6a9a31bb7014940c5a86b0519b523f48af3"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
@@ -3109,7 +3144,7 @@ spec:
                   resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_db_yaml = "40ccae24471e291d5cec7941ffc93e16c9c30e45bccb67e0beb009ad154b0cb0"
+const Sha256_deploy_internal_statefulset_db_yaml = "3de515b92c4892045b4e9c0ad8d0b69eaf198b7708818cd9e58c5e4cb53e2073"
 
 const File_deploy_internal_statefulset_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -3131,7 +3166,7 @@ spec:
         app: noobaa
         noobaa-db: noobaa
     spec:
-      serviceAccountName: noobaa
+      serviceAccountName: noobaa-endpoint
       terminationGracePeriodSeconds: 60
       initContainers:
       #----------------#
@@ -3188,7 +3223,7 @@ spec:
           storage: 50Gi
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "c6c0e65bbe94510f1f0333629821abd804b75832cb0cbaddacee9550fd3951f1"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "3921b3a648538a7f4ec337c34b59a837b4a3385cc0c52ce00389e0be6a5cb64e"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -3210,11 +3245,11 @@ spec:
         app: noobaa
         noobaa-db: postgres
     spec:
-      serviceAccountName: noobaa
+      serviceAccountName: noobaa-endpoint
       initContainers:
-      #----------------#
-      # INIT CONTAINER #
-      #----------------#
+      #-----------------#
+      # INIT CONTAINERS #
+      #-----------------#
       - name: init
         image: NOOBAA_CORE_IMAGE
         command:
@@ -3230,6 +3265,32 @@ spec:
         volumeMounts:
         - name: db
           mountPath: /var/lib/pgsql
+      - name: initialize-database
+        image: NOOBAA_DB_IMAGE
+        env:
+          - name: POSTGRESQL_DATABASE
+            value: nbcore
+          - name: POSTGRESQL_USER
+          - name: POSTGRESQL_PASSWORD
+        command:
+        - sh
+        - -x
+        - /init/initdb.sh
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "500Mi"
+          limits:
+            cpu: "500m"
+            memory: "500Mi"
+        volumeMounts:
+        - name: db
+          mountPath: /var/lib/pgsql
+        - name: noobaa-postgres-initdb-sh-volume
+          mountPath: /init
       containers:
       #--------------------#
       # Postgres CONTAINER #
@@ -3256,10 +3317,15 @@ spec:
             mountPath: /var/lib/pgsql
           - name: noobaa-postgres-config-volume
             mountPath: /opt/app-root/src/postgresql-cfg
+          - name: noobaa-postgres-initdb-sh-volume
+            mountPath: /init
       volumes:
       - name: noobaa-postgres-config-volume
         configMap:
           name: noobaa-postgres-config
+      - name: noobaa-postgres-initdb-sh-volume
+        configMap:
+          name: noobaa-postgres-initdb-sh
       securityContext: 
         runAsUser: 10001
         runAsGroup: 0

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -194,6 +194,31 @@ func (r *Reconciler) SetDesiredServiceDBForPostgres() error {
 	return nil
 }
 
+func (r *Reconciler) setPostgresUserPass(c *corev1.Container) {
+	for j := range c.Env {
+		switch c.Env[j].Name {
+		case "POSTGRESQL_USER":
+			c.Env[j].ValueFrom = &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: r.SecretDB.Name,
+					},
+					Key: "user",
+				},
+			}
+		case "POSTGRESQL_PASSWORD":
+			c.Env[j].ValueFrom = &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: r.SecretDB.Name,
+					},
+					Key: "password",
+				},
+			}
+		}
+	}
+}
+
 // SetDesiredNooBaaDB updates the NooBaaDB as desired for reconciling
 func (r *Reconciler) SetDesiredNooBaaDB() error {
 	var NooBaaDB *appsv1.StatefulSet = nil
@@ -214,7 +239,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 	}
 
 	podSpec := &NooBaaDB.Spec.Template.Spec
-	podSpec.ServiceAccountName = "noobaa"
+	podSpec.ServiceAccountName = "noobaa-endpoint"
 	defaultUID := int64(10001)
 	defaulfGID := int64(0)
 	podSpec.SecurityContext.RunAsUser = &defaultUID
@@ -223,6 +248,10 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 		c := &podSpec.InitContainers[i]
 		if c.Name == "init" {
 			c.Image = r.NooBaa.Status.ActualImage
+		}
+		if c.Name == "initialize-database" {
+			c.Image = GetDesiredDBImage(r.NooBaa)
+			r.setPostgresUserPass(c)
 		}
 	}
 	for i := range podSpec.Containers {
@@ -234,29 +263,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 				c.Resources = *r.NooBaa.Spec.DBResources
 			}
 			if r.NooBaa.Spec.DBType == "postgres" {
-				for j := range c.Env {
-					switch c.Env[j].Name {
-					case "POSTGRESQL_USER":
-						c.Env[j].ValueFrom = &corev1.EnvVarSource{
-							SecretKeyRef: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: r.SecretDB.Name,
-								},
-								Key: "user",
-							},
-						}
-					case "POSTGRESQL_PASSWORD":
-						c.Env[j].ValueFrom = &corev1.EnvVarSource{
-							SecretKeyRef: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: r.SecretDB.Name,
-								},
-								Key: "password",
-							},
-						}
-					}
-
-				}
+				r.setPostgresUserPass(c)
 			}
 		}
 	}
@@ -756,12 +763,15 @@ func (r *Reconciler) ReconcileRootSecret() error {
 func (r *Reconciler) ReconcileDB() error {
 	var err error
 	if r.NooBaa.Spec.DBType == "postgres" {
-		// this config map is required by the NooBaaPostgresDB StatefulSet,
+		// those are config maps required by the NooBaaPostgresDB StatefulSet,
 		// if the configMap was not created at this step, NooBaaPostgresDB
 		// would fail to start.
-		r.Own(r.PostgresDBConf)
-		if !util.KubeCreateSkipExisting(r.PostgresDBConf) {
-			return fmt.Errorf("could not create Postgres DB configMap %q in Namespace %q", r.PostgresDBConf.Name, r.PostgresDBConf.Namespace)
+		var postgresCMs = []*corev1.ConfigMap{r.PostgresDBConf, r.PostgresDBInitDb}
+		for  _, cm := range postgresCMs {
+			r.Own(cm)
+			if !util.KubeCreateSkipExisting(cm) {
+				return fmt.Errorf("could not create Postgres DB configMap %q in Namespace %q", cm.Name, cm.Namespace)
+			}
 		}
 
 		err = r.ReconcileObject(r.NooBaaPostgresDB, r.SetDesiredNooBaaDB)

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -71,6 +71,7 @@ type Reconciler struct {
 	DefaultCoreApp            *corev1.Container
 	NooBaaMongoDB             *appsv1.StatefulSet
 	PostgresDBConf            *corev1.ConfigMap
+	PostgresDBInitDb          *corev1.ConfigMap
 	NooBaaPostgresDB          *appsv1.StatefulSet
 	ServiceMgmt               *corev1.Service
 	ServiceS3                 *corev1.Service
@@ -128,6 +129,7 @@ func NewReconciler(
 		CoreAppConfig:       util.KubeObject(bundle.File_deploy_internal_configmap_empty_yaml).(*corev1.ConfigMap),
 		NooBaaMongoDB:       util.KubeObject(bundle.File_deploy_internal_statefulset_db_yaml).(*appsv1.StatefulSet),
 		PostgresDBConf:      util.KubeObject(bundle.File_deploy_internal_configmap_postgres_db_yaml).(*corev1.ConfigMap),
+		PostgresDBInitDb:    util.KubeObject(bundle.File_deploy_internal_configmap_postgres_initdb_yaml).(*corev1.ConfigMap),
 		NooBaaPostgresDB:    util.KubeObject(bundle.File_deploy_internal_statefulset_postgres_db_yaml).(*appsv1.StatefulSet),
 		ServiceDb:           util.KubeObject(bundle.File_deploy_internal_service_db_yaml).(*corev1.Service),
 		ServiceDbPg:         util.KubeObject(bundle.File_deploy_internal_service_db_yaml).(*corev1.Service),
@@ -166,6 +168,7 @@ func NewReconciler(
 	r.CoreAppConfig.Namespace = r.Request.Namespace
 	r.NooBaaMongoDB.Namespace = r.Request.Namespace
 	r.PostgresDBConf.Namespace = r.Request.Namespace
+	r.PostgresDBInitDb.Namespace = r.Request.Namespace
 	r.NooBaaPostgresDB.Namespace = r.Request.Namespace
 	r.ServiceMgmt.Namespace = r.Request.Namespace
 	r.ServiceS3.Namespace = r.Request.Namespace
@@ -273,6 +276,7 @@ func (r *Reconciler) CheckAll() {
 		if r.NooBaa.Spec.DBType == "postgres" {
 			util.KubeCheck(r.SecretDB)
 			util.KubeCheck(r.PostgresDBConf)
+			util.KubeCheck(r.PostgresDBInitDb)
 			util.KubeCheck(r.NooBaaPostgresDB)
 			util.KubeCheck(r.ServiceDbPg)
 		} else {


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1946792

- Extract Postgres initialisation into second init container
- During initialization wrap the postgres binary, force huge_pages=off for initdb

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>
(cherry picked from commit 40439724ea61bb0e8e162f40c05e9d96d5935947)