### PR TITLE
set EnableHTTPSTrafficOnly on create storage account

### DIFF
--- a/pkg/system/azure_utils.go
+++ b/pkg/system/azure_utils.go
@@ -54,6 +54,7 @@ func (r *Reconciler) CreateStorageAccount(accountName, accountGroupName string) 
 			accountName, err, *result.Message)
 	}
 
+	enableHTTPSTrafficOnly := true
 	future, err := storageAccountsClient.Create(
 		r.Ctx,
 		accountGroupName,
@@ -63,7 +64,7 @@ func (r *Reconciler) CreateStorageAccount(accountName, accountGroupName string) 
 				Name: storage.StandardLRS},
 			Kind:                              storage.Storage,
 			Location:                          to.StringPtr(r.AzureContainerCreds.StringData["azure_region"]),
-			AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{},
+			AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{EnableHTTPSTrafficOnly: &enableHTTPSTrafficOnly},
 		})
 
 	if err != nil {


### PR DESCRIPTION
### Explain the changes
* when creating a storage account in azure utils - setting EnableHTTPSTrafficOnly param to true.
* This is required for creating a storage account for resource groups that enforce secure transfer for storage account

### Issues: Fixed #xxx / Gap #xxx
1. fixes https://bugzilla.redhat.com/show_bug.cgi?id=1970123

### Testing Instructions:
1. 
