### PR TITLE
Increase CLI test timeout/Restore core image version

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.9.0-20210722"
+	ContainerImageTag = "5.9.0-20211118"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -125,7 +125,7 @@ function test_noobaa {
 function timeout {
     local PID func
     #the timeout is that big because it sometimes take a while to get pvc
-    local TIMEOUT=180
+    local TIMEOUT=600
     while true
     do
         if [[ ! "${1}" =~ "--" ]]


### PR DESCRIPTION

1. Increase CLI test timeout
2. Restore core image version

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>