### PR TITLE
Refactor SCC/RBAC

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -74,3 +74,9 @@ rules:
       - get
       - update
       - list
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - '*'

--- a/deploy/internal/statefulset-db.yaml
+++ b/deploy/internal/statefulset-db.yaml
@@ -18,7 +18,7 @@ spec:
         app: noobaa
         noobaa-db: noobaa
     spec:
-      serviceAccountName: noobaa-endpoint
+      serviceAccountName: noobaa-db
       terminationGracePeriodSeconds: 60
       initContainers:
       #----------------#

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -18,7 +18,7 @@ spec:
         app: noobaa
         noobaa-db: postgres
     spec:
-      serviceAccountName: noobaa-endpoint
+      serviceAccountName: noobaa-db
       initContainers:
       #-----------------#
       # INIT CONTAINERS #

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -7,12 +7,6 @@ rules:
   - noobaa.io
   resources:
   - '*'
-  - noobaas
-  - backingstores
-  - bucketclasses
-  - noobaas/finalizers
-  - backingstores/finalizers
-  - bucketclasses/finalizers
   verbs:
   - '*'
 - apiGroups:
@@ -132,10 +126,8 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - security.openshift.io 
-  resourceNames:
-  - noobaa 
+  - rbac.authorization.k8s.io
   resources:
-  - securitycontextconstraints 
+  - '*'
   verbs: 
-  - use
+  - '*'

--- a/deploy/role_binding_db.yaml
+++ b/deploy/role_binding_db.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: noobaa-db
+subjects:
+  - kind: ServiceAccount
+    name: noobaa-db
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: noobaa-db

--- a/deploy/role_db.yaml
+++ b/deploy/role_db.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: noobaa-db
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - noobaa-db
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/scc_db.yaml
+++ b/deploy/scc_db.yaml
@@ -1,38 +1,23 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: noobaa
+  name: noobaa-db
+allowPrivilegeEscalation: true
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
-allowedCapabilities: []
-defaultAddCapabilities: []
-fsGroup:
-  type: MustRunAs
-groups: []
-priority: null
 readOnlyRootFilesystem: false
-requiredDropCapabilities:
-- KILL
-- MKNOD
+allowedCapabilities:
 - SETUID
 - SETGID
+fsGroup:
+  type: MustRunAs
 runAsUser:
   type: RunAsAny
 seLinuxContext:
   type: MustRunAs
 supplementalGroups:
   type: RunAsAny
-users:
-- system:serviceaccount:openshift-storage:noobaa
-volumes:
-- configMap
-- downwardAPI
-- emptyDir
-- persistentVolumeClaim
-- projected
-- secret

--- a/deploy/scc_endpoint.yaml
+++ b/deploy/scc_endpoint.yaml
@@ -27,8 +27,6 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
-users:
-- system:serviceaccount:openshift-storage:noobaa-endpoint
 volumes:
 - configMap
 - downwardAPI

--- a/deploy/service_account_db.yaml
+++ b/deploy/service_account_db.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: noobaa-db

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2,7 +2,7 @@ package bundle
 
 const Version = "5.12.0"
 
-const Sha256_deploy_cluster_role_yaml = "5f07526991bfd118aa3ffe74a2ec9860f15a6e7cbbe9fb0eee3237fe0a32447d"
+const Sha256_deploy_cluster_role_yaml = "af479a2ade093cf0a2c220fe4650151075cc0aaa58a01dd0ae60e7f7022d42d5"
 
 const File_deploy_cluster_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -80,6 +80,12 @@ rules:
       - get
       - update
       - list
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - '*'
 `
 
 const Sha256_deploy_cluster_role_binding_yaml = "15c78355aefdceaf577bd96b4ae949ae424a3febdc8853be0917cf89a63941fc"
@@ -4034,7 +4040,7 @@ spec:
                   resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_db_yaml = "3de515b92c4892045b4e9c0ad8d0b69eaf198b7708818cd9e58c5e4cb53e2073"
+const Sha256_deploy_internal_statefulset_db_yaml = "b6039d7ba3604deb54fdf6c48a7df758e1768e1af294ea21d0988cf30103c1c4"
 
 const File_deploy_internal_statefulset_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4056,7 +4062,7 @@ spec:
         app: noobaa
         noobaa-db: noobaa
     spec:
-      serviceAccountName: noobaa-endpoint
+      serviceAccountName: noobaa-db
       terminationGracePeriodSeconds: 60
       initContainers:
       #----------------#
@@ -4113,7 +4119,7 @@ spec:
           storage: 50Gi
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "4ee587dcc35a363230bda91ec6f939b351f5efd205fdd9fed8cf69fc8f405d16"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "98abe98cd3089424ef5a7dcebd973b1c307f879d434872029b58c0be392b2756"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4135,7 +4141,7 @@ spec:
         app: noobaa
         noobaa-db: postgres
     spec:
-      serviceAccountName: noobaa-endpoint
+      serviceAccountName: noobaa-db
       initContainers:
       #-----------------#
       # INIT CONTAINERS #
@@ -5057,7 +5063,7 @@ spec:
                   fieldPath: metadata.namespace
 `
 
-const Sha256_deploy_role_yaml = "eb0941a5e095fa7ac391e05782e6847e419e4d0dc17f6d8151df0032c977c743"
+const Sha256_deploy_role_yaml = "99798a1daa31e0f0546dbea3ba11411f0298051c64c401c9f168120ef2a9ef46"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -5068,12 +5074,6 @@ rules:
   - noobaa.io
   resources:
   - '*'
-  - noobaas
-  - backingstores
-  - bucketclasses
-  - noobaas/finalizers
-  - backingstores/finalizers
-  - bucketclasses/finalizers
   verbs:
   - '*'
 - apiGroups:
@@ -5193,13 +5193,11 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - security.openshift.io 
-  resourceNames:
-  - noobaa 
+  - rbac.authorization.k8s.io
   resources:
-  - securitycontextconstraints 
+  - '*'
   verbs: 
-  - use
+  - '*'
 `
 
 const Sha256_deploy_role_binding_yaml = "59a2627156ed3db9cd1a4d9c47e8c1044279c65e84d79c525e51274329cb16ff"
@@ -5217,6 +5215,21 @@ roleRef:
   name: noobaa
 `
 
+const Sha256_deploy_role_binding_db_yaml = "3a4872fcde50e692ae52bbd208a8e1d115c574431c25a9644a7c820ae13c7748"
+
+const File_deploy_role_binding_db_yaml = `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: noobaa-db
+subjects:
+  - kind: ServiceAccount
+    name: noobaa-db
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: noobaa-db
+`
+
 const Sha256_deploy_role_binding_endpoint_yaml = "ab85a33434b0a5fb685fb4983a9d97313e277a5ec8a2142e49c276d51b8ba0e9"
 
 const File_deploy_role_binding_endpoint_yaml = `apiVersion: rbac.authorization.k8s.io/v1
@@ -5230,6 +5243,23 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: noobaa-endpoint
+`
+
+const Sha256_deploy_role_db_yaml = "8a7b6895de2e9847ec4a9e6e298b63251253f446961eb97f4dee50ee156f6d12"
+
+const File_deploy_role_db_yaml = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: noobaa-db
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - noobaa-db
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 `
 
 const Sha256_deploy_role_endpoint_yaml = "27ace6cdcae4d87add5ae79265c4eee9d247e5910fc8a74368139d31add6dac2"
@@ -5301,49 +5331,34 @@ rules:
       - bucketclasses
 `
 
-const Sha256_deploy_scc_yaml = "cbb071961f7dd77e5bdca7e36b89e1e1982265c4e7dc95f00109d0acc64a3c06"
+const Sha256_deploy_scc_db_yaml = "49d970f874b9f458e286badddd46d772bbf8270b4d28a7c02002f1eef4d226be"
 
-const File_deploy_scc_yaml = `apiVersion: security.openshift.io/v1
+const File_deploy_scc_db_yaml = `apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: noobaa
+  name: noobaa-db
+allowPrivilegeEscalation: true
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
-allowedCapabilities: []
-defaultAddCapabilities: []
-fsGroup:
-  type: MustRunAs
-groups: []
-priority: null
 readOnlyRootFilesystem: false
-requiredDropCapabilities:
-- KILL
-- MKNOD
+allowedCapabilities:
 - SETUID
 - SETGID
+fsGroup:
+  type: MustRunAs
 runAsUser:
   type: RunAsAny
 seLinuxContext:
   type: MustRunAs
 supplementalGroups:
   type: RunAsAny
-users:
-- system:serviceaccount:openshift-storage:noobaa
-volumes:
-- configMap
-- downwardAPI
-- emptyDir
-- persistentVolumeClaim
-- projected
-- secret
 `
 
-const Sha256_deploy_scc_endpoint_yaml = "27642f221c6289dff59734f9368aa5dcb3b10fe6c98de8aba2bfb71807c30c66"
+const Sha256_deploy_scc_endpoint_yaml = "f097a29eb11230a7612ab5f86894da523a743093e21eb2217a39332c5a31b10c"
 
 const File_deploy_scc_endpoint_yaml = `apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -5374,8 +5389,6 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
-users:
-- system:serviceaccount:openshift-storage:noobaa-endpoint
 volumes:
 - configMap
 - downwardAPI
@@ -5393,6 +5406,14 @@ metadata:
   name: noobaa
   annotations:
     serviceaccounts.openshift.io/oauth-redirectreference.noobaa-mgmt: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"noobaa-mgmt"}}'
+`
+
+const Sha256_deploy_service_account_db_yaml = "fcbccd7518ee5a426b071a3acc85d22142e27c5628b61ce4292cc393d2ecac31"
+
+const File_deploy_service_account_db_yaml = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: noobaa-db
 `
 
 const Sha256_deploy_service_account_endpoint_yaml = "c2331e027114658e48a2bd1139b00cce06dfd834aa682eae923de54874a6baed"

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -242,11 +242,6 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 		})
 	csv.Spec.InstallStrategy.StrategySpec.Permissions = append(csv.Spec.InstallStrategy.StrategySpec.Permissions,
 		operv1.StrategyDeploymentPermissions{
-			ServiceAccountName: opConf.SAEndpoint.Name,
-			Rules:              opConf.RoleEndpoint.Rules,
-		})
-	csv.Spec.InstallStrategy.StrategySpec.Permissions = append(csv.Spec.InstallStrategy.StrategySpec.Permissions,
-		operv1.StrategyDeploymentPermissions{
 			ServiceAccountName: opConf.SAUI.Name,
 			Rules:              opConf.RoleUI.Rules,
 		})

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -69,6 +69,9 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 	if err := r.ReconcileSystemSecrets(); err != nil {
 		return err
 	}
+	if err := r.reconcileEndpointRBAC(); err != nil {
+		return err
+	}
 	if err := r.ReconcileObject(r.DeploymentEndpoint, r.SetDesiredDeploymentEndpoint); err != nil {
 		return err
 	}
@@ -1678,4 +1681,13 @@ func FindNoobaaAdmissionController() (*admissionv1.ValidatingWebhookConfiguratio
 	}
 
 	return nil, fmt.Errorf("failed to find noobaa admission webhook")
+}
+
+// reconcileEndpointRBAC creates Endpoint scc, role, rolebinding and service account
+func (r* Reconciler) reconcileEndpointRBAC() error {
+	return r.reconcileRbac(
+		bundle.File_deploy_scc_endpoint_yaml,
+		bundle.File_deploy_service_account_endpoint_yaml,
+		bundle.File_deploy_role_endpoint_yaml,
+		bundle.File_deploy_role_binding_endpoint_yaml)
 }


### PR DESCRIPTION
1. Noobaa operator no longer uses 'noobaa' SCC and relies on RBAC only.
2. Handle SCC RBAC creation for DB and Endpoint inside operator's
   reconcile loop.
3. OCS operator interface:
   a. OCS operator no longer needs to create 'noobaa' & 'noobaa-endpoint'
      SCCs. newNooBaaSCC() and newNooBaaEndpointSCC() functions should be
      removed from the OCS codebase.
   b. Use ''noobaa olm csv' to pass operator's RBAC resources to OCS.
4. Create a rbac/scc for the db.

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>