### PR TITLE
Fix CLI install - DB init container

### DIFF
--- a/deploy/scc_endpoint.yaml
+++ b/deploy/scc_endpoint.yaml
@@ -7,7 +7,7 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities:
 - SETUID

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4878,7 +4878,7 @@ volumes:
 - secret
 `
 
-const Sha256_deploy_scc_endpoint_yaml = "5b7d6160b89ee45394d9c972fdee8a1f7527fd6bc87de5c90958c4386cd877e5"
+const Sha256_deploy_scc_endpoint_yaml = "ffa08bb5ddf81e493d19dc089e3d5e9be08df971212530654b30da17e91f338a"
 
 const File_deploy_scc_endpoint_yaml = `apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -4889,7 +4889,7 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities:
 - SETUID


### PR DESCRIPTION
Endpoint SCC is used by the DB.
allowPrivilegeEscalation has to be true for DB init
container pv chown to succeed.

The value is already true in OCS operator:
https://github.com/red-hat-storage/ocs-operator/blob/3ce08ad22efa4b4bcb53e5aa3216d8532f2c4bf1/controllers/ocsinitialization/sccs.go#L169

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
