### PR TITLE
Upgrade MongoDB to v3.6.23 in order to prevent segmentation fault

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ noobaa options
 
 The following options can be passed to any command:
 
-      --db-image='centos/mongodb-36-centos7': The database container image
+      --db-image='mongo:3.6.23': The database container image
       --db-storage-class='': The database volume storage class name
       --db-volume-size-gb=0: The database volume size in GB
       --image-pull-secret='': Image pull secret (must be in same namespace)

--- a/deploy/internal/statefulset-db.yaml
+++ b/deploy/internal/statefulset-db.yaml
@@ -48,7 +48,7 @@ spec:
         command:
         - bash
         - -c
-        - /opt/rh/rh-mongodb36/root/usr/bin/mongod --port 27017 --bind_ip_all --dbpath /data/mongo/cluster/shard1
+        - mongod --port 27017 --bind_ip_all --dbpath /data/mongo/cluster/shard1
         resources:
           requests:
             cpu: "2"

--- a/doc/noobaa-crd.md
+++ b/doc/noobaa-crd.md
@@ -165,7 +165,7 @@ metadata:
   namespace: noobaa
 spec:
   image: noobaa/noobaa-core:v9999.9.9
-  dbImage: centos/mongodb-36-centos7
+  dbImage: mongo:3.6.23
   imagePullSecret:
     name: <SECRET-NAME>
 ```

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3658,7 +3658,7 @@ spec:
                   resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_db_yaml = "3de515b92c4892045b4e9c0ad8d0b69eaf198b7708818cd9e58c5e4cb53e2073"
+const Sha256_deploy_internal_statefulset_db_yaml = "b607a6a558b1779f2191582a5b77195ed5b3628386c8548b9fd8bb4579ff0690"
 
 const File_deploy_internal_statefulset_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -3710,7 +3710,7 @@ spec:
         command:
         - bash
         - -c
-        - /opt/rh/rh-mongodb36/root/usr/bin/mongod --port 27017 --bind_ip_all --dbpath /data/mongo/cluster/shard1
+        - mongod --port 27017 --bind_ip_all --dbpath /data/mongo/cluster/shard1
         resources:
           requests:
             cpu: "2"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -69,7 +69,7 @@ var NooBaaImage = ContainerImage
 
 // DBImage is the default db image url
 // it can be overridden for testing or different registry locations.
-var DBImage = "centos/mongodb-36-centos7"
+var DBImage = "mongo:3.6.23"
 
 // DBPostgresImage is the default postgres db image url
 // currently it can not be overridden.
@@ -77,7 +77,7 @@ var DBPostgresImage = "centos/postgresql-12-centos7"
 
 // DBMongoImage is the default mongo db image url
 // this is used during migration to solve issues where mongo STS referencing to postgres image
-var DBMongoImage = "centos/mongodb-36-centos7"
+var DBMongoImage = "mongo:3.6.23"
 
 // DBType is the default db image type
 // it can be overridden for testing or different types.


### PR DESCRIPTION
Signed-off-by: Norwin Schnyder <norwin.schnyder+github@gmail.com>

### Explain the changes
Upgraded MongoDB to v3.6.23

### Issues: Fixed #817.
