### PR TITLE
Moved configmap annotation to change the deployment strategies of the endpoint from recreate to ramped

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app: noobaa
   name: noobaa-endpoint
-  annotations:
-    ConfigMapHash: ""
 spec:
   replicas: 1
   selector:
@@ -21,6 +19,8 @@ spec:
       labels:
         noobaa-s3: noobaa
         app: noobaa
+      annotations:
+        noobaa.io/configmap-hash: ""
     spec:
       serviceAccountName: noobaa-endpoint
       volumes:

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -4,8 +4,6 @@ metadata:
   name: noobaa-core
   labels:
     app: noobaa
-  annotations:
-    ConfigMapHash: ""
 spec:
   replicas: 1
   selector:
@@ -20,6 +18,8 @@ spec:
         app: noobaa
         noobaa-core: noobaa
         noobaa-mgmt: noobaa
+      annotations:
+        noobaa.io/configmap-hash: ""
     spec:
       serviceAccountName: noobaa
       volumes:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2887,7 +2887,7 @@ data:
           su postgres -c "bash -x /usr/bin/run-postgresql"
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "9e67a262b53e9b336a0d2810d3bf47b373704796ba7007b637492a3fac549ee7"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "d098321ca3038440e35b27277c1e38eedea852a5be25371e29a442d5f7987590"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -2895,8 +2895,6 @@ metadata:
   labels:
     app: noobaa
   name: noobaa-endpoint
-  annotations:
-    ConfigMapHash: ""
 spec:
   replicas: 1
   selector:
@@ -2912,6 +2910,8 @@ spec:
       labels:
         noobaa-s3: noobaa
         app: noobaa
+      annotations:
+        noobaa.io/configmap-hash: ""
     spec:
       serviceAccountName: noobaa-endpoint
       volumes:
@@ -3524,7 +3524,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "002ed83aac0df2458a67fe77ce70d2028845a415f5fc49ceaaa007ab159a2e3b"
+const Sha256_deploy_internal_statefulset_core_yaml = "f7bf9089a492b34c463bd92f621c19ba6908c660518b71b90f1db5b2ab3ee055"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -3532,8 +3532,6 @@ metadata:
   name: noobaa-core
   labels:
     app: noobaa
-  annotations:
-    ConfigMapHash: ""
 spec:
   replicas: 1
   selector:
@@ -3548,6 +3546,8 @@ spec:
         app: noobaa
         noobaa-core: noobaa
         noobaa-mgmt: noobaa
+      annotations:
+        noobaa.io/configmap-hash: ""
     spec:
       serviceAccountName: noobaa
       volumes:

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -484,11 +484,11 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 
 	}
 
-	if r.CoreApp.ObjectMeta.Annotations == nil {
-		r.CoreApp.ObjectMeta.Annotations = make(map[string]string)
+	if r.CoreApp.Spec.Template.Annotations == nil {
+		r.CoreApp.Spec.Template.Annotations = make(map[string]string)
 	}
 
-	r.SetConfigMapAnnotation(r.CoreApp.ObjectMeta.Annotations)
+	r.CoreApp.Spec.Template.Annotations["noobaa.io/configmap-hash"] = r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"]
 
 	phase := r.NooBaa.Status.UpgradePhase
 	replicas := int32(1)
@@ -1209,16 +1209,12 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 		}
 	}
 
-	return nil
-}
-
-// SetConfigMapAnnotation sets the ConfigMapHash annotation with the init data hash string
-func (r *Reconciler) SetConfigMapAnnotation(annotation map[string]string) {
-	if annotation["ConfigMapHash"] == "" {
-		input := &r.CoreAppConfig.Data
-		sha256Hex := util.GetCmDataHash(*input)
-		annotation["ConfigMapHash"] = sha256Hex
+	if r.CoreAppConfig.Annotations == nil {
+		r.CoreAppConfig.Annotations = make(map[string]string)
 	}
+	r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"] = util.GetCmDataHash(r.CoreAppConfig.Data)
+
+	return nil
 }
 
 func (r *Reconciler) findLocalStorageClass() (string, error) {

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -90,9 +89,6 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 		return err
 	}
 	if err := r.ReconcileDeploymentEndpointStatus(); err != nil {
-		return err
-	}
-	if err := r.ReconcileSystemConfigMap(); err != nil {
 		return err
 	}
 	return nil
@@ -395,11 +391,11 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 			util.ReflectEnvVariable(&c.Env, "HTTPS_PROXY")
 			util.ReflectEnvVariable(&c.Env, "NO_PROXY")
 
-			if r.DeploymentEndpoint.ObjectMeta.Annotations == nil {
-				r.DeploymentEndpoint.ObjectMeta.Annotations = make(map[string]string)
+			if r.DeploymentEndpoint.Spec.Template.Annotations == nil {
+				r.DeploymentEndpoint.Spec.Template.Annotations = make(map[string]string)
 			}
 
-			r.SetConfigMapAnnotation(r.DeploymentEndpoint.ObjectMeta.Annotations)
+			r.DeploymentEndpoint.Spec.Template.Annotations["noobaa.io/configmap-hash"] = r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"]
 
 			return r.setDesiredEndpointMounts(podSpec, c)
 		}
@@ -1464,49 +1460,5 @@ func (r *Reconciler) ReconcileNamespaceStores(namespaceResources []nb.NamespaceR
 			}
 		}
 	}
-	return nil
-}
-
-// ReconcileSystemConfigMap restarts the core and endpoint pods to recive updates from config map
-func (r *Reconciler) ReconcileSystemConfigMap() error {
-	sha256Hex := util.GetCmDataHash(r.CoreAppConfig.Data)
-
-	if r.DeploymentEndpoint.ObjectMeta.Annotations["ConfigMapHash"] != sha256Hex {
-		epPodList := &corev1.PodList{}
-		epPodSelector, _ := labels.Parse("noobaa-s3=" + r.Request.Name)
-		if !util.KubeList(epPodList, &client.ListOptions{Namespace: options.Namespace, LabelSelector: epPodSelector}) {
-			r.Logger.Errorf("failed to list to endpoint pods")
-		}
-		r.DeploymentEndpoint.ObjectMeta.Annotations["ConfigMapHash"] = sha256Hex
-
-		if !util.KubeUpdate(r.DeploymentEndpoint) {
-			r.Logger.Infof("NooBaa %q failed to update Deployment Endpoint Config Map Hash", options.SystemName)
-		}
-		for _, pod := range epPodList.Items {
-			util.KubeDeleteNoPolling(&pod)
-		}
-	}
-
-	corePodList := &corev1.PodList{}
-	corePodSelector, _ := labels.Parse("noobaa-core=" + r.Request.Name)
-	if !util.KubeList(corePodList, &client.ListOptions{Namespace: options.Namespace, LabelSelector: corePodSelector}) {
-		r.Logger.Errorf("failed to list to core pods")
-	}
-
-	if r.CoreApp.ObjectMeta.Annotations["ConfigMapHash"] != sha256Hex {
-		r.CoreApp.ObjectMeta.Annotations["ConfigMapHash"] = sha256Hex
-
-		if !util.KubeUpdate(r.CoreApp) {
-			r.Logger.Infof("NooBaa %q failed to update Core STS Config Map Hash", options.SystemName)
-		}
-
-		for _, pod := range corePodList.Items {
-			if pod.DeletionTimestamp == nil {
-				util.KubeDeleteNoPolling(&pod)
-			}
-		}
-
-	}
-
 	return nil
 }


### PR DESCRIPTION
### Explain the changes
1. Moved the configmap annotation into the spec.
2. Removed the force delete of the pods (core and endpoint)
3. Added the hash also to the config map under annotation

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: https://github.com/noobaa/noobaa-core/issues/6811

### Testing Instructions:
1. Edit the configmap noobaa-config
2. See that the endpoint deployment strategy is ramped (first  a new pod is up, then the old one is removed).
