### PR TITLE
[back-port to 5.9] added flags to set replaces and olm.skipRange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ gen-olm: $(OPERATOR_SDK) gen
 
 gen-odf-package: cli
 	rm -rf $(MANIFESTS)
-	MANIFESTS=$(MANIFESTS) CSV_NAME=$(csv-name) CORE_IMAGE=$(core-image) DB_IMAGE=$(db-image) OPERATOR_IMAGE=$(operator-image) build/gen-odf-package.sh
+	MANIFESTS="$(MANIFESTS)" CSV_NAME="$(csv-name)" SKIP_RANGE="$(skip-range)" REPLACES="$(replaces)" CORE_IMAGE="$(core-image)" DB_IMAGE="$(db-image)" OPERATOR_IMAGE="$(operator-image)" build/gen-odf-package.sh
 	@echo "✅ gen-odf-package"
 .PHONY: gen-odf-package
 

--- a/build/gen-odf-package.sh
+++ b/build/gen-odf-package.sh
@@ -6,7 +6,15 @@ then
   exit 1
 fi
 
-./build/_output/bin/noobaa-operator-local olm catalog -n openshift-storage --dir ${MANIFESTS} --odf --csv-name ${CSV_NAME} --noobaa-image ${CORE_IMAGE} --db-image ${DB_IMAGE} --operator-image ${OPERATOR_IMAGE}
+./build/_output/bin/noobaa-operator-local olm catalog -n openshift-storage \
+--dir ${MANIFESTS} \
+--odf \
+--csv-name ${CSV_NAME} \
+--skip-range "${SKIP_RANGE}" \
+--replaces "${REPLACES}" \
+--noobaa-image ${CORE_IMAGE} \
+--db-image ${DB_IMAGE} \
+--operator-image ${OPERATOR_IMAGE}
 
 temp_csv=$(mktemp)
 

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -30,6 +30,12 @@ import (
 type unObj = map[string]interface{}
 type unArr = []interface{}
 
+type generateCSVParams struct {
+	IsForODF  bool
+	SkipRange string
+	Replaces  string
+}
+
 // Cmd returns a CLI command
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -59,6 +65,8 @@ func CmdCatalog() *cobra.Command {
 	cmd.Flags().String("dir", "./build/_output/olm", "The output dir for the OLM package")
 	cmd.Flags().Bool("odf", false, "Build package according to ODF requirements")
 	cmd.Flags().String("csv-name", "", "File name for the CSV YAML")
+	cmd.Flags().String("skip-range", "", "set the olm.skipRange annotation in the CSV")
+	cmd.Flags().String("replaces", "", "set the replaces property in the CSV")
 	return cmd
 }
 
@@ -146,8 +154,14 @@ func RunCatalog(cmd *cobra.Command, args []string) {
 	var versionDir string
 
 	forODF, _ := cmd.Flags().GetBool("odf")
+	skipRange, _ := cmd.Flags().GetString("skip-range")
+	replaces, _ := cmd.Flags().GetString("replaces")
+	csvParams := &generateCSVParams{
+		IsForODF:  forODF,
+		SkipRange: skipRange,
+		Replaces:  replaces,
+	}
 	if forODF {
-		opConf.IsForODF = true
 		versionDir = dir
 	} else {
 		versionDir = dir + version.Version + "/"
@@ -174,7 +188,7 @@ func RunCatalog(cmd *cobra.Command, args []string) {
 	if !forODF {
 		util.Panic(ioutil.WriteFile(dir+"noobaa-operator.package.yaml", pkgBytes, 0644))
 	}
-	util.Panic(util.WriteYamlFile(csvFileName, GenerateCSV(opConf)))
+	util.Panic(util.WriteYamlFile(csvFileName, GenerateCSV(opConf, csvParams)))
 	crd.ForEachCRD(func(c *crd.CRD) {
 		if c.Spec.Group == nbv1.SchemeGroupVersion.Group {
 			util.Panic(util.WriteYamlFile(versionDir+c.Name+".crd.yaml", c))
@@ -185,13 +199,13 @@ func RunCatalog(cmd *cobra.Command, args []string) {
 // RunCSV runs a CLI command
 func RunCSV(cmd *cobra.Command, args []string) {
 	opConf := operator.LoadOperatorConf(cmd)
-	csv := GenerateCSV(opConf)
+	csv := GenerateCSV(opConf, nil)
 	p := printers.YAMLPrinter{}
 	util.Panic(p.PrintObj(csv, os.Stdout))
 }
 
 // GenerateCSV creates the CSV
-func GenerateCSV(opConf *operator.Conf) *operv1.ClusterServiceVersion {
+func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.ClusterServiceVersion {
 	almExamples, err := json.Marshal([]runtime.Object{
 		util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml),
 		util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml),
@@ -235,19 +249,31 @@ func GenerateCSV(opConf *operator.Conf) *operv1.ClusterServiceVersion {
 			Spec: opConf.Deployment.Spec,
 		})
 
-	if opConf.IsForODF {
-		// add anotation to hide the operator in OCP console
-		csv.Annotations["operators.operatorframework.io/operator-type"] = "non-standalone"
-		operatorContainer := &csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0]
-		operatorContainer.Env = append(operatorContainer.Env,
-			corev1.EnvVar{
-				Name:  "NOOBAA_CORE_IMAGE",
-				Value: options.NooBaaImage,
-			},
-			corev1.EnvVar{
-				Name:  "NOOBAA_DB_IMAGE",
-				Value: options.DBImage,
-			})
+	if csvParams != nil {
+		if csvParams.IsForODF {
+			// add anotation to hide the operator in OCP console
+			csv.Annotations["operators.operatorframework.io/operator-type"] = "non-standalone"
+
+			// add env vars for noobaa-core and noobaa-db images
+			operatorContainer := &csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0]
+			operatorContainer.Env = append(operatorContainer.Env,
+				corev1.EnvVar{
+					Name:  "NOOBAA_CORE_IMAGE",
+					Value: options.NooBaaImage,
+				},
+				corev1.EnvVar{
+					Name:  "NOOBAA_DB_IMAGE",
+					Value: options.DBImage,
+				})
+		}
+
+		if csvParams.Replaces != "" {
+			csv.Spec.Replaces = csvParams.Replaces
+		}
+
+		if csvParams.SkipRange != "" {
+			csv.Annotations[operv1.SkipRangeAnnotationKey] = csvParams.SkipRange
+		}
 	}
 
 	csv.Spec.CustomResourceDefinitions.Owned = []operv1.CRDDescription{}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -210,7 +210,6 @@ type Conf struct {
 	SecurityContextConstraints *secv1.SecurityContextConstraints
 	SCCEndpoint                *secv1.SecurityContextConstraints
 	Deployment                 *appsv1.Deployment
-	IsForODF                   bool
 }
 
 // LoadOperatorConf loads and initializes all the objects needed to install the operator
@@ -229,7 +228,6 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.SecurityContextConstraints = util.KubeObject(bundle.File_deploy_scc_yaml).(*secv1.SecurityContextConstraints)
 	c.SCCEndpoint = util.KubeObject(bundle.File_deploy_scc_endpoint_yaml).(*secv1.SecurityContextConstraints)
 	c.Deployment = util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
-	c.IsForODF = false
 
 	c.NS.Name = options.Namespace
 	c.SA.Namespace = options.Namespace


### PR DESCRIPTION
back-ported https://github.com/noobaa/noobaa-operator/pull/766 

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 1349eece780f1371096963ef0734f08d10e5df6d)