### PR TITLE
Allow definition of pv-pool backing store agent resources requests/limits

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -1027,7 +1028,9 @@ func (r *Reconciler) reconcileMissingPods(podsList *corev1.PodList, pvcsList *co
 	for _, pod := range podsList.Items {
 		claimNames = append(claimNames, pod.Spec.Volumes[1].PersistentVolumeClaim.ClaimName)
 	}
-	r.updatePodTemplate()
+	if err := r.updatePodTemplate(); err != nil {
+		return err
+	}
 	for _, pvc := range pvcsList.Items {
 		if !contains(claimNames, pvc.Name) {
 			i := strings.LastIndex(pvc.Name, "-")
@@ -1077,6 +1080,29 @@ func (r *Reconciler) reconcileExistingPods(podsList *corev1.PodList) error {
 	return nil
 }
 
+// return true if update is required
+func compareResourceList(template, container *corev1.ResourceList) bool {
+	for _, res := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if qty, ok := (*template)[res]; ok {
+			if qty.Cmp((*container)[res]) != 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// return true if resources need to be updated
+func (r *Reconciler) needUpdateResources(c *corev1.Container) bool {
+	pvPool := r.BackingStore.Spec.PVPool
+	if pvPool == nil || pvPool.VolumeResources == nil {
+		return false
+	}
+
+	return compareResourceList(&pvPool.VolumeResources.Requests, &c.Resources.Requests) ||
+		compareResourceList(&pvPool.VolumeResources.Limits, &c.Resources.Limits)
+}
+
 func (r *Reconciler) needUpdate(pod *corev1.Pod) bool {
 	var c = &pod.Spec.Containers[0]
 	for _, name := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
@@ -1091,6 +1117,12 @@ func (r *Reconciler) needUpdate(pod *corev1.Pod) bool {
 		r.Logger.Warnf("Change in Image detected: current image(%v) noobaa image(%v)", c.Image, r.NooBaa.Status.ActualImage)
 		return true
 	}
+
+	if r.needUpdateResources(c) {
+		r.Logger.Warnf("Change in backing store agent resources detected")
+		return true
+	}
+
 	podSecrets := pod.Spec.ImagePullSecrets
 	noobaaSecret := r.NooBaa.Spec.ImagePullSecret
 	if noobaaSecret == nil {
@@ -1131,7 +1163,7 @@ func (r *Reconciler) isPodinNoobaa(pod *corev1.Pod) bool {
 	return false
 }
 
-func (r *Reconciler) updatePodTemplate() {
+func (r *Reconciler) updatePodTemplate() error {
 	c := &r.PodAgentTemplate.Spec.Containers[0]
 	for j := range c.Env {
 		switch c.Env[j].Name {
@@ -1168,6 +1200,36 @@ func (r *Reconciler) updatePodTemplate() {
 	if r.NooBaa.Spec.Affinity != nil {
 		r.PodAgentTemplate.Spec.Affinity = r.NooBaa.Spec.Affinity
 	}
+
+	return r.updatePodResourcesTemplate(c)
+}
+
+func (r *Reconciler) updatePodResourcesTemplate(c *corev1.Container) error {
+	minimalCPU := resource.MustParse(minCPUString)
+	minimalMemory := resource.MustParse(minMemoryString)
+	var src, dst *corev1.ResourceList
+	pvPool := r.BackingStore.Spec.PVPool
+
+	// Request
+	dst = &c.Resources.Requests
+	if pvPool != nil && pvPool.VolumeResources != nil {
+		src = &pvPool.VolumeResources.Requests
+	}
+	if err := r.reconcileResources(src, dst, minimalCPU, minimalMemory); err != nil {
+		return err
+	}
+
+	// Limits
+	src = nil
+	if pvPool != nil && pvPool.VolumeResources != nil {
+		src = &pvPool.VolumeResources.Limits
+	}
+	dst = &c.Resources.Limits
+	if err := r.reconcileResources(src, dst, minimalCPU, minimalMemory); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *Reconciler) updatePvcTemplate() {
@@ -1233,5 +1295,31 @@ func (r *Reconciler) upgradeBackingStore(sts *appsv1.StatefulSet) error {
 			util.KubeUpdate(pvc)
 		}
 	}
+	return nil
+}
+
+func (r *Reconciler) reconcileResources(src, dst *corev1.ResourceList, minCPU, minMem resource.Quantity) error {
+	cpu := minCPU
+	mem := minMem
+
+	if src != nil {
+		if qty, ok := (*src)[corev1.ResourceCPU]; ok {
+			if qty.Cmp(minCPU) < 0 {
+				return util.NewPersistentError("MinRequestCpu",
+				fmt.Sprintf("NooBaa BackingStore %v is in rejected phase due to small cpu request %v, min is %v", r.BackingStore.Name, qty.String(), minCPU.String()))
+			}
+			cpu = qty
+		}
+		if qty, ok := (*src)[corev1.ResourceMemory]; ok {
+			if qty.Cmp(minMem) < 0 {
+				return util.NewPersistentError("MinRequestCpu",
+				fmt.Sprintf("NooBaa BackingStore %v is in rejected phase due to small memory request %v, min is %v", r.BackingStore.Name, qty.String(), minMem.String()))
+			}
+			mem = qty
+		}
+	}
+
+	(*dst)[corev1.ResourceCPU] = cpu
+	(*dst)[corev1.ResourceMemory] = mem
 	return nil
 }

--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -54,6 +54,7 @@ NAMESPACE='test'
 function post_install_tests {
     check_core_config_map
     aws_credentials
+    check_pv_pool_resources
     check_S3_compatible
     check_namespacestore
     create_replication_files

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -318,6 +318,54 @@ function check_namespacestore_nsfs_validator {
     echo_time "✅  namespacestore nsfs validator is done"
 }
 
+function check_pv_pool_resources {
+    echo_time "💬  Staring PV Pool resources cycle"
+
+    # Minimum CPU     100m
+    #         Memory  400Mi
+    test_noobaa should_fail backingstore create pv-pool request-small-cpu \
+            --num-volumes 1 \
+            --pv-size-gb 16 \
+            --request-cpu 50m
+
+    test_noobaa should_fail backingstore create pv-pool request-small-memory \
+            --num-volumes 1 \
+            --pv-size-gb 16 \
+            --request-memory 100Mi
+
+    test_noobaa should_fail backingstore create pv-pool request-larger-limit \
+            --num-volumes 1 \
+            --pv-size-gb 16 \
+            --request-cpu 300m \
+            --limit-cpu 200m
+
+    test_noobaa backingstore create pv-pool minimum-request-limit \
+            --num-volumes 1 \
+            --pv-size-gb 16 \
+            --request-cpu 100m \
+            --request-memory 400Mi \
+            --limit-cpu 100m \
+            --limit-memory 400Mi
+
+    test_noobaa backingstore create pv-pool large-request-limit \
+            --num-volumes 1 \
+            --pv-size-gb 16 \
+            --request-cpu 300m \
+            --request-memory 500Mi \
+            --limit-cpu 400m \
+            --limit-memory 600Mi
+
+    test_noobaa backingstore list
+    test_noobaa status
+    kuberun get backingstore
+    kuberun describe backingstore
+
+    test_noobaa backingstore delete minimum-request-limit
+    test_noobaa backingstore delete large-request-limit
+
+    echo_time "✅  PV Pool resources cycle is done"
+}
+
 function check_S3_compatible {
     echo_time "💬  Staring compatible cycle"
     local cycle


### PR DESCRIPTION
Allow definition of pv-pool backing store agent resources requests/limits

1. Use PVPoolSpec VolumeResources to pass memory/cpu resources
2. Expose request/limit cpu/memory resource configuration in CLI `backingstore create pv-pool` command
3. Add CLI tests for new functionality

Investigating [Cache issue](https://github.com/noobaa/noobaa-core/issues/6709).
