### PR TITLE
updated default core image to master-20211222

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "5.9.0-20210722"
+	ContainerImageTag = "master-20211222"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
### Explain the changes
1. updated default core image to master-20211222
