### PR TITLE
Adding HumanizeDuration to better print Durations as AGE

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -806,7 +806,7 @@ func RunList(cmd *cobra.Command, args []string) {
 			string(bs.Spec.Type),
 			GetBackingStoreTargetBucket(bs),
 			string(bs.Status.Phase),
-			time.Since(bs.CreationTimestamp.Time).Round(time.Second).String(),
+			util.HumanizeDuration(time.Since(bs.CreationTimestamp.Time).Round(time.Second)),
 		)
 	}
 	fmt.Print(table.String())

--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -499,7 +499,7 @@ func RunList(cmd *cobra.Command, args []string) {
 			fmt.Sprintf("%+v", string(pp)),
 			fmt.Sprintf("%+v", string(np)),
 			string(bc.Status.Phase),
-			time.Since(bc.CreationTimestamp.Time).Round(time.Second).String(),
+			util.HumanizeDuration(time.Since(bc.CreationTimestamp.Time).Round(time.Second)),
 		)
 	}
 	fmt.Print(table.String())

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -615,7 +615,7 @@ func RunList(cmd *cobra.Command, args []string) {
 			string(bs.Spec.Type),
 			GetNamespaceStoreTargetBucket(bs),
 			string(bs.Status.Phase),
-			time.Since(bs.CreationTimestamp.Time).Round(time.Second).String(),
+			util.HumanizeDuration(time.Since(bs.CreationTimestamp.Time).Round(time.Second)),
 		)
 	}
 	fmt.Print(table.String())

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -418,7 +418,7 @@ func RunList(cmd *cobra.Command, args []string) {
 			fmt.Sprint(s.Status.Services.ServiceS3.NodePorts),
 			s.Status.ActualImage,
 			string(s.Status.Phase),
-			time.Since(s.CreationTimestamp.Time).Round(time.Second).String(),
+			util.HumanizeDuration(time.Since(s.CreationTimestamp.Time).Round(time.Second)),
 		)
 	}
 	fmt.Print(table.String())

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1303,6 +1303,31 @@ func MergeEnvArrays(envA, envB *[]corev1.EnvVar) {
 	}
 }
 
+// HumanizeDuration humanizes time.Duration output to a meaningful value - will show days/years
+func HumanizeDuration(duration time.Duration) string {
+	const (
+		oneDay  = time.Minute * 60 * 24
+		oneYear = 365 * oneDay
+	)
+	if duration < oneDay {
+		return duration.String()
+	}
+
+	var builder strings.Builder
+
+	if duration >= oneYear {
+		years := duration / oneYear
+		fmt.Fprintf(&builder, "%dy", years)
+		duration -= years * oneYear
+	}
+
+	days := duration / oneDay
+	duration -= days * oneDay
+	fmt.Fprintf(&builder, "%dd%s", days, duration)
+
+	return builder.String()
+}
+
 // EnsureCommonMetaFields ensures that the resource has all mandatory meta fields
 func EnsureCommonMetaFields(object metav1.Object, finalizer string) bool {
 	updated := false


### PR DESCRIPTION
Table format will change from this (example):
```
NAME                          NAMESPACE-POLICY   PHASE   AGE
noobaa-default-bucket-class   null               Ready   989h1m6s
```
to this: 
```
NAME                          NAMESPACE-POLICY   PHASE   AGE
noobaa-default-bucket-class   null               Ready   41d5h1m6s
```
fix for https://bugzilla.redhat.com/show_bug.cgi?id=1999581

Signed-off-by: jackyalbo <jalbo@redhat.com>