### PR TITLE
[backport to 5.8] removed tiering creation for namespace buckets

### DIFF
--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -353,19 +353,6 @@ func (r *BucketRequest) CreateBucket(
 		var readResources []nb.NamespaceResourceFullConfig
 		createBucketParams.Namespace = &nb.NamespaceBucketInfo{}
 
-		if r.BucketClass.Spec.PlacementPolicy == nil { // For none-caching will use default bucket class
-			defaultBucketClass, err := GetDefaultBucketClass(p, bucketOptions)
-			if err != nil {
-				return fmt.Errorf("GetDefaultBucketClass for NamespacePolicy failed with error: %v", err)
-			}
-
-			tierName, err := r.CreateTieringStructure(*defaultBucketClass)
-			if err != nil {
-				return fmt.Errorf("CreateTieringStructure for NamespacePolicy failed to create policy %q with error: %v", tierName, err)
-			}
-			createBucketParams.Tiering = tierName
-		}
-
 		if namespacePolicyType == nbv1.NSBucketClassTypeSingle {
 			createBucketParams.Namespace.WriteResource = nb.NamespaceResourceFullConfig{
 				Resource: r.BucketClass.Spec.NamespacePolicy.Single.Resource}

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1095,6 +1095,11 @@ func (r *Reconciler) UpdateBucketClassesPhase(Buckets []nb.BucketInfo) {
 		bc := &bucketclassList.Items[i]
 		for _, bucket := range Buckets {
 
+			// in case of a namespace bucket, we might not have bucket.Tiering. skip
+			if bucket.Tiering == nil {
+				continue
+			}
+
 			bucketTieringPolicyName := ""
 			if bucket.BucketClaim != nil {
 				bucketTieringPolicyName = bucket.BucketClaim.BucketClass


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 9dbc41421583d1040804fc52ffa700c4d0af015c)

### Explain the changes
1. backported https://github.com/noobaa/noobaa-operator/pull/686

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
