### PR TITLE
COSI - Initial Support [WIP]

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -66,3 +66,28 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  - apiGroups: 
+      - coordination.k8s.io
+    resources: 
+      - leases
+    verbs: 
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+  - apiGroups: 
+      - objectstorage.k8s.io
+    resources: 
+      - buckets
+      - bucketaccesses
+      - buckets/status
+      - bucketaccesses/status
+    verbs: 
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create

--- a/deploy/cosi/bucket_access_class.yaml
+++ b/deploy/cosi/bucket_access_class.yaml
@@ -1,0 +1,7 @@
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketAccessClass
+metadata:
+  name: my-bac
+policyActionsConfigMap:
+  name: policy-cm
+  namespace: jacky

--- a/deploy/cosi/bucket_access_request.yaml
+++ b/deploy/cosi/bucket_access_request.yaml
@@ -1,0 +1,7 @@
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketAccessRequest
+metadata:
+  name: my-bar
+spec:
+  bucketAccessClassName: my-bac
+  bucketRequestName: my-br

--- a/deploy/cosi/bucket_class.yaml
+++ b/deploy/cosi/bucket_class.yaml
@@ -1,0 +1,14 @@
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketClass
+metadata:
+  name: my-bc
+provisioner: noobaa.objectstorage.k8s.io
+isDefaultBucketClass: true
+allowedNamespaces:
+- default
+protocol:
+  s3:
+    region: us-east-1
+    signatureVersion: S3V4
+parameters:
+  policy: "{\"placementPolicy\":{\"tiers\":[{\"backingStores\":[\"noobaa-default-backing-store\"]}]}}"

--- a/deploy/cosi/bucket_request.yaml
+++ b/deploy/cosi/bucket_request.yaml
@@ -1,0 +1,7 @@
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketRequest
+metadata:
+  name: my-br
+spec:
+  bucketPrefix: my-br
+  bucketClassName: my-bc

--- a/deploy/operator_cosi.yaml
+++ b/deploy/operator_cosi.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: noobaa-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      noobaa-operator: deployment
+  template:
+    metadata:
+      labels:
+        app: noobaa
+        noobaa-operator: deployment
+    spec:
+      serviceAccountName: noobaa
+      volumes:
+      - name: socket
+        emptyDir: {}
+      containers:
+        - name: noobaa-operator
+          image: NOOBAA_OPERATOR_IMAGE
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "512Mi"
+          env:
+            - name: OPERATOR_NAME
+              value: noobaa-operator
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+          - mountPath: /var/lib/cosi
+            name: socket
+        - name: objectstorage-provisioner-sidecar
+          image: COSI_SIDECAR_IMAGE
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "512Mi"
+          imagePullPolicy: Always
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          volumeMounts:
+          - mountPath: /var/lib/cosi
+            name: socket

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/go-semver v0.3.0
 	github.com/docker/distribution v2.7.1+incompatible
-	github.com/go-openapi/spec v0.19.8
+	github.com/go-openapi/spec v0.19.12
 	github.com/hashicorp/vault/api v1.0.5-0.20200902155336-f9d5ce5a171a
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20210818162813-3eee31c01875
 	github.com/marstr/randname v0.0.0-20200428202425-99aca53a2176
@@ -34,6 +34,7 @@ require (
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 	google.golang.org/api v0.32.0
+	google.golang.org/grpc v1.35.0
 	k8s.io/api v0.21.3
 	k8s.io/apiextensions-apiserver v0.21.3
 	k8s.io/apimachinery v0.21.3
@@ -44,6 +45,8 @@ require (
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 	k8s.io/kubectl v0.21.3
 	nhooyr.io/websocket v1.7.4
+	sigs.k8s.io/container-object-storage-interface-provisioner-sidecar v0.0.0-20210528161624-b46634c30d14
+	sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210507203703-a97f2e98ac90
 	sigs.k8s.io/controller-runtime v0.9.5
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381/go.mod h1:e5+USP2j8Le2M0Jo3qKPFnNhuo1wueU4nWHCXBOfQ14=
 github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1wt9Z3DP8O6W3rvwCt0REIlshg1InHImaLW0t3ObY0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190531201743-edce55837238/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -358,6 +359,7 @@ github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65/go.mod h1:q2w6Bg5je
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
 github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
+github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -423,6 +425,7 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
@@ -532,8 +535,9 @@ github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3Hfo
 github.com/go-openapi/jsonreference v0.17.2/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
-github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
+github.com/go-openapi/jsonreference v0.19.4 h1:3Vw+rh13uq2JFNxgnMTGE1rnoieU9FmyE1gvnyylsYg=
+github.com/go-openapi/jsonreference v0.19.4/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE69AqPYEJeo/TWfEeg=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.17.2/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
@@ -557,8 +561,9 @@ github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8
 github.com/go-openapi/spec v0.19.5/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/spec v0.19.6/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/spec v0.19.7/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
-github.com/go-openapi/spec v0.19.8 h1:qAdZLh1r6QF/hI/gTq+TJTvsQUodZsM7KLqkAJdiJNg=
 github.com/go-openapi/spec v0.19.8/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
+github.com/go-openapi/spec v0.19.12 h1:OO9WrvhDwtiMY/Opr1j1iFZzirI3JW4/bxNFRcntAr4=
+github.com/go-openapi/spec v0.19.12/go.mod h1:gwrgJS15eCUgjLpMjBJmbZezCsw88LmgeEip0M63doA=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.17.2/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
@@ -576,8 +581,9 @@ github.com/go-openapi/swag v0.19.4/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.7/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
 github.com/go-openapi/swag v0.19.9/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
-github.com/go-openapi/swag v0.19.10 h1:A1SWXruroGP15P1sOiegIPbaKio+G9N5TwWTFaVPmAU=
 github.com/go-openapi/swag v0.19.10/go.mod h1:Uc0gKkdR+ojzsEpjh39QChyu92vPgIr72POcgHMAgSY=
+github.com/go-openapi/swag v0.19.11 h1:RFTu/dlFySpyVvJDfp/7674JY4SDglYWKztbiIGFpmc=
+github.com/go-openapi/swag v0.19.11/go.mod h1:Uc0gKkdR+ojzsEpjh39QChyu92vPgIr72POcgHMAgSY=
 github.com/go-openapi/validate v0.17.2/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
@@ -752,8 +758,9 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -1000,6 +1007,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joyent/triton-go v0.0.0-20190112182421-51ffac552869/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -1099,8 +1108,9 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
+github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/pkger v0.17.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
@@ -1264,6 +1274,7 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
@@ -1521,6 +1532,7 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/smartystreets/assertions v0.0.0-20180725160413-e900ae048470/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
+github.com/smartystreets/assertions v1.1.1/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -1721,6 +1733,7 @@ golang.org/x/crypto v0.0.0-20200422194213-44a606286825/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1823,6 +1836,7 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201216054612-986b41b23924/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
@@ -1983,6 +1997,7 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -2204,8 +2219,9 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
+google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -2225,8 +2241,9 @@ gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUy
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -2337,6 +2354,7 @@ k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH
 k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6/go.mod h1:RZvgC8MSN6DjiMV6oIfEE9pDL9CYXokkfaCKZeHm3nc=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
+k8s.io/kube-openapi v0.0.0-20200923155610-8b5066479488/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
@@ -2376,8 +2394,15 @@ rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.19/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
+sigs.k8s.io/container-object-storage-interface-api v0.0.0-20210507174303-fac7c5076c3d/go.mod h1:WTzZGS4Q6MdQqDihJdMh2kCvqMx9Amhx0KIainA4lXQ=
+sigs.k8s.io/container-object-storage-interface-provisioner-sidecar v0.0.0-20210528161624-b46634c30d14 h1:5kSkLV2QTZAkzP2thjykzMrhk3DR9TJAM2jyYPhoJbY=
+sigs.k8s.io/container-object-storage-interface-provisioner-sidecar v0.0.0-20210528161624-b46634c30d14/go.mod h1:f0JfR9/8unxtADsMCD8JxebnkAWUTu11C7VGNEUqGVU=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210329232956-3bbacbbc9c19/go.mod h1:kafkL5l/lTUrZXhVi/9p1GzpEE/ts29BkWkL3Ao33WU=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210507203703-a97f2e98ac90 h1:gC+gbzEMq1EPR+QmXuDmC50USLWLY/8Ci2ezgqhloUs=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210507203703-a97f2e98ac90/go.mod h1:kafkL5l/lTUrZXhVi/9p1GzpEE/ts29BkWkL3Ao33WU=
 sigs.k8s.io/controller-runtime v0.2.0-beta.2/go.mod h1:TSH2R0nSz4WAlUUlNnOFcOR/VUhfwBLlmtq2X6AiQCA=
 sigs.k8s.io/controller-runtime v0.6.2/go.mod h1:vhcq/rlnENJ09SIRp3EveTaZ0yqH526hjf9iJdbUJ/E=
+sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/controller-runtime v0.7.0/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/controller-runtime v0.8.0/go.mod h1:v9Lbj5oX443uR7GXYY46E0EE2o7k2YxQ58GxVNeXSW4=
 sigs.k8s.io/controller-runtime v0.9.0/go.mod h1:TgkfvrhhEw3PlI0BRL/5xM+89y3/yc0ZDfdbTl84si8=
@@ -2396,6 +2421,7 @@ sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.1.0/go.mod h1:DhZ52sQMJHW
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/pkg/bucket/bucket.go
+++ b/pkg/bucket/bucket.go
@@ -83,7 +83,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(fmt.Errorf("Failed to get default bucketclass with error: %v", err))
 	}
 
-	tierName, err := bucketclass.CreateTieringStructure(*bucketClass, bucketName, nbClient);
+	tierName, err := bucketclass.CreateTieringStructure(*bucketClass.Spec.PlacementPolicy, bucketName, nbClient);
 	if err != nil {
 		log.Fatal(fmt.Errorf("CreateTieringStructure for PlacementPolicy failed to create policy %q with error: %v", tierName, err))
 	}

--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -658,12 +658,12 @@ func MapNamespacestoreToBucketclasses(namespacestore types.NamespacedName) []rec
 }
 
 // CreateTieringStructure creates a tering policy for a bucket
-func CreateTieringStructure(BucketClass nbv1.BucketClass, BucketName string, nbClient nb.Client) (string, error) {
+func CreateTieringStructure(PlacementPolicy nbv1.PlacementPolicy, BucketName string, nbClient nb.Client) (string, error) {
 	tierName := fmt.Sprintf("%s.%x", BucketName, time.Now().Unix())
 	tiers := []nb.TierItem{}
 
-	for i := range BucketClass.Spec.PlacementPolicy.Tiers {
-		tier := BucketClass.Spec.PlacementPolicy.Tiers[i]
+	for i := range PlacementPolicy.Tiers {
+		tier := PlacementPolicy.Tiers[i]
 		name := fmt.Sprintf("%s.%d", tierName, i)
 		tiers = append(tiers, nb.TierItem{Order: int64(i), Tier: name})
 		// we assume either mirror or spread but no mix and the bucket class controller rejects mixed classes.
@@ -687,7 +687,7 @@ func CreateTieringStructure(BucketClass nbv1.BucketClass, BucketName string, nbC
 		Tiers: tiers,
 	})
 	if err != nil {
-		return tierName, fmt.Errorf("Failed to create tier %q with error: %v", tierName, err)
+		return tierName, fmt.Errorf("Failed to create tiering policy %q with error: %v", tierName, err)
 	}
 	return tierName, nil
 }

--- a/pkg/controller/add_cosi.go
+++ b/pkg/controller/add_cosi.go
@@ -1,0 +1,13 @@
+package controller
+
+import (
+	"github.com/noobaa/noobaa-operator/v5/pkg/controller/cosi"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	if options.EnableCosi {
+		AddToManagerFuncs = append(AddToManagerFuncs, cosi.Add)
+	}
+}

--- a/pkg/controller/cosi/cosi_controller.go
+++ b/pkg/controller/cosi/cosi_controller.go
@@ -1,0 +1,15 @@
+package cosi
+
+import (
+	"github.com/noobaa/noobaa-operator/v5/pkg/cosi"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Add starts running the noobaa cosi provisioner
+func Add(mgr manager.Manager) error {
+	return cosi.RunProvisioner(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("noobaa-operator"),
+	)
+}

--- a/pkg/cosi/identityserver.go
+++ b/pkg/cosi/identityserver.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Ceph-COSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cosi
+
+import (
+	"context"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	cosi "sigs.k8s.io/container-object-storage-interface-spec"
+)
+
+// IdentityServer holds the name of NooBaa's COSI provisioner
+type IdentityServer struct {
+	provisioner string
+}
+
+// ProvisionerGetInfo returns the info of the Noobaa's COSI provisioner
+func (id *IdentityServer) ProvisionerGetInfo(ctx context.Context,
+	req *cosi.ProvisionerGetInfoRequest) (*cosi.ProvisionerGetInfoResponse, error) {
+	log := util.Logger()
+	if id.provisioner == "" {
+		log.Errorf("Provisioner name cannot be empty")
+		return nil, status.Error(codes.InvalidArgument, "Provisioner name is empty")
+	}
+
+	return &cosi.ProvisionerGetInfoResponse{
+		Name: id.provisioner,
+	}, nil
+}

--- a/pkg/cosi/provisioner.go
+++ b/pkg/cosi/provisioner.go
@@ -1,0 +1,430 @@
+package cosi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
+	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/system"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/container-object-storage-interface-provisioner-sidecar/pkg/provisioner"
+	cosi "sigs.k8s.io/container-object-storage-interface-spec"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Provisioner implements lib-bucket-provisioner callbacks
+type Provisioner struct {
+	client    client.Client
+	scheme    *runtime.Scheme
+	recorder  record.EventRecorder
+	Logger    *logrus.Entry
+	Namespace string
+}
+
+// RunProvisioner will run the COSI provisioner
+func RunProvisioner(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) error {
+
+	provisionerName := options.COSIProvisionerName()
+	log := logrus.WithField("provisioner", provisionerName)
+	log.Info("COSI Provisioner - start..")
+
+	p := &Provisioner{
+		client:    client,
+		scheme:    scheme,
+		recorder:  recorder,
+		Logger:    log,
+		Namespace: options.Namespace,
+	}
+
+	cosiProv, err := provisioner.NewDefaultCOSIProvisionerServer(options.CosiDriverAddress,
+		&IdentityServer{
+			provisioner: provisionerName,
+		}, p);
+	if err != nil {
+		return err
+	}
+
+	log.Info("running noobaa cosi provisioner ", provisionerName)
+	go func() {
+		util.Panic(cosiProv.Run(util.Context()))
+	}()
+
+	return nil
+}
+
+// ProvisionerCreateBucket is an idempotent method for creating buckets
+// It is expected to create the same bucket given a bucketName and protocol
+// If the bucket already exists, then it MUST return codes.AlreadyExists
+// Return values
+//    nil -                   Bucket successfully created
+//    codes.AlreadyExists -   Bucket already exists. No more retries
+//    non-nil err -           Internal error                                [requeue'd with exponential backoff]
+func (p *Provisioner) ProvisionerCreateBucket(ctx context.Context,
+	req *cosi.ProvisionerCreateBucketRequest) (*cosi.ProvisionerCreateBucketResponse, error) {
+	log := p.Logger
+
+	protocol := req.GetProtocol()
+	if protocol == nil {
+		msg := "Protocol is nil"
+		log.Errorf(msg)
+		return nil, status.Error(codes.InvalidArgument, msg)
+	}
+	s3 := protocol.GetS3()
+	if s3 == nil {
+		msg :=  "S3 protocol is missing, only S3 is supported"
+		log.Errorf(msg)
+		return nil, status.Error(codes.InvalidArgument, msg)
+	}
+	bucketName := req.GetName()
+	log.Infof("ProvisionerCreateBucket: got request to provision bucket %q", req.Name)
+	r, err := NewBucketRequest(p, req, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.SysClient.NooBaa.DeletionTimestamp != nil {
+		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
+		if util.Contains(nbv1.GracefulFinalizer, finalizersArray) {
+			msg := "NooBaa is in deleting state, new requests will be ignored"
+			log.Errorf(msg)
+			return nil, status.Error(codes.Internal, msg)
+		}
+	}
+	// TODO: we need to better handle the case that a bucket was created, but Provision failed
+	// right now we will fail on create bucket when Provision is called the second time
+	err = r.CreateBucket(p, req)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("ProvisionerCreateBucket: Successfully created backend Bucket %q", bucketName)
+
+	return &cosi.ProvisionerCreateBucketResponse{
+		BucketId: bucketName,
+	}, nil
+}
+
+// ProvisionerDeleteBucket is an idempotent method for deleting buckets
+// It is expected to delete the same bucket given a bucketName
+// Return values
+//    nil -                   Bucket successfully deleted
+//    non-nil err -           Internal error                                [requeue'd with exponential backoff]
+func (p *Provisioner) ProvisionerDeleteBucket(ctx context.Context,
+	req *cosi.ProvisionerDeleteBucketRequest) (*cosi.ProvisionerDeleteBucketResponse, error) {
+	log := p.Logger
+	log.Infof("ProvisionerDeleteBucket: got request to delete bucket %q", req.GetBucketId())
+
+	r, err := NewBucketRequest(p, nil, req)
+	if err != nil {
+		return nil, err
+	}
+	err = r.DeleteBucket()
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("ProvisionerDeleteBucket: Successfully deleted Bucket %q", req.GetBucketId())
+
+	return &cosi.ProvisionerDeleteBucketResponse{}, nil
+}
+
+// ProvisionerGrantBucketAccess is an idempotent method for granting bucket access
+// It is expected to grant access to the given bucketName
+// Return values
+//    nil -                   Access was successfully granted
+//    non-nil err -           Internal error                                [requeue'd with exponential backoff]
+func (p *Provisioner) ProvisionerGrantBucketAccess(ctx context.Context,
+	req *cosi.ProvisionerGrantBucketAccessRequest) (*cosi.ProvisionerGrantBucketAccessResponse, error) {
+	log := p.Logger
+	log.Infof("ProvisionerGrantBucketAccess: got request to grant user %q access to bucket %q", req.AccountName, req.BucketId)
+	r, err := NewAccountRequest(p, req, nil)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := r.CreateAccount()
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("ProvisionerGrantBucketAccess: Successfully created backend account %q", r.AccountName)
+
+	return &cosi.ProvisionerGrantBucketAccessResponse{
+		AccountId:   r.AccountName,
+		Credentials: fetchUserCredentials(*keys),
+	}, nil
+}
+
+// ProvisionerRevokeBucketAccess is an idempotent method for revoking bucket access
+// It is expected to revoke access of a given accountId to the given bucketId
+// Return values
+//    nil -                   Access successfully revoked
+//    non-nil err -           Internal error                                [requeue'd with exponential backoff]
+func (p *Provisioner) ProvisionerRevokeBucketAccess(ctx context.Context,
+	req *cosi.ProvisionerRevokeBucketAccessRequest) (*cosi.ProvisionerRevokeBucketAccessResponse, error) {
+	log := p.Logger
+	log.Infof("ProvisionerRevokeBucketAccess: got request to revoke user %q access to bucket %q", req.AccountId, req.BucketId)
+	r, err := NewAccountRequest(p, nil, req)
+	if err != nil {
+		return nil, err
+	}
+	err = r.DeleteAccount()
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("ProvisionerGrantBucketAccess: Successfully deleted Account %q", r.AccountName)
+	return &cosi.ProvisionerRevokeBucketAccessResponse{}, nil
+}
+
+
+// APIRequest is the context of handling a single api request (bucket or account)
+type APIRequest struct {
+	Provisioner *Provisioner
+	BucketName  string
+	AccountName  string
+	SysClient   *system.Client
+	Policy 		*nbv1.BucketClassSpec
+}
+
+// NewBucketRequest initializes a cosi bucket request
+func NewBucketRequest(
+	p *Provisioner,
+	bucketCreateReq *cosi.ProvisionerCreateBucketRequest,
+	bucketDelReq    *cosi.ProvisionerDeleteBucketRequest,
+) (*APIRequest, error) {
+	log := p.Logger
+	sysClient, err := system.Connect(false)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &APIRequest{
+		Provisioner: p,
+		SysClient:   sysClient,
+	}
+
+	if bucketCreateReq != nil {
+		r.BucketName = bucketCreateReq.Name
+		if bucketCreateReq.Parameters["policy"] != "" {
+			err = json.Unmarshal([]byte(bucketCreateReq.Parameters["policy"]), &r.Policy)
+			if err != nil {
+				msg := fmt.Sprintf("failed to parse policy in COSI params %s",
+					bucketCreateReq.Parameters["policy"],
+				)	
+				log.Error(msg)
+				return nil, status.Error(codes.Internal, msg)
+			}
+		}
+	} else if bucketDelReq != nil {
+		r.BucketName = bucketDelReq.BucketId
+	}
+	return r, nil
+}
+
+// NewAccountRequest initializes a cosi bucket access request
+func NewAccountRequest(
+	p *Provisioner,
+	accountCreateReq *cosi.ProvisionerGrantBucketAccessRequest,
+	accountDelReq    *cosi.ProvisionerRevokeBucketAccessRequest,
+) (*APIRequest, error) {
+
+	sysClient, err := system.Connect(false)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &APIRequest{
+		Provisioner: p,
+		SysClient:   sysClient,
+	}
+
+	if accountCreateReq != nil {
+		r.BucketName = accountCreateReq.BucketId
+		r.AccountName = accountCreateReq.AccountName
+	} else if accountDelReq != nil {
+		r.BucketName = accountDelReq.BucketId
+		r.AccountName = accountDelReq.AccountId
+	}
+
+	return r, nil
+}
+
+// CreateBucket creates a new cosi bucket
+func (r *APIRequest) CreateBucket(
+	p *Provisioner,
+	bucketReq *cosi.ProvisionerCreateBucketRequest,
+) error {
+
+	log := r.Provisioner.Logger
+
+	_, err := r.SysClient.NBClient.ReadBucketAPI(nb.ReadBucketParams{Name: r.BucketName})
+	if err == nil {
+		msg := fmt.Sprintf("Bucket %q already exists", r.BucketName)
+		log.Error(msg)
+		return status.Error(codes.InvalidArgument, msg)
+	}
+	if nbErr, ok := err.(*nb.RPCError); ok && nbErr.RPCCode != "NO_SUCH_BUCKET" {
+		return status.Error(codes.Internal, nbErr.RPCCode)
+	}
+
+	if r.Policy == nil {
+		msg := fmt.Sprintf("BucketClass/Bucket policy not loaded %#v", r)
+		log.Error(msg)
+		return status.Error(codes.Internal, msg)
+	}
+	createBucketParams := &nb.CreateBucketParams{
+		Name: r.BucketName,
+	}
+	if r.Policy.PlacementPolicy != nil {
+		tierName, err := bucketclass.CreateTieringStructure(*r.Policy.PlacementPolicy, r.BucketName, r.SysClient.NBClient)
+		createBucketParams.Tiering = tierName
+		if err != nil {
+			return fmt.Errorf("CreateTieringStructure for PlacementPolicy failed to create policy %q with error: %v", tierName, err)
+		}
+		createBucketParams.Tiering = tierName
+	}
+
+	// create NS bucket
+	if r.Policy.NamespacePolicy != nil {
+		namespacePolicyType := r.Policy.NamespacePolicy.Type
+		var readResources []nb.NamespaceResourceFullConfig
+		createBucketParams.Namespace = &nb.NamespaceBucketInfo{}
+
+		if namespacePolicyType == nbv1.NSBucketClassTypeSingle {
+			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{ 
+				Resource: r.Policy.NamespacePolicy.Single.Resource,
+				Path:  bucketReq.Parameters["path"],
+			}
+			createBucketParams.Namespace.ReadResources = append(readResources, nb.NamespaceResourceFullConfig{ 
+				Resource: r.Policy.NamespacePolicy.Single.Resource })
+		} else if namespacePolicyType == nbv1.NSBucketClassTypeMulti {
+			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{ 
+				Resource: r.Policy.NamespacePolicy.Multi.WriteResource,
+				Path:  bucketReq.Parameters["path"],
+			}
+			for i := range r.Policy.NamespacePolicy.Multi.ReadResources {
+				rr := r.Policy.NamespacePolicy.Multi.ReadResources[i]
+				readResources = append(readResources, nb.NamespaceResourceFullConfig{Resource: rr})
+			}
+			createBucketParams.Namespace.ReadResources = readResources
+		} else if namespacePolicyType == nbv1.NSBucketClassTypeCache {
+			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{
+				Resource: r.Policy.NamespacePolicy.Cache.HubResource}
+			createBucketParams.Namespace.ReadResources = append(readResources, nb.NamespaceResourceFullConfig{
+				Resource: r.Policy.NamespacePolicy.Cache.HubResource})
+			createBucketParams.Namespace.Caching = &nb.CacheSpec{TTLMs: r.Policy.NamespacePolicy.Cache.Caching.TTL}
+			//cachePrefix := r.BucketClass.Spec.NamespacePolicy.Cache.Prefix
+		}
+	}
+	err = r.SysClient.NBClient.CreateBucketAPI(*createBucketParams)
+
+	if err != nil {
+		if nbErr, ok := err.(*nb.RPCError); ok {
+			if nbErr.RPCCode == "BUCKET_ALREADY_EXISTS" {
+				msg := fmt.Sprintf("Bucket %q already exists", r.BucketName)
+				log.Error(msg)
+				return status.Error(codes.InvalidArgument, msg)
+			}
+		}
+		return fmt.Errorf("Failed to create bucket %q with error: %v", r.BucketName, err)
+	}
+
+	log.Infof("✅ Successfully created bucket %q", r.BucketName)
+	return nil
+}
+
+// CreateAccount creates a new bar account
+func (r *APIRequest) CreateAccount() (*nb.S3AccessKeys, error) {
+	log := r.Provisioner.Logger
+	_, err := r.SysClient.NBClient.ReadBucketAPI(nb.ReadBucketParams{Name: r.BucketName})
+	if nbErr, ok := err.(*nb.RPCError); ok && nbErr.RPCCode == "NO_SUCH_BUCKET" {
+		return nil, status.Error(codes.Internal, nbErr.RPCCode)
+	}
+	accountInfo, err := r.SysClient.NBClient.CreateAccountAPI(nb.CreateAccountParams{
+		Name:              r.AccountName,
+		Email:             r.AccountName,
+		DefaultResource:   "",
+		HasLogin:          false,
+		S3Access:          true,
+		AllowBucketCreate: false,
+		AllowedBuckets: nb.AccountAllowedBuckets{
+			FullPermission: false,
+			PermissionList: []string{r.BucketName},
+		},
+		BucketClaimOwner: r.BucketName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var accessKeys nb.S3AccessKeys
+	// if we didn't get the access keys in the create_account reply we might be talking to an older noobaa version (prior to 5.1)
+	// in that case try to get it using read account
+	if len(accountInfo.AccessKeys) == 0 {
+		log.Info("CreateAccountAPI did not return access keys. calling ReadAccountAPI to get keys..")
+		readAccountReply, err := r.SysClient.NBClient.ReadAccountAPI(nb.ReadAccountParams{Email: r.AccountName})
+		if err != nil {
+			return nil, err
+		}
+		accessKeys = readAccountReply.AccessKeys[0]
+	} else {
+		accessKeys = accountInfo.AccessKeys[0]
+	}
+
+	log.Infof("✅ Successfully created account %q with access to bucket %q", r.AccountName, r.BucketName)
+	return &accessKeys, nil
+}
+
+// DeleteAccount deletes the bar account
+func (r *APIRequest) DeleteAccount() error {
+
+	log := r.Provisioner.Logger
+	log.Infof("deleting account %q", r.AccountName)
+	err := r.SysClient.NBClient.DeleteAccountAPI(nb.DeleteAccountParams{Email: r.AccountName})
+
+	if err != nil {
+		if nbErr, ok := err.(*nb.RPCError); ok && nbErr.RPCCode == "NO_SUCH_ACCOUNT" {
+			log.Warnf("Account to delete was not found %q", r.AccountName)
+		} else {
+			return fmt.Errorf("failed to delete account %q. got error: %v", r.AccountName, err)
+		}
+	} else {
+		log.Infof("✅ Successfully deleted account %q", r.AccountName)
+	}
+
+	return nil
+}
+
+// DeleteBucket deletes the cosi bucket **including data**
+func (r *APIRequest) DeleteBucket() error {
+	// TODO we should support the different delete options - not completely closed by the KEP
+	var err error
+	log := r.Provisioner.Logger
+	info, err := r.SysClient.NBClient.ReadBucketAPI(nb.ReadBucketParams{Name: r.BucketName})
+	if nbErr, ok := err.(*nb.RPCError); ok && nbErr.RPCCode != "NO_SUCH_BUCKET" {
+		log.Warnf("Bucket to delete was not found %q", r.BucketName)
+		return nil
+	}
+	log.Infof("deleting bucket %q", r.BucketName)
+	if info.Namespace != nil {
+		err = r.SysClient.NBClient.DeleteBucketAPI(nb.DeleteBucketParams{Name: r.BucketName})
+	} else {
+		err = r.SysClient.NBClient.DeleteBucketAndObjectsAPI(nb.DeleteBucketParams{Name: r.BucketName})
+	}
+	if err != nil {
+		return fmt.Errorf("failed to delete bucket %q. got error: %v", r.BucketName, err)
+	}
+
+	log.Infof("✅ Successfully deleted bucket %q", r.BucketName)
+	return nil
+}
+
+func fetchUserCredentials(accessKeys nb.S3AccessKeys) string {
+	return fmt.Sprintf("[default]\naws_access_key %s\naws_secret_key %s", accessKeys.AccessKey, accessKeys.SecretKey)
+}

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -376,7 +376,7 @@ func (r *BucketRequest) CreateBucket(
 			return fmt.Errorf("Could not create OBC %q with inner path while missing namespace bucketclass", r.OBC.Name)
 		}
 
-		tierName, err := bucketclass.CreateTieringStructure(*r.BucketClass, r.BucketName, r.SysClient.NBClient)
+		tierName, err := bucketclass.CreateTieringStructure(*r.BucketClass.Spec.PlacementPolicy, r.BucketName, r.SysClient.NBClient)
 		if err != nil {
 			return fmt.Errorf("CreateTieringStructure for PlacementPolicy failed to create policy %q with error: %v", tierName, err)
 		}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -228,6 +228,9 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.SecurityContextConstraints = util.KubeObject(bundle.File_deploy_scc_yaml).(*secv1.SecurityContextConstraints)
 	c.SCCEndpoint = util.KubeObject(bundle.File_deploy_scc_endpoint_yaml).(*secv1.SecurityContextConstraints)
 	c.Deployment = util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
+	if (options.EnableCosi) {
+		c.Deployment = util.KubeObject(bundle.File_deploy_operator_cosi_yaml).(*appsv1.Deployment)
+	}
 
 	c.NS.Name = options.Namespace
 	c.SA.Namespace = options.Namespace
@@ -250,6 +253,9 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	if options.ImagePullSecret != "" {
 		c.Deployment.Spec.Template.Spec.ImagePullSecrets =
 			[]corev1.LocalObjectReference{{Name: options.ImagePullSecret}}
+	}
+	if options.EnableCosi {
+		c.Deployment.Spec.Template.Spec.Containers[1].Image = options.CosiSideCarImage
 	}
 
 	c.SecurityContextConstraints.Users[0] = fmt.Sprintf("system:serviceaccount:%s:%s", options.Namespace, c.SA.Name)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -63,6 +63,9 @@ var Namespace = "noobaa"
 // it can be overridden for testing or different registry locations.
 var OperatorImage = "noobaa/noobaa-operator:" + version.Version
 
+// CosiSideCarImage is the container image url built from https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar
+var CosiSideCarImage = "quay.io/containerobjectstorage/objectstorage-sidecar:canary"
+
 // NooBaaImage is the container image url built from https://github.com/noobaa/noobaa-core
 // it can be overridden for testing or different registry locations.
 var NooBaaImage = ContainerImage
@@ -113,6 +116,12 @@ var MiniEnv = false
 // DisableLoadBalancerService is used for setting the service type to ClusterIP instead of LoadBalancer
 var DisableLoadBalancerService = false
 
+// EnableCosi is used to enable the operator with cosi and attaching the cosi sidecar to the operator
+var EnableCosi = false
+
+// CosiDriverAddress is the cosi socket address
+var CosiDriverAddress = "unix:///var/lib/cosi/cosi.sock"
+
 // SubDomainNS returns a unique subdomain for the namespace
 func SubDomainNS() string {
 	return Namespace + ".noobaa.io"
@@ -121,6 +130,11 @@ func SubDomainNS() string {
 // ObjectBucketProvisionerName returns the provisioner name to be used in storage classes for OB/OBC
 func ObjectBucketProvisionerName() string {
 	return SubDomainNS() + "/obc"
+}
+
+// COSIProvisionerName returns the provisioner name to be used in for COSI
+func COSIProvisionerName() string {
+	return "noobaa.objectstorage.k8s.io"
 }
 
 // FlagSet defines the
@@ -183,7 +197,15 @@ func init() {
 		false, "Signal the operator that it is running in a low resource environment",
 	)
 	FlagSet.BoolVar(
+		&EnableCosi, "cosi",
+		false, "Enable cosi support in the operator",
+	)
+	FlagSet.BoolVar(
 		&DisableLoadBalancerService, "disable-load-balancer",
 		false, "Set the service type to ClusterIP instead of LoadBalancer",
+	)
+	FlagSet.StringVar(
+		&CosiDriverAddress, "cosi-driver-addr",
+		CosiDriverAddress, "unix socket address for COSI",
 	)
 }


### PR DESCRIPTION
Signed-off-by: jackyalbo <jalbo@redhat.com>

### Explain the changes
1. Adding a COSI provisioner to support cosi API 4 commands: Create/Delete Bucket, and Grant/Revoke Bucket Access
2. Add an option to run w/o cosi support --cosi
3. Running with cosi support will start the cosi sidecar container as part of operator pod
4. Adding example yaml files for all 4 cosi CRDs: bucketClass, bucketRequest, bucketAccessClass and bucketAccessRequest. bucketClass is adapted for supporting noobaa's default placement policy using the default backingstore.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
