### PR TITLE
Updating prometheus-rules for odf

### DIFF
--- a/deploy/internal/prometheus-rules.yaml
+++ b/deploy/internal/prometheus-rules.yaml
@@ -40,7 +40,7 @@ spec:
         system_vendor: Red Hat
       record: odf_system_health_status
     - expr: |
-        NooBaa_system_capacity
+        NooBaa_total_usage
       labels:
         system_type: OCS
         system_vendor: Red Hat

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3086,7 +3086,7 @@ spec:
         claimName: noobaa-pv-claim
 `
 
-const Sha256_deploy_internal_prometheus_rules_yaml = "769cf65b44ae9a93b9ba2c9f0473173aeabbb7a673b94af5e3a6a7498d394aec"
+const Sha256_deploy_internal_prometheus_rules_yaml = "020543cc2d0cae0cec95afc569bca77511e1d8d2d09969b8f303fa7b1c977935"
 
 const File_deploy_internal_prometheus_rules_yaml = `apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -3130,7 +3130,7 @@ spec:
         system_vendor: Red Hat
       record: odf_system_health_status
     - expr: |
-        NooBaa_system_capacity
+        NooBaa_total_usage
       labels:
         system_type: OCS
         system_vendor: Red Hat


### PR DESCRIPTION
### Explain the changes
Updating prometheus-rules for odf:
changed the expr for odf_system_raw_capacity_used_bytes from `NooBaa_system_capacity` to `NooBaa_total_usage`

According to https://github.com/noobaa/noobaa-mixins/pull/28

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2030602
