### PR TITLE
Remove the prints of S3 credentials from NooBaa create backingstore and namespacestore

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -780,10 +780,8 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	fmt.Print(string(output))
 	fmt.Println()
 	if secretRef != nil {
-		fmt.Println("# Secret data:")
-		output, err = sigyaml.Marshal(secret.StringData)
+		_, err = sigyaml.Marshal(secret.StringData)
 		util.Panic(err)
-		fmt.Print(string(output))
 		fmt.Println()
 	}
 }

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -522,10 +522,8 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	fmt.Print(string(output))
 	fmt.Println()
 	if secretRef != nil {
-		fmt.Println("# Secret data:")
-		output, err = sigyaml.Marshal(secret.StringData)
+		_, err = sigyaml.Marshal(secret.StringData)
 		util.Panic(err)
-		fmt.Print(string(output))
 		fmt.Println()
 	}
 }


### PR DESCRIPTION
### Explain the changes

Remove  Secret data printing from backingstore and namespacestore

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1.  Fixes: #783 

### Testing Instructions:
1.  Run `noobaa backingstore create` or `noobaa  namespacestore create` and see that it is not printing the `# Secret data:`