### PR TITLE
Fix for noobaa CR deletion (uninstall) flow

### DIFF
--- a/pkg/controller/cephcluster/cephcluster_controller.go
+++ b/pkg/controller/cephcluster/cephcluster_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -55,6 +56,14 @@ func Add(mgr manager.Manager) error {
 func doReconcile(context context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logrus.WithField("cephcluster", req.Namespace+"/"+req.Name)
 	res := reconcile.Result{}
+
+	nooBaa := nbv1.NooBaa{}
+	nooBaa.Name = options.SystemName
+	nooBaa.Namespace = req.Namespace
+	if !system.CheckSystem(&nooBaa) {
+		log.Infof("NooBaa not found or already deleted. Skip reconcile.")
+		return res, nil
+	}
 
 	cephCluster := cephv1.CephCluster{}
 	cephCluster.Name = req.Name

--- a/pkg/system/cmd_ui.go
+++ b/pkg/system/cmd_ui.go
@@ -29,7 +29,10 @@ func RunUI(cmd *cobra.Command, args []string) {
 	klient := util.KubeClient()
 	sysKey := client.ObjectKey{Namespace: options.Namespace, Name: options.SystemName}
 	r := NewReconciler(sysKey, klient, scheme.Scheme, nil)
-	CheckSystem(r.NooBaa)
+	if  !CheckSystem(r.NooBaa) {
+		log.Infof("NooBaa not found or already deleted. Skip.")
+		return
+	}
 
 	sysClient, err := Connect(true)
 	if err != nil {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -911,6 +911,11 @@ func GetDesiredDBImage(sys *nbv1.NooBaa) string {
 func CheckSystem(sys *nbv1.NooBaa) bool {
 	log := util.Logger()
 	found := util.KubeCheck(sys)
+
+	if ts := sys.GetDeletionTimestamp(); ts != nil {
+		log.Printf("❌ NooBaa system deleted at %v", ts)
+		return false // deleted
+	}
 	if sys.Status.Accounts == nil {
 		sys.Status.Accounts = &nbv1.AccountsStatus{}
 	}


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2005040

1. Avoid race conditions during NooBaa CR deletion in
   NooBaa system reconciler
2. Secondary controllers should not reconcile if NooBaa CR is
   missing or marked for deletion (Terminating)
3. Factor in systemFound during FinalizeDeletion()

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>