### PR TITLE
RPC WS refactor

### DIFF
--- a/pkg/nb/rpc_http.go
+++ b/pkg/nb/rpc_http.go
@@ -18,7 +18,7 @@ type RPCConnHTTP struct {
 }
 
 // NewRPCConnHTTP returns a new http connection
-func NewRPCConnHTTP(r *RPC, address string) *RPCConnHTTP {
+func NewRPCConnHTTP(r *RPC, address string) RPCConn {
 	return &RPCConnHTTP{
 		RPC:     r,
 		Address: address,
@@ -28,10 +28,6 @@ func NewRPCConnHTTP(r *RPC, address string) *RPCConnHTTP {
 // GetAddress returns the connection address
 func (c *RPCConnHTTP) GetAddress() string {
 	return c.Address
-}
-
-// Reconnect is doing nothing for http connection
-func (c *RPCConnHTTP) Reconnect() {
 }
 
 // Call calls an API method to noobaa over https


### PR DESCRIPTION
 RPC WS refactor

    - Use channel/goroutine for sending messages
    - Rework connect/reconnect logic
    - Remove WS specific logic from common RPC layer


# Description

## Abstract
[RPCConnWS](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L34-L47) implements [RPCConn](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc.go#L47-L54) interface used by the RPC layer in terms of [nhooyr.io/websocket](https://github.com/nhooyr/websocket) transport. RPC messages are dispatched according to address URL protocol in [GetConnection()](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc.go#L182-L192).

## States
RPCConnWS is a WebSocket connection that is shared and multiplexed
 for all concurrent requests to the same address.  An RPCConnWS instance is [constructed](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L57-L98) in a connected state and ready for executing RPC Calls.  `nil` is returned if connection refused or within [reconnect delay](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L20). RPCConnWS detects peer disconnect on send and receives paths enhanced by heartbeat Ping goroutine and closes gracefully.

### [Connection, reconnection map](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L25-L31)
[NewRPCConnWS](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L57-L98) uses connection and reconnection tables mapped by the connection's address URL. The state shared by the construction and closing logic is guarded by the mutex, unlocking is insured by deferring unlock.

## IO 
### Threads
An open connection is served by three goroutines two of those pump messages between the WebSocket and [Call](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L46) and [Reply](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L54) channels, while one is used for WS control ping-pong to improve reaction time to peer disconnect.
1. [SendMessages()](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L152-L166) pumps request messages from the [Call](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L46) channel into the WebSocket connection
2. [ReadMessages()](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L330-L357) handles incoming messages and dispatches responses into [Reply](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L54) channel by [HandleResponse()](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L441-L451)
3. [SendPings()](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L168-L186) sends pings periodically to improve detection of a peer disconnect. nhooyr.io/websocket library responds to pongs automatically independently of a reading goroutine, but RPCConnWS must send pings itself.

### Shared state
IO "in-flight" state is tracked using  RPCConnWS [PendingRequests](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L41) mapped by the request's ID. Request ID counter increment, the state shared by the IO read/send/close threads is guarded by the connection [mutex](https://github.com/baum/noobaa-operator/blob/906f04ba735675b26fe7e2090f91b2646aebd41d/pkg/nb/rpc_ws.go#L43), unlocking is insured by deferring unlock.






