### PR TITLE
Add admission webhook cli deployment

### DIFF
--- a/deploy/internal/admission-webhook.yaml
+++ b/deploy/internal/admission-webhook.yaml
@@ -2,8 +2,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: admission-validation-webhook
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
   - name: admissionwebhook.noobaa.io
     matchPolicy: Equivalent
@@ -26,7 +24,7 @@ webhooks:
     sideEffects: None
     clientConfig:
       service:
-        name: noobaa-operator-service
+        name: admission-webhook-service
         namespace: placeholder
         path: "/validate"
       caBundle:

--- a/deploy/internal/service_admission_webhook.yaml
+++ b/deploy/internal/service_admission_webhook.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: admission-webhook-service
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    targetPort: 8080
+  selector:
+    noobaa-operator: deployment

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2679,14 +2679,12 @@ metadata:
 spec: {}
 `
 
-const Sha256_deploy_internal_admission_webhook_yaml = "ff31e4f8fc894f2ebed18058a9a200c2bb66d3045677b84d8fb5f5630bf76ac5"
+const Sha256_deploy_internal_admission_webhook_yaml = "10f0567d8cd2c7f37d305de4e34787138863546c8ad39c5da6fbfa7b0c4ab587"
 
 const File_deploy_internal_admission_webhook_yaml = `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: admission-validation-webhook
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
   - name: admissionwebhook.noobaa.io
     matchPolicy: Equivalent
@@ -2709,13 +2707,14 @@ webhooks:
     sideEffects: None
     clientConfig:
       service:
-        name: noobaa-operator-service
+        name: admission-webhook-service
         namespace: placeholder
         path: "/validate"
       caBundle:
     admissionReviewVersions: ["v1", "v1beta1"]
     failurePolicy: Ignore
-    timeoutSeconds: 5`
+    timeoutSeconds: 5
+`
 
 const Sha256_deploy_internal_ceph_objectstore_user_yaml = "655f33a1e3053847a298294d67d7db647d26fd11d1df7e229af718a8308bbd8e"
 
@@ -3453,6 +3452,21 @@ spec:
     - port: 7004
       name: metrics
 
+`
+
+const Sha256_deploy_internal_service_admission_webhook_yaml = "810a70b263d44621713864aa6e6e72e6079bbdc02f6e2b9143ba9ebf4ab52102"
+
+const File_deploy_internal_service_admission_webhook_yaml = `apiVersion: v1
+kind: Service
+metadata:
+  name: admission-webhook-service
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    targetPort: 8080
+  selector:
+    noobaa-operator: deployment
 `
 
 const Sha256_deploy_internal_servicemonitor_mgmt_yaml = "172b25b71872e74fb32ecf32b9c68d41cc60d155cb469ed5ecf7ad282f3e597a"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -113,6 +113,9 @@ var MiniEnv = false
 // DisableLoadBalancerService is used for setting the service type to ClusterIP instead of LoadBalancer
 var DisableLoadBalancerService = false
 
+// AdmissionWebhook is used for deploying the system with admission validation webhook
+var AdmissionWebhook = false
+
 // SubDomainNS returns a unique subdomain for the namespace
 func SubDomainNS() string {
 	return Namespace + ".noobaa.io"
@@ -185,5 +188,9 @@ func init() {
 	FlagSet.BoolVar(
 		&DisableLoadBalancerService, "disable-load-balancer",
 		false, "Set the service type to ClusterIP instead of LoadBalancer",
+	)
+	FlagSet.BoolVar(
+		&AdmissionWebhook, "admission",
+		false, "Install the system with admission validation webhook",
 	)
 }

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -176,7 +176,7 @@ function install {
     local use_obc_cleanup_policy
     
     [ $((RANDOM%2)) -gt 0 ] && use_obc_cleanup_policy="--use-obc-cleanup-policy"
-    test_noobaa install --mini ${use_obc_cleanup_policy}
+    test_noobaa install --mini --admission ${use_obc_cleanup_policy}
 
     local status=$(kuberun silence get noobaa noobaa -o 'jsonpath={.status.phase}')
     while [ "${status}" != "Ready" ]
@@ -193,6 +193,13 @@ function noobaa_install {
     test_noobaa status
     kuberun get noobaa
     kuberun describe noobaa
+    test_admission_deployment
+}
+
+function test_admission_deployment {
+    kuberun get Secret "admission-webhook-secret"
+    kuberun get ValidatingWebhookConfiguration "admission-validation-webhook"
+    kuberun get Service "admission-webhook-service"
 }
 
 function check_core_config_map {

--- a/test/test-olm.sh
+++ b/test/test-olm.sh
@@ -40,6 +40,7 @@ function create_catalog() {
     echo "----> Creating CatalogSource ..."
     # kubectl delete -n olm catalogsource operatorhubio-catalog
     yq write deploy/olm/catalog-source.yaml spec.image $CATALOG_IMAGE | kubectl apply -f -
+    # yq eval ".spec.image = \"$CATALOG_IMAGE"\" deploy/olm/catalog-source.yaml
 }
 
 function create_subscription() {
@@ -62,7 +63,8 @@ function wait_for_operator() {
     done
 
     echo "----> Wait for operator to be ready ..."
-    kubectl wait pod -l noobaa-operator=deployment --for condition=ready
+    # kubectl wait pod -l noobaa-operator=deployment --for condition=ready
+    kubectl rollout status deployment noobaa-operator
 }
 
 function test_operator() {


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. Add admission webhook deployment in cli installation.
2. Deploy the required resources for the admission webhook (ValidationWebhookConfiguration, Service, Secret).
3. Generate self-signed certificate for the admission webhook server to use.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
