### PR TITLE
Add Regenerate S3 Credentials to the CLI

### DIFF
--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -59,6 +59,8 @@ type Client interface {
 	PutBucketReplicationAPI(BucketReplicationParams) error
 	ValidateReplicationAPI(BucketReplicationParams) error
 	DeleteBucketReplicationAPI(DeleteBucketReplicationParams) error
+
+	GenerateAccountKeysAPI(GenerateAccountKeysParams) error
 }
 
 // ReadAuthAPI calls auth_api.read_auth()
@@ -400,5 +402,11 @@ func (c *RPCClient) ValidateReplicationAPI(params BucketReplicationParams) error
 // DeleteBucketReplicationAPI calls bucket_api.delete_bucket_replication()
 func (c *RPCClient) DeleteBucketReplicationAPI(params DeleteBucketReplicationParams) error {
 	req := &RPCMessage{API: "bucket_api", Method: "delete_bucket_replication", Params: params}
+	return c.Call(req, nil)
+}
+
+// GenerateAccountKeysAPI calls account_api.generate_account_keys()
+func (c *RPCClient) GenerateAccountKeysAPI(params GenerateAccountKeysParams) error {
+	req := &RPCMessage{API: "account_api", Method: "generate_account_keys", Params: params}
 	return c.Call(req, nil)
 }

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -409,6 +409,11 @@ type CreateAccountReply struct {
 	AccessKeys []S3AccessKeys `json:"access_keys"`
 }
 
+// GenerateAccountKeysParams is the params of account_api.generate_account_keys()
+type GenerateAccountKeysParams struct {
+	Email             string                `json:"email"`
+}
+
 // BackingStoreInfo describes backingstore info
 type BackingStoreInfo struct {
 	// Name describes backingstore name


### PR DESCRIPTION
### Explain the changes
Add Regenerate S3 Credentials to the CLI

Handling 3 cases:
1. An account with no CRD and no secret
2. An account with no CRD but with secret
3. An account with CRD and with a secret

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Testing Instructions:
1.  regenerate the s3 keys see that they changed and try to use them
