### PR TITLE
Adding `fsGroupChangePolicy` and `seLinuxOptions` to `securityContext`

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -46,6 +46,9 @@ spec:
               cpu: "1"
               memory: "2Gi"
           securityContext:
+            fsGroupChangePolicy: "OnRootMismatch"
+            seLinuxOptions:
+              type: "spc_t"
             capabilities:
               add: ["SETUID", "SETGID"]
           ports:

--- a/deploy/scc_endpoint.yaml
+++ b/deploy/scc_endpoint.yaml
@@ -24,7 +24,7 @@ requiredDropCapabilities:
 runAsUser:
   type: RunAsAny
 seLinuxContext:
-  type: MustRunAs
+  type: RunAsAny
 supplementalGroups:
   type: RunAsAny
 users:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2890,7 +2890,7 @@ data:
           su postgres -c "bash -x /usr/bin/run-postgresql"
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "d098321ca3038440e35b27277c1e38eedea852a5be25371e29a442d5f7987590"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "26b0dc615d97e493cac78d7050e3156d01a1033e3b7b6397fd037a6c74971c0b"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -2940,6 +2940,9 @@ spec:
               cpu: "1"
               memory: "2Gi"
           securityContext:
+            fsGroupChangePolicy: "OnRootMismatch"
+            seLinuxOptions:
+              type: "spc_t"
             capabilities:
               add: ["SETUID", "SETGID"]
           ports:
@@ -4948,7 +4951,7 @@ volumes:
 - secret
 `
 
-const Sha256_deploy_scc_endpoint_yaml = "ffa08bb5ddf81e493d19dc089e3d5e9be08df971212530654b30da17e91f338a"
+const Sha256_deploy_scc_endpoint_yaml = "27642f221c6289dff59734f9368aa5dcb3b10fe6c98de8aba2bfb71807c30c66"
 
 const File_deploy_scc_endpoint_yaml = `apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -4976,7 +4979,7 @@ requiredDropCapabilities:
 runAsUser:
   type: RunAsAny
 seLinuxContext:
-  type: MustRunAs
+  type: RunAsAny
 supplementalGroups:
   type: RunAsAny
 users:


### PR DESCRIPTION
### Explain the changes
- Adding `fsGroupChangePolicy` and `seLinuxOptions` to `securityContext`

according to https://hackmd.io/7heLp_noQmqU_Ef7VaiCKg when we have a large number of files and we want to mount the volume we can get the `Error: context deadline exceeded`.

there are 2 root causes (which are detailed in the link above), and this PR tries to handle them both.

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: https://github.com/noobaa/noobaa-core/issues/6708
2. Fixes: https://github.com/noobaa/noobaa-core/issues/6786
3. Fixes: https://github.com/noobaa/noobaa-core/issues/6707

### Testing Instructions:
1. Attach a directory with a large number of files to a bucket (or write a lot of files into an NSFS bucket).
2. Restart the endpoint
3. See that there are the endpoint is not in `CreateContainerError` and there are no `Error: context deadline exceeded`
