### PR TITLE
added flags to set replaces and olm.skipRange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ gen-olm: $(OPERATOR_SDK) gen
 
 gen-odf-package: cli
 	rm -rf $(MANIFESTS)
-	MANIFESTS=$(MANIFESTS) CSV_NAME=$(csv-name) CORE_IMAGE=$(core-image) DB_IMAGE=$(db-image) OPERATOR_IMAGE=$(operator-image) build/gen-odf-package.sh
+	MANIFESTS="$(MANIFESTS)" CSV_NAME="$(csv-name)" SKIP_RANGE="$(skip-range)" REPLACES="$(replaces)" CORE_IMAGE="$(core-image)" DB_IMAGE="$(db-image)" OPERATOR_IMAGE="$(operator-image)" build/gen-odf-package.sh
 	@echo "✅ gen-odf-package"
 .PHONY: gen-odf-package
 

--- a/build/gen-odf-package.sh
+++ b/build/gen-odf-package.sh
@@ -6,7 +6,15 @@ then
   exit 1
 fi
 
-./build/_output/bin/noobaa-operator-local olm catalog -n openshift-storage --dir ${MANIFESTS} --odf --csv-name ${CSV_NAME} --noobaa-image ${CORE_IMAGE} --db-image ${DB_IMAGE} --operator-image ${OPERATOR_IMAGE}
+./build/_output/bin/noobaa-operator-local olm catalog -n openshift-storage \
+--dir ${MANIFESTS} \
+--odf \
+--csv-name ${CSV_NAME} \
+--skip-range "${SKIP_RANGE}" \
+--replaces "${REPLACES}" \
+--noobaa-image ${CORE_IMAGE} \
+--db-image ${DB_IMAGE} \
+--operator-image ${OPERATOR_IMAGE}
 
 temp_csv=$(mktemp)
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -210,7 +210,6 @@ type Conf struct {
 	SecurityContextConstraints *secv1.SecurityContextConstraints
 	SCCEndpoint                *secv1.SecurityContextConstraints
 	Deployment                 *appsv1.Deployment
-	IsForODF                   bool
 }
 
 // LoadOperatorConf loads and initializes all the objects needed to install the operator
@@ -229,7 +228,6 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.SecurityContextConstraints = util.KubeObject(bundle.File_deploy_scc_yaml).(*secv1.SecurityContextConstraints)
 	c.SCCEndpoint = util.KubeObject(bundle.File_deploy_scc_endpoint_yaml).(*secv1.SecurityContextConstraints)
 	c.Deployment = util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
-	c.IsForODF = false
 
 	c.NS.Name = options.Namespace
 	c.SA.Namespace = options.Namespace


### PR DESCRIPTION
* example for generating noobaa CSV with the new parameters:
```
make gen-odf-package csv-name=noobaa-operator.clusterserviceversion.yaml core-image=noobaa/noobaa-core:master-20210816 operator-image=noobaa/noobaa-operator:master-20210816 db-image=centos/postgresql-12-centos7 skip-range=">=4.2.0 <4.9.0" replaces="4.9.0"
```

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>