### PR TITLE
[backport to 5.9] added toleration node.ocs.openshift.io/storage to noobaa-operator deployment

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -265,6 +265,15 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 					Name:  "NOOBAA_DB_IMAGE",
 					Value: options.DBImage,
 				})
+
+			csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Tolerations = []corev1.Toleration{
+				{
+					Key:      "node.ocs.openshift.io/storage",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpEqual,
+					Value:    "true",
+				},
+			}
 		}
 
 		if csvParams.Replaces != "" {


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 4ce37dc8646ac886b46ea9388ca8f8334d539cc5)

### Explain the changes
1. backported pr #798 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
