### PR TITLE
added toleration node.ocs.openshift.io/storage to noobaa-operator deployment

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -268,6 +268,15 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 					Name:  "NOOBAA_DB_IMAGE",
 					Value: options.DBImage,
 				})
+
+			csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Tolerations = []corev1.Toleration{
+				{
+					Key:      "node.ocs.openshift.io/storage",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpEqual,
+					Value:    "true",
+				},
+			}
 		}
 
 		if csvParams.Replaces != "" {


### PR DESCRIPTION
### Explain the changes
1.  in CSV generation for ODF - add toleration for `node.ocs.openshift.io/storage`

### Issues: Fixed #xxx / Gap #xxx
1. fix for bz https://bugzilla.redhat.com/show_bug.cgi?id=2023275

### Testing Instructions:
1. 
