### PR TITLE
Add Bucketclass admission validations

### DIFF
--- a/deploy/internal/admission-webhook.yaml
+++ b/deploy/internal/admission-webhook.yaml
@@ -15,15 +15,14 @@ webhooks:
       resources:   
       - "backingstores"
       - "namespacestores"
-      scope:       "Namespaced"
+      scope: "Namespaced"
     - apiGroups:   ["noobaa.io"]
       apiVersions: ["v1alpha1"]
       operations:  
       - "CREATE" 
-      - "DELETE"
       resources:   
       - "bucketclasses"
-      scope:       "Namespaced"
+      scope: "Namespaced"
     sideEffects: None
     clientConfig:
       service:

--- a/pkg/admission/validate_bucketclass.go
+++ b/pkg/admission/validate_bucketclass.go
@@ -1,0 +1,92 @@
+package admission
+
+import (
+	"encoding/json"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/sirupsen/logrus"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BucketClassValidator is the context of a bucketclass validation
+type BucketClassValidator struct {
+	Logger     *logrus.Entry
+	arRequest  *admissionv1.AdmissionReview
+	arResponse *admissionv1.AdmissionReview
+}
+
+// NewBucketClassValidator initializes a BucketClassValidator to be used for loading and validating a bucketclass
+func NewBucketClassValidator(arRequest admissionv1.AdmissionReview) *BucketClassValidator {
+	bcv := &BucketClassValidator{
+		Logger:    logrus.WithField("admission bucketclass validation", arRequest.Request.Namespace),
+		arRequest: &arRequest,
+		arResponse: &admissionv1.AdmissionReview{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AdmissionReview",
+				APIVersion: "admission.k8s.io/v1",
+			},
+			Response: &admissionv1.AdmissionResponse{
+				UID:     arRequest.Request.UID,
+				Allowed: true,
+				Result: &metav1.Status{
+					Message: "allowed",
+				},
+			},
+		},
+	}
+	return bcv
+}
+
+// ValidateBucketClass call appropriate validations based on the operation
+func (bcv *BucketClassValidator) ValidateBucketClass() admissionv1.AdmissionReview {
+	switch bcv.arRequest.Request.Operation {
+	case admissionv1.Create:
+		bcv.ValidateCreate()
+	default:
+		bcv.Logger.Error("Failed to identify bucketclass operation type")
+	}
+	return *bcv.arResponse
+}
+
+// SetValidationResult responsible of assinging the return values of a validation into the response appropriate fields
+func (bcv *BucketClassValidator) SetValidationResult(isAllowed bool, message string) {
+	bcv.arResponse.Response.Allowed = isAllowed
+	bcv.arResponse.Response.Result.Message = message
+}
+
+// DeserializeBC extract the bucketclass object from the request
+func (bcv *BucketClassValidator) DeserializeBC(rawBS []byte) *nbv1.BucketClass {
+	BC := nbv1.BucketClass{}
+	if err := json.Unmarshal(rawBS, &BC); err != nil {
+		bcv.Logger.Error("error deserializing bucketclass")
+	}
+	return &BC
+}
+
+// ValidateCreate runs all the validations tests for CREATE operations
+func (bcv *BucketClassValidator) ValidateCreate() {
+	bc := bcv.DeserializeBC(bcv.arRequest.Request.Object.Raw)
+	if bc == nil {
+		return
+	}
+
+	if err := bucketclass.ValidateQuotaConfig(bc.Name, bc.Spec.Quota); err != nil && util.IsValidationError(err) {
+		bcv.SetValidationResult(false, err.Error())
+		return
+	}
+	if bc.Spec.NamespacePolicy != nil {
+		if err := bucketclass.ValidateNSFSSingleBC(bc); err != nil && util.IsValidationError(err) {
+			bcv.SetValidationResult(false, err.Error())
+			return
+		}
+	}
+	if bc.Spec.PlacementPolicy != nil {
+		if err := bucketclass.ValidateTiersNumber(bc.Spec.PlacementPolicy.Tiers); err != nil {
+			bcv.SetValidationResult(false, err.Error())
+			return
+		}
+	}
+}

--- a/pkg/admission/validate_namespacestore.go
+++ b/pkg/admission/validate_namespacestore.go
@@ -23,7 +23,6 @@ type NamespaceStoreValidator struct {
 	Logger         *logrus.Entry
 	arRequest      *admissionv1.AdmissionReview
 	arResponse     *admissionv1.AdmissionReview
-	Client         *system.Client
 }
 
 // NewNamespaceStoreValidator initializes a BackingStoreValidator to be used for loading and validating a namespacestore

--- a/pkg/admission/validator.go
+++ b/pkg/admission/validator.go
@@ -50,9 +50,11 @@ func (gs *ServerHandler) serve(w http.ResponseWriter, r *http.Request) {
 		arResponse = NewBackingStoreValidator(arRequest).ValidateBackingstore()
 	case "namespacestores":
 		arResponse = NewNamespaceStoreValidator(arRequest).ValidateNamespaceStore()
+	case "bucketclasses":
+		arResponse = NewBucketClassValidator(arRequest).ValidateBucketClass()
 	default:
-		log.Error("failed to identify Resource type")
-		http.Error(w, "incorrect body", http.StatusBadRequest)
+		log.Error("failed to identify resource type")
+		http.Error(w, "incorrect resource", http.StatusBadRequest)
 		return
 	}
 

--- a/pkg/bucketclass/validation.go
+++ b/pkg/bucketclass/validation.go
@@ -1,8 +1,11 @@
 package bucketclass
 
 import (
+	"fmt"
+
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ValidateBucketClass bucket class
@@ -10,14 +13,67 @@ func ValidateBucketClass(bc *nbv1.BucketClass) error {
 	if bc == nil {
 		return nil
 	}
-	return validateQuotaConfig(bc.Name, bc.Spec.Quota)
+	return ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
 }
 
-// Validate quota config
-func validateQuotaConfig(bcName string, quota *nbv1.Quota) error {
+// ValidateQuotaConfig validates the quota values
+func ValidateQuotaConfig(bcName string, quota *nbv1.Quota) error {
 	if quota == nil {
 		return nil
 	}
 
 	return util.ValidateQuotaConfig(bcName, quota.MaxSize, quota.MaxObjects)
+}
+
+// ValidateTiersNumber validates the provided number of tiers is 1 or 2
+func ValidateTiersNumber(tiers []nbv1.Tier) error {
+	if len(tiers) != 1 && len(tiers) != 2 {
+		return util.ValidationError{
+			Msg: "unsupported number of tiers, bucketclass supports only 1 or 2 tiers",
+		}
+	}
+	return nil
+}
+
+// GetBucketclassNamespaceStoreArray returns an array of namespacestores of the provided bc
+func GetBucketclassNamespaceStoreArray(bc *nbv1.BucketClass) []string {
+	var namespaceStoresArr []string
+
+	switch bc.Spec.NamespacePolicy.Type {
+	case nbv1.NSBucketClassTypeCache:
+		namespaceStoresArr = append(namespaceStoresArr, bc.Spec.NamespacePolicy.Cache.HubResource)
+	case nbv1.NSBucketClassTypeMulti:
+		namespaceStoresArr = append(bc.Spec.NamespacePolicy.Multi.ReadResources,
+			bc.Spec.NamespacePolicy.Multi.WriteResource)
+	case nbv1.NSBucketClassTypeSingle:
+		namespaceStoresArr = append(namespaceStoresArr, bc.Spec.NamespacePolicy.Single.Resource)
+	}
+
+	return namespaceStoresArr
+}
+
+// ValidateNSFSSingleBC validates that bucketclass configured to NS of type NSFS it will only be of type Single.
+func ValidateNSFSSingleBC(bc *nbv1.BucketClass) error {
+	if bc.Spec.NamespacePolicy.Type == nbv1.NSBucketClassTypeSingle {
+		return nil
+	}
+	namespaceStoresArr := GetBucketclassNamespaceStoreArray(bc)
+	for _, name := range namespaceStoresArr {
+		nsStore := &nbv1.NamespaceStore{
+			TypeMeta: metav1.TypeMeta{Kind: "NamespaceStore"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: bc.Namespace,
+			},
+		}
+		if !util.KubeCheck(nsStore) {
+			return fmt.Errorf("failed to check namespacestore in NSFS single bucketclass type validation")
+		}
+		if nsStore.Spec.Type == nbv1.NSStoreTypeNSFS {
+			return util.ValidationError{
+				Msg: fmt.Sprintf("invalid namespaceStore types, nsfs namespacestore %q is allowed on bucketclass of type single", name),
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2694,7 +2694,7 @@ metadata:
 spec: {}
 `
 
-const Sha256_deploy_internal_admission_webhook_yaml = "770236fedd076bd21a87a9f20601225ee796b656c8c04531d7969c19fb2ecb73"
+const Sha256_deploy_internal_admission_webhook_yaml = "bbfc8f0f288a423b8304575aed0fc12e6b747c47b86c35c81fcb2be40904d31e"
 
 const File_deploy_internal_admission_webhook_yaml = `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -2713,15 +2713,14 @@ webhooks:
       resources:   
       - "backingstores"
       - "namespacestores"
-      scope:       "Namespaced"
+      scope: "Namespaced"
     - apiGroups:   ["noobaa.io"]
       apiVersions: ["v1alpha1"]
       operations:  
       - "CREATE" 
-      - "DELETE"
       resources:   
       - "bucketclasses"
-      scope:       "Namespaced"
+      scope: "Namespaced"
     sideEffects: None
     clientConfig:
       service:


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. add bucketclass validation to the admission webhook server.
2. add unit and integration  tests for the bucketclass validations.
3. bug fix in namespacestore quota validation.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `ginkgo -v pkg/admission/test/integ`
2. `ginkgo -v pkg/admission/test/unit`
