### PR TITLE
fixed default backingstore creation in azure

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -775,8 +775,9 @@ func (r *Reconciler) prepareAzureBackingStore() error {
 		r.AzureContainerCreds.StringData["AccountKey"] = key
 	}
 
+	azureContainerName := ""
 	if r.AzureContainerCreds.StringData["targetBlobContainer"] == "" {
-		var azureContainerName = strings.ToLower(randname.GenerateWithPrefix("noobaacontainer", 5))
+		azureContainerName = strings.ToLower(randname.GenerateWithPrefix("noobaacontainer", 5))
 		_, err := r.CreateContainer(r.AzureContainerCreds.StringData["AccountName"], azureGroupName, azureContainerName)
 		if err != nil {
 			return err
@@ -791,7 +792,7 @@ func (r *Reconciler) prepareAzureBackingStore() error {
 	// create backing store
 	r.DefaultBackingStore.Spec.Type = nbv1.StoreTypeAzureBlob
 	r.DefaultBackingStore.Spec.AzureBlob = &nbv1.AzureBlobSpec{
-		TargetBlobContainer: r.AzureContainerCreds.StringData["targetBlobContainer"],
+		TargetBlobContainer: azureContainerName,
 		Secret: corev1.SecretReference{
 			Name:      r.AzureContainerCreds.Name,
 			Namespace: r.AzureContainerCreds.Namespace,
@@ -1000,12 +1001,12 @@ func (r *Reconciler) prepareCephBackingStore() error {
 	forcePathStyle := true
 	client := &http.Client{
 		Transport: util.InsecureHTTPTransport,
-		Timeout: 10 * time.Second, 
-	}	
+		Timeout:   10 * time.Second,
+	}
 	if r.ApplyCAsToPods != "" {
 		client.Transport = util.SecureHTTPTransport
 	}
-	
+
 	s3Config := &aws.Config{
 		Credentials: credentials.NewStaticCredentials(
 			cephObjectStoreUserSecret.StringData["AccessKey"],


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1.  target container for the default backing store was assigned to the backing store spec from the credentials secret `StringData` (line 794 below). 
2. just before taking the target container from the secret, it was updated in the API server (line 787 below).
3. In the newer versions of the API client, this Update caused the StringData to be cleared, so an empty string was taken as the target container
4. changed so that the target container will be read from another local var

https://github.com/noobaa/noobaa-operator/blob/f3df8d7d06a383b58533f3438c46b84cd658056e/pkg/system/phase4_configuring.go#L787-L799

### Issues: Fixed #xxx / Gap #xxx
1.  Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2023769

### Testing Instructions:
1. 
