### PR TITLE
Refactor Backingstore and Namespacestore validations

### DIFF
--- a/pkg/admission/test/integ/admission_integ_test.go
+++ b/pkg/admission/test/integ/admission_integ_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Admission server integration tests", func() {
 				result, err = KubeCreate(testNamespacestore)
 				Expect(result).To(BeFalse())
 				Ω(err).Should(HaveOccurred())
-				Expect(err.Error()).To(Equal("admission webhook \"admissionwebhook.noobaa.io\" denied the request: Invalid namespacestore type, please provide a valid one"))
+				Expect(err.Error()).To(Equal("admission webhook \"admissionwebhook.noobaa.io\" denied the request: Invalid Namespacestore type, please provide a valid Namespacestore type"))
 			})
 		})
 		Context("Pass create validations", func() {
@@ -241,7 +241,7 @@ var _ = Describe("Admission server integration tests", func() {
 			result, err = KubeDelete(defaultBs)
 			Expect(result).To(BeFalse())
 			Ω(err).Should(HaveOccurred())
-			Expect(err.Error()).To(Equal("admission webhook \"admissionwebhook.noobaa.io\" denied the request: Cannot complete because pool \"noobaa-default-backing-store\" in \"IN_USE\" state"))
+			Expect(err.Error()).To(Equal("admission webhook \"admissionwebhook.noobaa.io\" denied the request: cannot complete because pool \"noobaa-default-backing-store\" in \"IN_USE\" state"))
 		})
 		It("Should Allow", func() {
 			// delete "bs-name" backingstore

--- a/pkg/admission/validate_backingstore.go
+++ b/pkg/admission/validate_backingstore.go
@@ -2,77 +2,54 @@ package admission
 
 import (
 	"encoding/json"
-	"fmt"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
-	"github.com/noobaa/noobaa-operator/v5/pkg/system"
+	"github.com/noobaa/noobaa-operator/v5/pkg/backingstore"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/sirupsen/logrus"
 	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// const configuration values for the validation checks
-const (
-	MinimumVolumeSize       = 16
-	MaximumPvpoolNameLength = 43
-	MaximumVolumeCount      = 20
-)
-
-// BackingStoreValidator is the context of a backingstore validation
-type BackingStoreValidator struct {
-	BackingStore *nbv1.BackingStore
-	Logger       *logrus.Entry
-	arRequest    *admissionv1.AdmissionReview
-	arResponse   *admissionv1.AdmissionReview
-}
-
 // NewBackingStoreValidator initializes a BackingStoreValidator to be used for loading and validating a backingstore
-func NewBackingStoreValidator(arRequest admissionv1.AdmissionReview) *BackingStoreValidator {
-	bsv := &BackingStoreValidator{
-		arRequest: &arRequest,
+func NewBackingStoreValidator(arRequest admissionv1.AdmissionReview) *ResourceValidator {
+	bsv := &ResourceValidator{
 		Logger:    logrus.WithField("admission backingstore validation", arRequest.Request.Namespace),
+		arRequest: &arRequest,
+		arResponse: &admissionv1.AdmissionReview{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AdmissionReview",
+				APIVersion: "admission.k8s.io/v1",
+			},
+			Response: &admissionv1.AdmissionResponse{
+				UID:     arRequest.Request.UID,
+				Allowed: true,
+				Result: &metav1.Status{
+					Message: "allowed",
+				},
+			},
+		},
 	}
 	return bsv
 }
 
 // ValidateBackingstore call appropriate validations based on the operation
-func (bsv *BackingStoreValidator) ValidateBackingstore() admissionv1.AdmissionReview {
-	bsv.arResponse = &admissionv1.AdmissionReview{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "AdmissionReview",
-			APIVersion: "admission.k8s.io/v1",
-		},
-		Response: &admissionv1.AdmissionResponse{
-			UID:     bsv.arRequest.Request.UID,
-			Allowed: true,
-			Result: &metav1.Status{
-				Message: "allowed",
-			},
-		},
-	}
-
+func (bsv *ResourceValidator) ValidateBackingstore() admissionv1.AdmissionReview {
 	switch bsv.arRequest.Request.Operation {
 	case admissionv1.Create:
-		bsv.ValidateCreate()
+		bsv.ValidateCreateBS()
 	case admissionv1.Update:
-		bsv.ValidateUpdate()
+		bsv.ValidateUpdateBS()
 	case admissionv1.Delete:
-		bsv.ValidateDelete()
+		bsv.ValidateDeleteBS()
 	default:
 		bsv.Logger.Error("Failed to identify backindstore operation type")
 	}
 	return *bsv.arResponse
 }
 
-// SetValidationResult responsible of assinging the return values of a validation into the response appropriate fields
-func (bsv *BackingStoreValidator) SetValidationResult(isAllowed bool, message string) {
-	bsv.arResponse.Response.Allowed = isAllowed
-	bsv.arResponse.Response.Result.Message = message
-}
-
 // DeserializeBS extract the backingstore object from the request
-func (bsv *BackingStoreValidator) DeserializeBS(rawBS []byte) *nbv1.BackingStore {
+func (bsv *ResourceValidator) DeserializeBS(rawBS []byte) *nbv1.BackingStore {
 	BS := nbv1.BackingStore{}
 	if err := json.Unmarshal(rawBS, &BS); err != nil {
 		bsv.Logger.Error("error deserializing backingstore")
@@ -80,247 +57,56 @@ func (bsv *BackingStoreValidator) DeserializeBS(rawBS []byte) *nbv1.BackingStore
 	return &BS
 }
 
-// ValidateCreate runs all the validations tests for CREATE operations
-func (bsv *BackingStoreValidator) ValidateCreate() {
-	bsv.BackingStore = bsv.DeserializeBS(bsv.arRequest.Request.Object.Raw)
-	if ok, message := bsv.ValidateBackingStoreType(); !ok {
-		bsv.SetValidationResult(ok, message)
+// ValidateCreateBS runs all the validations tests for CREATE operations
+func (bsv *ResourceValidator) ValidateCreateBS() {
+	bs := bsv.DeserializeBS(bsv.arRequest.Request.Object.Raw)
+	if bs == nil {
 		return
 	}
 
-	if ok, message := bsv.ValidateBSEmptySecretName(); !ok {
-		bsv.SetValidationResult(ok, message)
+	if err := backingstore.ValidateBackingStore(*bs); err != nil && util.IsValidationError(err) {
+		bsv.SetValidationResult(false, err.Error())
 		return
-	}
-
-	switch bsv.BackingStore.Spec.Type {
-	case nbv1.StoreTypePVPool:
-		if ok, message := bsv.ValidatePvpoolNameLength(); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := bsv.ValidateMinVolumeCount(); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := bsv.ValidateMaxVolumeCount(); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := bsv.ValidatePvpoolMinVolSize(); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-	case nbv1.StoreTypeS3Compatible:
-		if ok, message := bsv.ValidateS3CompatibleSigVersion(); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
 	}
 }
 
-// ValidateUpdate runs all the validations tests for UPDATE operations
-func (bsv *BackingStoreValidator) ValidateUpdate() {
-	bsv.BackingStore = bsv.DeserializeBS(bsv.arRequest.Request.Object.Raw)
+// ValidateUpdateBS runs all the validations tests for UPDATE operations
+func (bsv *ResourceValidator) ValidateUpdateBS() {
+	bs := bsv.DeserializeBS(bsv.arRequest.Request.Object.Raw)
 	oldBS := bsv.DeserializeBS(bsv.arRequest.Request.OldObject.Raw)
 
-	if ok, message := bsv.ValidateBackingStoreType(); !ok {
-		bsv.SetValidationResult(ok, message)
+	if bs == nil || oldBS == nil {
 		return
 	}
 
-	if ok, message := bsv.ValidateBSEmptySecretName(); !ok {
-		bsv.SetValidationResult(ok, message)
+	if err := backingstore.ValidateBackingStore(*bs); err != nil && util.IsValidationError(err) {
+		bsv.SetValidationResult(false, err.Error())
 		return
 	}
 
-	switch bsv.BackingStore.Spec.Type {
+	switch bs.Spec.Type {
 	case nbv1.StoreTypePVPool:
-		if ok, message := bsv.ValidatePvpoolScaleDown(*oldBS); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := bsv.ValidatePvpoolNameLength(); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := bsv.ValidateMinVolumeCount(); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := bsv.ValidateMaxVolumeCount(); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := bsv.ValidatePvpoolMinVolSize(); !ok {
-			bsv.SetValidationResult(ok, message)
+		if err := backingstore.ValidatePvpoolScaleDown(*bs, *oldBS); err != nil && util.IsValidationError(err) {
+			bsv.SetValidationResult(false, err.Error())
 			return
 		}
 	case nbv1.StoreTypeAWSS3, nbv1.StoreTypeIBMCos, nbv1.StoreTypeAzureBlob, nbv1.StoreTypeGoogleCloudStorage:
-		if ok, message := bsv.ValidateTargetBucketChange(*oldBS); !ok {
-			bsv.SetValidationResult(ok, message)
-			return
-		}
-	case nbv1.StoreTypeS3Compatible:
-		if ok, message := bsv.ValidateS3CompatibleSigVersion(); !ok {
-			bsv.SetValidationResult(ok, message)
+		if err := backingstore.ValidateTargetBucketChange(*bs, *oldBS); err != nil && util.IsValidationError(err) {
+			bsv.SetValidationResult(false, err.Error())
 			return
 		}
 	}
 }
 
-// ValidateDelete runs all the validations tests for DELETE operations
-func (bsv *BackingStoreValidator) ValidateDelete() {
-	bsv.BackingStore = bsv.DeserializeBS(bsv.arRequest.Request.OldObject.Raw)
-
-	if ok, message := bsv.ValidateBackingstoreDeletion(); !ok {
-		bsv.SetValidationResult(ok, message)
+// ValidateDeleteBS runs all the validations tests for DELETE operations
+func (bsv *ResourceValidator) ValidateDeleteBS() {
+	bs := bsv.DeserializeBS(bsv.arRequest.Request.OldObject.Raw)
+	if bs == nil {
 		return
 	}
-}
 
-// ValidateBSEmptySecretName validates a secret name is provided for cloud backingstores
-func (bsv *BackingStoreValidator) ValidateBSEmptySecretName() (bool, string) {
-	switch bsv.BackingStore.Spec.Type {
-	case nbv1.StoreTypeAWSS3:
-		if len(bsv.BackingStore.Spec.AWSS3.Secret.Name) == 0 {
-			return false, "Failed creating the Backingstore, please provide secret name"
-		}
-	case nbv1.StoreTypeS3Compatible:
-		if len(bsv.BackingStore.Spec.S3Compatible.Secret.Name) == 0 {
-			return false, "Failed creating the Backingstore, please provide secret name"
-		}
-	case nbv1.StoreTypeIBMCos:
-		if len(bsv.BackingStore.Spec.IBMCos.Secret.Name) == 0 {
-			return false, "Failed creating the Backingstore, please provide secret name"
-		}
-	case nbv1.StoreTypeAzureBlob:
-		if len(bsv.BackingStore.Spec.AzureBlob.Secret.Name) == 0 {
-			return false, "Failed creating the Backingstore, please provide secret name"
-		}
-	case nbv1.StoreTypeGoogleCloudStorage:
-		if len(bsv.BackingStore.Spec.GoogleCloudStorage.Secret.Name) == 0 {
-			return false, "Failed creating the Backingstore, please provide secret name"
-		}
-	case nbv1.StoreTypePVPool:
-		break
-	default:
-		return false, "Failed to identify Backingstore type"
+	if err := backingstore.ValidateBackingstoreDeletion(*bs); err != nil && util.IsValidationError(err) {
+		bsv.SetValidationResult(false, err.Error())
+		return
 	}
-	return true, "allowed"
-}
-
-// ValidateBackingStoreType validates a supported backingstore type
-func (bsv *BackingStoreValidator) ValidateBackingStoreType() (bool, string) {
-	switch bsv.BackingStore.Spec.Type {
-	case nbv1.StoreTypeAWSS3, nbv1.StoreTypeS3Compatible, nbv1.StoreTypeIBMCos, nbv1.StoreTypeAzureBlob, nbv1.StoreTypeGoogleCloudStorage, nbv1.StoreTypePVPool:
-		return true, "allowed"
-	default:
-		return false, "Invalid Backingstore type, please provide a valid Backingstore type"
-	}
-}
-
-// ValidatePvpoolNameLength validates the name of pvpool backingstore is under 43 characters
-func (bsv *BackingStoreValidator) ValidatePvpoolNameLength() (bool, string) {
-	if len(bsv.BackingStore.Name) > MaximumPvpoolNameLength {
-		return false, "Unsupported BackingStore name length, please provide a name shorter then 43 characters"
-	}
-	return true, "allowed"
-}
-
-// ValidatePvpoolMinVolSize validates pvpool volume size is above 16GB
-func (bsv *BackingStoreValidator) ValidatePvpoolMinVolSize() (bool, string) {
-	min := *resource.NewScaledQuantity(int64(MinimumVolumeSize), resource.Giga)
-	if bsv.BackingStore.Spec.PVPool.VolumeResources.Requests.Storage().Cmp(min) == -1 {
-		return false, "Invalid volume size, minimum volume size is 16Gi"
-	}
-	return true, "allowed"
-}
-
-// ValidateS3CompatibleSigVersion validates S3 Compatible backingstore provided with a supported signature viersion
-func (bsv *BackingStoreValidator) ValidateS3CompatibleSigVersion() (bool, string) {
-	switch bsv.BackingStore.Spec.S3Compatible.SignatureVersion {
-	case nbv1.S3SignatureVersionV2, nbv1.S3SignatureVersionV4:
-		return true, "allowed"
-	default:
-		return false, "Invalid S3 compatible Backingstore signature version, please choose either v2/v4"
-	}
-}
-
-// ValidateMaxVolumeCount validates pvpool backingstore volume count is under 20
-func (bsv *BackingStoreValidator) ValidateMaxVolumeCount() (bool, string) {
-	if bsv.BackingStore.Spec.PVPool.NumVolumes > MaximumVolumeCount {
-		return false, "Unsupported volume count, the maximum supported volume count is 20"
-	}
-	return true, "allowed"
-}
-
-// ValidateMinVolumeCount validates pvpool backingstore volume count is above 0
-func (bsv *BackingStoreValidator) ValidateMinVolumeCount() (bool, string) {
-	if bsv.BackingStore.Spec.PVPool.NumVolumes <= 0 {
-		return false, "Unsupported volume count, the minimum supported volume count is 1"
-	}
-	return true, "allowed"
-}
-
-// ValidatePvpoolScaleDown validates an operation of scaling down node in pvpool backingstore
-func (bsv *BackingStoreValidator) ValidatePvpoolScaleDown(oldBs nbv1.BackingStore) (bool, string) {
-	if oldBs.Spec.PVPool.NumVolumes > bsv.BackingStore.Spec.PVPool.NumVolumes {
-		return false, "Scaling down the number of nodes is not currently supported"
-	}
-	return true, "allowed"
-}
-
-// ValidateTargetBucketChange validates the user is not trying to update the backingstore target bucket
-func (bsv *BackingStoreValidator) ValidateTargetBucketChange(oldBs nbv1.BackingStore) (bool, string) {
-	switch bsv.BackingStore.Spec.Type {
-	case nbv1.StoreTypeAWSS3:
-		if oldBs.Spec.AWSS3.TargetBucket != bsv.BackingStore.Spec.AWSS3.TargetBucket {
-			return false, "Changing a Backingstore target bucket is unsupported"
-		}
-	case nbv1.StoreTypeS3Compatible:
-		if oldBs.Spec.S3Compatible.TargetBucket != bsv.BackingStore.Spec.S3Compatible.TargetBucket {
-			return false, "Changing a Backingstore target bucket is unsupported"
-		}
-	case nbv1.StoreTypeIBMCos:
-		if oldBs.Spec.IBMCos.TargetBucket != bsv.BackingStore.Spec.IBMCos.TargetBucket {
-			return false, "Changing a Backingstore target bucket is unsupported"
-		}
-	case nbv1.StoreTypeAzureBlob:
-		if oldBs.Spec.AzureBlob.TargetBlobContainer != bsv.BackingStore.Spec.AzureBlob.TargetBlobContainer {
-			return false, "Changing a Backingstore target bucket is unsupported"
-		}
-	case nbv1.StoreTypeGoogleCloudStorage:
-		if oldBs.Spec.GoogleCloudStorage.TargetBucket != bsv.BackingStore.Spec.GoogleCloudStorage.TargetBucket {
-			return false, "Changing a Backingstore target bucket is unsupported"
-		}
-	default:
-		return false, "Failed to identify Backingstore type"
-	}
-	return true, "allowed"
-}
-
-// ValidateBackingstoreDeletion validates the deleted backingstore not containing data buckets
-func (bsv *BackingStoreValidator) ValidateBackingstoreDeletion() (bool, string) {
-	sysClient, err := system.Connect(false)
-	if err != nil {
-		bsv.Logger.Error("Failed to load noobaa system connection info")
-		return true, "allowed"
-	}
-	systemInfo, err := sysClient.NBClient.ReadSystemAPI()
-	if err != nil {
-		bsv.Logger.Error("Failed to call ReadSystemInfo API")
-		return true, "allowed"
-	}
-
-	for _, pool := range systemInfo.Pools {
-		if pool.Name == bsv.BackingStore.Name {
-			if pool.Undeletable == "IS_BACKINGSTORE" || pool.Undeletable == "BEING_DELETED" {
-				return true, "allowed"
-			}
-			return false, fmt.Sprintf("Cannot complete because pool %q in %q state", pool.Name, pool.Undeletable)
-		}
-	}
-
-	return true, "allowed"
 }

--- a/pkg/admission/validate_namespacestore.go
+++ b/pkg/admission/validate_namespacestore.go
@@ -2,75 +2,55 @@ package admission
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
-	"github.com/noobaa/noobaa-operator/v5/pkg/system"
+	"github.com/noobaa/noobaa-operator/v5/pkg/namespacestore"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/sirupsen/logrus"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// const configuration values for the validation checks
-const (
-	MaximumMountPathLength = 63
-)
-
-// NamespaceStoreValidator is the context of a namespacestore validation
-type NamespaceStoreValidator struct {
-	NamespaceStore *nbv1.NamespaceStore
-	Logger         *logrus.Entry
-	arRequest      *admissionv1.AdmissionReview
-	arResponse     *admissionv1.AdmissionReview
-}
-
 // NewNamespaceStoreValidator initializes a BackingStoreValidator to be used for loading and validating a namespacestore
-func NewNamespaceStoreValidator(arRequest admissionv1.AdmissionReview) *NamespaceStoreValidator {
-	nsv := &NamespaceStoreValidator{
-		arRequest: &arRequest,
+func NewNamespaceStoreValidator(arRequest admissionv1.AdmissionReview) *ResourceValidator {
+	nsv := &ResourceValidator{
+
 		Logger:    logrus.WithField("admission namespacestore validation", arRequest.Request.Namespace),
+		arRequest: &arRequest,
+		arResponse: &admissionv1.AdmissionReview{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AdmissionReview",
+				APIVersion: "admission.k8s.io/v1",
+			},
+			Response: &admissionv1.AdmissionResponse{
+				UID:     arRequest.Request.UID,
+				Allowed: true,
+				Result: &metav1.Status{
+					Message: "allowed",
+				},
+			},
+		},
 	}
 	return nsv
 }
 
 // ValidateNamespaceStore call appropriate validations based on the operation
-func (nsv *NamespaceStoreValidator) ValidateNamespaceStore() admissionv1.AdmissionReview {
-	nsv.arResponse = &admissionv1.AdmissionReview{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "AdmissionReview",
-			APIVersion: "admission.k8s.io/v1",
-		},
-		Response: &admissionv1.AdmissionResponse{
-			UID:     nsv.arRequest.Request.UID,
-			Allowed: true,
-			Result: &metav1.Status{
-				Message: "allowed",
-			},
-		},
-	}
-
+func (nsv *ResourceValidator) ValidateNamespaceStore() admissionv1.AdmissionReview {
 	switch nsv.arRequest.Request.Operation {
 	case admissionv1.Create:
-		nsv.ValidateCreate()
+		nsv.ValidateCreateNS()
 	case admissionv1.Update:
-		nsv.ValidateUpdate()
+		nsv.ValidateUpdateNS()
 	case admissionv1.Delete:
-		nsv.ValidateDelete()
+		nsv.ValidateDeleteNS()
 	default:
 		nsv.Logger.Error("Failed to identify namespacestore operation type")
 	}
 	return *nsv.arResponse
 }
 
-// SetValidationResult responsible of assinging the return values of a validation into the response appropriate fields
-func (nsv *NamespaceStoreValidator) SetValidationResult(isAllowed bool, message string) {
-	nsv.arResponse.Response.Allowed = isAllowed
-	nsv.arResponse.Response.Result.Message = message
-}
-
 // DeserializeNS extract the namespacestore object from the request
-func (nsv *NamespaceStoreValidator) DeserializeNS(rawNS []byte) *nbv1.NamespaceStore {
+func (nsv *ResourceValidator) DeserializeNS(rawNS []byte) *nbv1.NamespaceStore {
 	NS := nbv1.NamespaceStore{}
 	if err := json.Unmarshal(rawNS, &NS); err != nil {
 		nsv.Logger.Error("error deserializing namespacestore")
@@ -78,196 +58,51 @@ func (nsv *NamespaceStoreValidator) DeserializeNS(rawNS []byte) *nbv1.NamespaceS
 	return &NS
 }
 
-// ValidateCreate runs all the validations tests for CREATE operations
-func (nsv *NamespaceStoreValidator) ValidateCreate() {
-	nsv.NamespaceStore = nsv.DeserializeNS(nsv.arRequest.Request.Object.Raw)
-
-	if ok, message := nsv.ValidateNamespaceStoreType(); !ok {
-		nsv.SetValidationResult(ok, message)
+// ValidateCreateNS runs all the validations tests for CREATE operations
+func (nsv *ResourceValidator) ValidateCreateNS() {
+	ns := nsv.DeserializeNS(nsv.arRequest.Request.Object.Raw)
+	if ns == nil {
 		return
 	}
 
-	if ok, message := nsv.ValidateNSEmptySecretName(); !ok {
-		nsv.SetValidationResult(ok, message)
+	if err := namespacestore.ValidateNamespaceStore(ns); err != nil && util.IsValidationError(err) {
+		nsv.SetValidationResult(false, err.Error())
 		return
-	}
-
-	switch nsv.NamespaceStore.Spec.Type {
-	case nbv1.NSStoreTypeNSFS:
-		if ok, message := nsv.ValidateMountPath(); !ok {
-			nsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := nsv.ValidateEmptyPvcName(); !ok {
-			nsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := nsv.ValidateSubPath(); !ok {
-			nsv.SetValidationResult(ok, message)
-			return
-		}
 	}
 }
 
-// ValidateUpdate runs all the validations tests for UPDATE operations
-func (nsv *NamespaceStoreValidator) ValidateUpdate() {
-	nsv.NamespaceStore = nsv.DeserializeNS(nsv.arRequest.Request.Object.Raw)
+// ValidateUpdateNS runs all the validations tests for UPDATE operations
+func (nsv *ResourceValidator) ValidateUpdateNS() {
+	ns := nsv.DeserializeNS(nsv.arRequest.Request.Object.Raw)
 	oldNS := nsv.DeserializeNS(nsv.arRequest.Request.OldObject.Raw)
 
-	if ok, message := nsv.ValidateNamespaceStoreType(); !ok {
-		nsv.SetValidationResult(ok, message)
+	if ns == nil || oldNS == nil {
 		return
 	}
 
-	if ok, message := nsv.ValidateNSEmptySecretName(); !ok {
-		nsv.SetValidationResult(ok, message)
+	if err := namespacestore.ValidateNamespaceStore(ns); err != nil && util.IsValidationError(err) {
+		nsv.SetValidationResult(false, err.Error())
 		return
 	}
 
-	switch nsv.NamespaceStore.Spec.Type {
-	case nbv1.NSStoreTypeNSFS:
-		if ok, message := nsv.ValidateMountPath(); !ok {
-			nsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := nsv.ValidateEmptyPvcName(); !ok {
-			nsv.SetValidationResult(ok, message)
-			return
-		}
-		if ok, message := nsv.ValidateSubPath(); !ok {
-			nsv.SetValidationResult(ok, message)
-			return
-		}
+	switch ns.Spec.Type {
 	case nbv1.NSStoreTypeAWSS3, nbv1.NSStoreTypeS3Compatible, nbv1.NSStoreTypeIBMCos, nbv1.NSStoreTypeAzureBlob:
-		if ok, message := nsv.ValidateTargetBucketChange(*oldNS); !ok {
-			nsv.SetValidationResult(ok, message)
+		if err := namespacestore.ValidateTargetBucketChange(*ns, *oldNS); err != nil && util.IsValidationError(err) {
+			nsv.SetValidationResult(false, err.Error())
 			return
 		}
 	}
 }
 
-// ValidateDelete runs all the validations tests for DELETE operations
-func (nsv *NamespaceStoreValidator) ValidateDelete() {
-	nsv.NamespaceStore = nsv.DeserializeNS(nsv.arRequest.Request.OldObject.Raw)
-
-	if ok, message := nsv.ValidateNamespacestoreDeletion(); !ok {
-		nsv.SetValidationResult(ok, message)
+// ValidateDeleteNS runs all the validations tests for DELETE operations
+func (nsv *ResourceValidator) ValidateDeleteNS() {
+	ns := nsv.DeserializeNS(nsv.arRequest.Request.OldObject.Raw)
+	if ns == nil {
 		return
 	}
-}
 
-// ValidateNSEmptySecretName validates a secret name is provided for cloud namespacestore
-func (nsv *NamespaceStoreValidator) ValidateNSEmptySecretName() (bool, string) {
-	switch nsv.NamespaceStore.Spec.Type {
-	case nbv1.NSStoreTypeAWSS3:
-		if len(nsv.NamespaceStore.Spec.AWSS3.Secret.Name) == 0 {
-			return false, "Failed creating the namespacestore, please provide secret name"
-		}
-	case nbv1.NSStoreTypeS3Compatible:
-		if len(nsv.NamespaceStore.Spec.S3Compatible.Secret.Name) == 0 {
-			return false, "Failed creating the namespacestore, please provide secret name"
-		}
-	case nbv1.NSStoreTypeIBMCos:
-		if len(nsv.NamespaceStore.Spec.IBMCos.Secret.Name) == 0 {
-			return false, "Failed creating the namespacestore, please provide secret name"
-		}
-	case nbv1.NSStoreTypeAzureBlob:
-		if len(nsv.NamespaceStore.Spec.AzureBlob.Secret.Name) == 0 {
-			return false, "Failed creating the namespacestore, please provide secret name"
-		}
-	case nbv1.NSStoreTypeNSFS:
-		break
-	default:
-		return false, "Failed to identify namespacestore type"
+	if err := namespacestore.ValidateNamespacestoreDeletion(*ns); err != nil && util.IsValidationError(err) {
+		nsv.SetValidationResult(false, err.Error())
+		return
 	}
-	return true, "allowed"
-}
-
-// ValidateNamespaceStoreType validates a supported namespacestore type
-func (nsv *NamespaceStoreValidator) ValidateNamespaceStoreType() (bool, string) {
-	switch nsv.NamespaceStore.Spec.Type {
-	case nbv1.NSStoreTypeAWSS3, nbv1.NSStoreTypeS3Compatible, nbv1.NSStoreTypeIBMCos, nbv1.NSStoreTypeAzureBlob, nbv1.NSStoreTypeNSFS:
-		return true, "allowed"
-	default:
-		return false, "Invalid namespacestore type, please provide a valid one"
-	}
-}
-
-// ValidateEmptyPvcName validates NSFS pvc name provided
-func (nsv *NamespaceStoreValidator) ValidateEmptyPvcName() (bool, string) {
-	if nsv.NamespaceStore.Spec.NSFS.PvcName == "" {
-		return false, "Failed to create NSFS, please provide pvc name"
-	}
-	return true, "allowed"
-}
-
-// ValidateSubPath validates NSFS SubPath is relative path and not containing '..' character
-func (nsv *NamespaceStoreValidator) ValidateSubPath() (bool, string) {
-	path := nsv.NamespaceStore.Spec.NSFS.SubPath
-	if len(path) > 0 && path[0] == '/' {
-		return false, "Failed to create NSFS, SubPath must be a relative path"
-	}
-	if strings.Contains(path, "..") {
-		return false, "Failed to create NSFS, SubPath must not contain '..'"
-	}
-	return true, "allowed"
-}
-
-// ValidateMountPath validates NSFS mount path, including '/nsfs/', is no more than 63 characters
-func (nsv *NamespaceStoreValidator) ValidateMountPath() (bool, string) {
-	mountPath := "/nsfs/" + nsv.NamespaceStore.Name
-	if len(mountPath) > MaximumMountPathLength {
-		return false, "Failed to create NSFS, MountPath must be no more than 63 characters"
-	}
-	return true, "allowed"
-}
-
-// ValidateTargetBucketChange validates the user is not trying to update the namespacestore target bucket
-func (nsv *NamespaceStoreValidator) ValidateTargetBucketChange(oldNs nbv1.NamespaceStore) (bool, string) {
-	switch nsv.NamespaceStore.Spec.Type {
-	case nbv1.NSStoreTypeAWSS3:
-		if oldNs.Spec.AWSS3.TargetBucket != nsv.NamespaceStore.Spec.AWSS3.TargetBucket {
-			return false, "Changing a NamespaceStore target bucket is unsupported"
-		}
-	case nbv1.NSStoreTypeS3Compatible:
-		if oldNs.Spec.S3Compatible.TargetBucket != nsv.NamespaceStore.Spec.S3Compatible.TargetBucket {
-			return false, "Changing a NamespaceStore target bucket is unsupported"
-		}
-	case nbv1.NSStoreTypeIBMCos:
-		if oldNs.Spec.IBMCos.TargetBucket != nsv.NamespaceStore.Spec.IBMCos.TargetBucket {
-			return false, "Changing a NamespaceStore target bucket is unsupported"
-		}
-	case nbv1.NSStoreTypeAzureBlob:
-		if oldNs.Spec.AzureBlob.TargetBlobContainer != nsv.NamespaceStore.Spec.AzureBlob.TargetBlobContainer {
-			return false, "Changing a NamespaceStore target bucket is unsupported"
-		}
-	default:
-		return false, "Failed to identify NamespaceStore type"
-	}
-	return true, "allowed"
-}
-
-// ValidateNamespacestoreDeletion validates the deleted namespacestore not containing data buckets
-func (nsv *NamespaceStoreValidator) ValidateNamespacestoreDeletion() (bool, string) {
-	sysClient, err := system.Connect(false)
-	if err != nil {
-		nsv.Logger.Error("Failed to load noobaa system connection info")
-		return true, "allowed"
-	}
-	systemInfo, err := sysClient.NBClient.ReadSystemAPI()
-	if err != nil {
-		nsv.Logger.Error("Failed to call ReadSystemInfo API")
-		return true, "allowed"
-	}
-
-	for _, nsr := range systemInfo.NamespaceResources {
-		if nsr.Name == nsv.NamespaceStore.Name {
-			if nsr.Undeletable == "IN_USE" {
-				return false, fmt.Sprintf("Cannot complete because nsr %q in %q state", nsr.Name, nsr.Undeletable)
-			}
-			return true, "allowed"
-		}
-	}
-
-	return true, "allowed"
 }

--- a/pkg/admission/validator.go
+++ b/pkg/admission/validator.go
@@ -11,6 +11,13 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 )
 
+// ResourceValidator struct holds a resource information required to preform the validations
+type ResourceValidator struct {
+	Logger     *logrus.Entry
+	arRequest  *admissionv1.AdmissionReview
+	arResponse *admissionv1.AdmissionReview
+}
+
 //ServerHandler listen to admission requests and serve responses
 type ServerHandler struct {
 }
@@ -70,4 +77,10 @@ func (gs *ServerHandler) serve(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
 		return
 	}
+}
+
+// SetValidationResult responsible of assinging the return values of a validation into the response appropriate fields
+func (rv *ResourceValidator) SetValidationResult(isAllowed bool, message string) {
+	rv.arResponse.Response.Allowed = isAllowed
+	rv.arResponse.Response.Result.Message = message
 }

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -340,6 +340,11 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 
 	populate(backStore, secret)
 
+	validationErr := ValidateBackingStore(*backStore)
+	if validationErr != nil {
+		log.Fatalf(`❌ %s %s`, validationErr, cmd.UsageString())
+	}
+
 	// Create backing store CR
 	util.Panic(controllerutil.SetControllerReference(sys, backStore, scheme.Scheme))
 	if !util.KubeCreateFailExisting(backStore) {
@@ -578,35 +583,35 @@ func RunCreatePVPool(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		var requestCPUQuantity, requestMemoryQuantity,  limitCPUQuantity, limitMemoryQuantity resource.Quantity
+		var requestCPUQuantity, requestMemoryQuantity, limitCPUQuantity, limitMemoryQuantity resource.Quantity
 		var err error
 		requestCPUQuantity, err = resource.ParseQuantity(requestCPU)
 		if err != nil {
 			log.Fatalf(`❌ Could not parse request cpu %q`,
-			requestCPU)
+				requestCPU)
 		}
 		requestMemoryQuantity, err = resource.ParseQuantity(requestMemory)
 		if err != nil {
 			log.Fatalf(`❌ Could not parse request Memory %q`,
-			requestMemory)
+				requestMemory)
 		}
 		limitCPUQuantity, err = resource.ParseQuantity(limitCPU)
 		if err != nil {
 			log.Fatalf(`❌ Could not parse limit cpu %q`,
-			limitCPU)
+				limitCPU)
 		}
 		limitMemoryQuantity, err = resource.ParseQuantity(limitMemory)
 		if err != nil {
 			log.Fatalf(`❌ Could not parse limit Memory %q`,
-			limitMemory)
+				limitMemory)
 		}
 		if requestCPUQuantity.Cmp(limitCPUQuantity) > 0 {
 			log.Fatalf(`❌ Request CPU %v is larger than limit CPU %v`,
-			requestCPUQuantity.String(), limitCPUQuantity.String())
+				requestCPUQuantity.String(), limitCPUQuantity.String())
 		}
 		if requestMemoryQuantity.Cmp(limitMemoryQuantity) > 0 {
 			log.Fatalf(`❌ Request memory %v is larger than limit memory %v`,
-			requestMemoryQuantity.String(), limitMemoryQuantity.String())
+				requestMemoryQuantity.String(), limitMemoryQuantity.String())
 		}
 
 		backStore.Spec.PVPool = &nbv1.PVPoolSpec{
@@ -615,11 +620,11 @@ func RunCreatePVPool(cmd *cobra.Command, args []string) {
 			VolumeResources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceStorage: *resource.NewQuantity(int64(pvSizeGB)*1024*1024*1024, resource.BinarySI),
-					corev1.ResourceCPU: requestCPUQuantity,
-					corev1.ResourceMemory: requestMemoryQuantity,
+					corev1.ResourceCPU:     requestCPUQuantity,
+					corev1.ResourceMemory:  requestMemoryQuantity,
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU: limitCPUQuantity,
+					corev1.ResourceCPU:    limitCPUQuantity,
 					corev1.ResourceMemory: limitMemoryQuantity,
 				},
 			},

--- a/pkg/backingstore/validation.go
+++ b/pkg/backingstore/validation.go
@@ -1,0 +1,225 @@
+package backingstore
+
+import (
+	"fmt"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/system"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// const configuration values for the validation checks
+const (
+	MinimumVolumeSize       = 16
+	MaximumPvpoolNameLength = 43
+	MaximumVolumeCount      = 20
+)
+
+// ValidateBackingStore validates create validations on resource Backinstore
+func ValidateBackingStore(bs nbv1.BackingStore) error {
+	if err := ValidateBSEmptySecretName(bs); err != nil {
+		return err
+	}
+	switch bs.Spec.Type {
+	case nbv1.StoreTypePVPool:
+		if err := ValidatePvpoolNameLength(bs); err != nil {
+			return err
+		}
+		if err := ValidatePvpoolMinVolSize(bs); err != nil {
+			return err
+		}
+		if err := ValidateMaxVolumeCount(bs); err != nil {
+			return err
+		}
+		if err := ValidateMinVolumeCount(bs); err != nil {
+			return err
+		}
+	case nbv1.StoreTypeS3Compatible:
+		return ValidateSigVersion(bs.Spec.S3Compatible.SignatureVersion)
+	case nbv1.StoreTypeIBMCos:
+		return ValidateSigVersion(bs.Spec.IBMCos.SignatureVersion)
+	case nbv1.StoreTypeAWSS3, nbv1.StoreTypeAzureBlob, nbv1.StoreTypeGoogleCloudStorage:
+		return nil
+	default:
+		return util.ValidationError{
+			Msg: "Invalid Backingstore type, please provide a valid Backingstore type",
+		}
+	}
+	return nil
+}
+
+// ValidateBSEmptySecretName validates a secret name is provided for cloud backingstores
+func ValidateBSEmptySecretName(bs nbv1.BackingStore) error {
+	switch bs.Spec.Type {
+	case nbv1.StoreTypeAWSS3:
+		if len(bs.Spec.AWSS3.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the Backingstore, please provide secret name",
+			}
+		}
+	case nbv1.StoreTypeS3Compatible:
+		if len(bs.Spec.S3Compatible.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the Backingstore, please provide secret name",
+			}
+		}
+	case nbv1.StoreTypeIBMCos:
+		if len(bs.Spec.IBMCos.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the Backingstore, please provide secret name",
+			}
+		}
+	case nbv1.StoreTypeAzureBlob:
+		if len(bs.Spec.AzureBlob.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the Backingstore, please provide secret name",
+			}
+		}
+	case nbv1.StoreTypeGoogleCloudStorage:
+		if len(bs.Spec.GoogleCloudStorage.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the Backingstore, please provide secret name",
+			}
+		}
+	case nbv1.StoreTypePVPool:
+		break
+	default:
+		return util.ValidationError{
+			Msg: "Invalid Backingstore type, please provide a valid Backingstore type",
+		}
+	}
+	return nil
+}
+
+// ValidatePvpoolNameLength validates the name of pvpool backingstore is under 43 characters
+func ValidatePvpoolNameLength(bs nbv1.BackingStore) error {
+	if len(bs.Name) > MaximumPvpoolNameLength {
+		return util.ValidationError{
+			Msg: "Unsupported BackingStore name length, please provide a name shorter then 43 characters",
+		}
+	}
+	return nil
+}
+
+// ValidatePvpoolMinVolSize validates pvpool volume size is above 16GB
+func ValidatePvpoolMinVolSize(bs nbv1.BackingStore) error {
+	if bs.Spec.PVPool.VolumeResources == nil {
+		return nil
+	}
+	min := *resource.NewScaledQuantity(int64(MinimumVolumeSize), resource.Giga)
+	if bs.Spec.PVPool.VolumeResources.Requests.Storage().Cmp(min) == -1 {
+		return util.ValidationError{
+			Msg: "Invalid volume size, minimum volume size is 16Gi",
+		}
+	}
+	return nil
+}
+
+// ValidateSigVersion validates backingstore provided with a supported signature version
+func ValidateSigVersion(sigver nbv1.S3SignatureVersion) error {
+	switch sigver {
+	case nbv1.S3SignatureVersionV2, nbv1.S3SignatureVersionV4, "":
+		return nil
+	default:
+		return util.ValidationError{
+			Msg: "Invalid S3 compatible Backingstore signature version, please choose either v2/v4",
+		}
+	}
+}
+
+// ValidateMaxVolumeCount validates pvpool backingstore volume count is under 20
+func ValidateMaxVolumeCount(bs nbv1.BackingStore) error {
+	if bs.Spec.PVPool.NumVolumes > MaximumVolumeCount {
+		return util.ValidationError{
+			Msg: "Unsupported volume count, the maximum supported volume count is 20",
+		}
+	}
+	return nil
+}
+
+// ValidateMinVolumeCount validates pvpool backingstore volume count is above 0
+func ValidateMinVolumeCount(bs nbv1.BackingStore) error {
+	if bs.Spec.PVPool.NumVolumes <= 0 {
+		return util.ValidationError{
+			Msg: "Unsupported volume count, the minimum supported volume count is 1",
+		}
+	}
+	return nil
+}
+
+// ValidatePvpoolScaleDown validates an operation of scaling down node in pvpool backingstore
+func ValidatePvpoolScaleDown(bs nbv1.BackingStore, oldBs nbv1.BackingStore) error {
+	if oldBs.Spec.PVPool.NumVolumes > bs.Spec.PVPool.NumVolumes {
+		return util.ValidationError{
+			Msg: "Scaling down the number of nodes is not currently supported",
+		}
+	}
+	return nil
+}
+
+// ValidateTargetBucketChange validates the user is not trying to update the backingstore target bucket
+func ValidateTargetBucketChange(bs nbv1.BackingStore, oldBs nbv1.BackingStore) error {
+	switch bs.Spec.Type {
+	case nbv1.StoreTypeAWSS3:
+		if oldBs.Spec.AWSS3.TargetBucket != bs.Spec.AWSS3.TargetBucket {
+			return util.ValidationError{
+				Msg: "Changing a Backingstore target bucket is unsupported",
+			}
+		}
+	case nbv1.StoreTypeS3Compatible:
+		if oldBs.Spec.S3Compatible.TargetBucket != bs.Spec.S3Compatible.TargetBucket {
+			return util.ValidationError{
+				Msg: "Changing a Backingstore target bucket is unsupported",
+			}
+		}
+	case nbv1.StoreTypeIBMCos:
+		if oldBs.Spec.IBMCos.TargetBucket != bs.Spec.IBMCos.TargetBucket {
+			return util.ValidationError{
+				Msg: "Changing a Backingstore target bucket is unsupported",
+			}
+		}
+	case nbv1.StoreTypeAzureBlob:
+		if oldBs.Spec.AzureBlob.TargetBlobContainer != bs.Spec.AzureBlob.TargetBlobContainer {
+			return util.ValidationError{
+				Msg: "Changing a Backingstore target bucket is unsupported",
+			}
+		}
+	case nbv1.StoreTypeGoogleCloudStorage:
+		if oldBs.Spec.GoogleCloudStorage.TargetBucket != bs.Spec.GoogleCloudStorage.TargetBucket {
+			return util.ValidationError{
+				Msg: "Changing a Backingstore target bucket is unsupported",
+			}
+		}
+	default:
+		return util.ValidationError{
+			Msg: "Failed to identify Backingstore type",
+		}
+	}
+	return nil
+}
+
+// ValidateBackingstoreDeletion validates the deleted backingstore not containing data buckets
+func ValidateBackingstoreDeletion(bs nbv1.BackingStore) error {
+	sysClient, err := system.Connect(false)
+	if err != nil {
+		return fmt.Errorf("failed to load noobaa system connection info")
+	}
+	systemInfo, err := sysClient.NBClient.ReadSystemAPI()
+	if err != nil {
+		return fmt.Errorf("failed to call ReadSystemInfo API")
+	}
+
+	for _, pool := range systemInfo.Pools {
+		if pool.Name == bs.Name {
+			if pool.Undeletable == "IS_BACKINGSTORE" || pool.Undeletable == "BEING_DELETED" {
+				return nil
+			}
+			return util.ValidationError{
+				Msg: fmt.Sprintf("cannot complete because pool %q in %q state", pool.Name, pool.Undeletable),
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/bucketclass/validation.go
+++ b/pkg/bucketclass/validation.go
@@ -13,6 +13,17 @@ func ValidateBucketClass(bc *nbv1.BucketClass) error {
 	if bc == nil {
 		return nil
 	}
+	if bc.Spec.NamespacePolicy != nil {
+		if err := ValidateNSFSSingleBC(bc); err != nil {
+			return err
+		}
+	}
+	if bc.Spec.PlacementPolicy != nil {
+		if err := ValidateTiersNumber(bc.Spec.PlacementPolicy.Tiers); err != nil {
+			return err
+		}
+	}
+
 	return ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
 }
 
@@ -67,7 +78,7 @@ func ValidateNSFSSingleBC(bc *nbv1.BucketClass) error {
 			},
 		}
 		if !util.KubeCheck(nsStore) {
-			return fmt.Errorf("failed to check namespacestore in NSFS single bucketclass type validation")
+			return fmt.Errorf("failed to KubeCheck namespacestore in NSFS single bucketclass type validation")
 		}
 		if nsStore.Spec.Type == nbv1.NSStoreTypeNSFS {
 			return util.ValidationError{

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -266,7 +266,7 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 
 	err := ValidateNamespaceStore(r.NamespaceStore)
 	if err != nil {
-		return err
+		return util.NewPersistentError("NamespaceStoreValidationError", err.Error())
 	}
 
 	if r.NooBaa.UID == "" {

--- a/pkg/namespacestore/validation.go
+++ b/pkg/namespacestore/validation.go
@@ -7,40 +7,47 @@ import (
 	"strings"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 )
 
+// const configuration values for the validation checks
 const (
-	defaultEndPointURI = "https://127.0.0.1:6443"
+	defaultEndPointURI     = "https://127.0.0.1:6443"
+	MaximumMountPathLength = 63
 )
 
 // ValidateNamespaceStore validates namespacestore configuration
 func ValidateNamespaceStore(nsStore *nbv1.NamespaceStore) error {
+	if err := ValidateNSEmptySecretName(*nsStore); err != nil {
+		return err
+	}
 	switch nsStore.Spec.Type {
 
 	case nbv1.NSStoreTypeNSFS:
-		return validateNsStoreNSFS(nsStore)
+		return ValidateNsStoreNSFS(nsStore)
 
 	case nbv1.NSStoreTypeAWSS3:
 		return nil
 
 	case nbv1.NSStoreTypeS3Compatible:
-		return validateNsStoreS3Compatible(nsStore)
+		return ValidateNsStoreS3Compatible(nsStore)
 
 	case nbv1.NSStoreTypeIBMCos:
-		return validateNsStoreIBMCos(nsStore)
+		return ValidateNsStoreIBMCos(nsStore)
 
 	case nbv1.NSStoreTypeAzureBlob:
 		return nil
 
 	default:
-		return util.NewPersistentError("ConfigurationError",
-			fmt.Sprintf("Invalid namespace store type %q", nsStore.Spec.Type))
+		return util.ValidationError{
+			Msg: "Invalid Namespacestore type, please provide a valid Namespacestore type",
+		}
 	}
 }
 
-// validateNamespaceStoreNSFS validates namespacestore nsfs type configuration
-func validateNsStoreNSFS(nsStore *nbv1.NamespaceStore) error {
+// ValidateNsStoreNSFS validates namespacestore nsfs type configuration
+func ValidateNsStoreNSFS(nsStore *nbv1.NamespaceStore) error {
 	nsfs := nsStore.Spec.NSFS
 
 	if nsfs == nil {
@@ -49,49 +56,54 @@ func validateNsStoreNSFS(nsStore *nbv1.NamespaceStore) error {
 
 	//pvcName validation
 	if nsfs.PvcName == "" {
-		return util.NewPersistentError("InvalidPvcName", "PvcName must not be empty")
+		return util.ValidationError{
+			Msg: "PvcName must not be empty",
+		}
 	}
 
 	//SubPath validation
 	if nsfs.SubPath != "" {
 		path := nsfs.SubPath
 		if len(path) > 0 && path[0] == '/' {
-			return util.NewPersistentError("InvalidSubPath",
-				fmt.Sprintf("SubPath %s must be a relative path", path))
+			return util.ValidationError{
+				Msg: fmt.Sprintf("SubPath %s must be a relative path", path),
+			}
 		}
 		parts := strings.Split(path, "/")
 		for _, item := range parts {
 			if item == ".." {
-				return util.NewPersistentError("InvalidSubPath",
-					fmt.Sprintf("SubPath %s must not contain '..'", path))
+				return util.ValidationError{
+					Msg: fmt.Sprintf("SubPath %s must not contain '..'", path),
+				}
 			}
 		}
 	}
 
 	//Check the mountPath
 	mountPath := "/nsfs/" + nsStore.Name
-	if len(mountPath) > 63 {
-		return util.NewPersistentError("InvalidMountPath",
-		fmt.Sprintf(" MountPath %v must be no more than 63 characters", mountPath))
+	if len(mountPath) > MaximumMountPathLength {
+		return util.ValidationError{
+			Msg: fmt.Sprintf("MountPath %v must be no more than 63 characters", mountPath),
+		}
 	}
 
 	return nil
 }
 
-// validateNsStoreS3Compatible validates namespacestore S3Compatible type configuration
-func validateNsStoreS3Compatible(nsStore *nbv1.NamespaceStore) error {
+// ValidateNsStoreS3Compatible validates namespacestore S3Compatible type configuration
+func ValidateNsStoreS3Compatible(nsStore *nbv1.NamespaceStore) error {
 	s3Compatible := nsStore.Spec.S3Compatible
 
 	if s3Compatible == nil {
 		return nil
 	}
 
-	err := validateSignatureVersion(s3Compatible.SignatureVersion, nsStore.Name)
+	err := ValidateSignatureVersion(s3Compatible.SignatureVersion, nsStore.Name)
 	if err != nil {
 		return err
 	}
 
-	err = validateEndPoint(&s3Compatible.Endpoint)
+	err = ValidateEndPoint(&s3Compatible.Endpoint)
 	if err != nil {
 		return err
 	}
@@ -99,20 +111,20 @@ func validateNsStoreS3Compatible(nsStore *nbv1.NamespaceStore) error {
 	return nil
 }
 
-// validateNsStoreIBMCos validates namespacestore IBMCos type configuration
-func validateNsStoreIBMCos(nsStore *nbv1.NamespaceStore) error {
+// ValidateNsStoreIBMCos validates namespacestore IBMCos type configuration
+func ValidateNsStoreIBMCos(nsStore *nbv1.NamespaceStore) error {
 	IBMCos := nsStore.Spec.IBMCos
 
 	if IBMCos == nil {
 		return nil
 	}
 
-	err := validateSignatureVersion(IBMCos.SignatureVersion, nsStore.Name)
+	err := ValidateSignatureVersion(IBMCos.SignatureVersion, nsStore.Name)
 	if err != nil {
 		return err
 	}
 
-	err = validateEndPoint(&IBMCos.Endpoint)
+	err = ValidateEndPoint(&IBMCos.Endpoint)
 	if err != nil {
 		return err
 	}
@@ -120,20 +132,20 @@ func validateNsStoreIBMCos(nsStore *nbv1.NamespaceStore) error {
 	return nil
 }
 
-//SignatureVersion validation, must be empty or v2 or v4
-func validateSignatureVersion(signature nbv1.S3SignatureVersion, nsStoreName string) error {
+//ValidateSignatureVersion validation, must be empty or v2 or v4
+func ValidateSignatureVersion(signature nbv1.S3SignatureVersion, nsStoreName string) error {
 	if signature != "" &&
 		signature != nbv1.S3SignatureVersionV2 &&
 		signature != nbv1.S3SignatureVersionV4 {
-		return util.NewPersistentError("InvalidSignatureVersion",
-			fmt.Sprintf("Invalid s3 signature version %q for namespace store %q",
-				signature, nsStoreName))
+		return util.ValidationError{
+			Msg: fmt.Sprintf("Invalid s3 signature version %q for namespace store %q", signature, nsStoreName),
+		}
 	}
 	return nil
 }
 
-//Endpoint validation and sets default
-func validateEndPoint(endPointPointer *string) error {
+//ValidateEndPoint Endpoint validation and sets default
+func ValidateEndPoint(endPointPointer *string) error {
 	endPoint := *endPointPointer
 
 	if endPoint == "" {
@@ -142,22 +154,121 @@ func validateEndPoint(endPointPointer *string) error {
 
 	match, err := regexp.MatchString(`^\w+://`, endPoint)
 	if err != nil {
-		return util.NewPersistentError("InvalidEndpoint",
-			fmt.Sprintf("Invalid endpoint url %q: %v", endPoint, err))
+		return util.ValidationError{
+			Msg: fmt.Sprintf("Invalid endpoint url %q: %v", endPoint, err),
+		}
 	}
 	if !match {
 		endPoint = "https://" + endPoint
 	}
 	u, err := url.Parse(endPoint)
 	if err != nil {
-		return util.NewPersistentError("InvalidEndpoint",
-			fmt.Sprintf("Invalid endpoint url %q: %v", endPoint, err))
+		return util.ValidationError{
+			Msg: fmt.Sprintf("Invalid endpoint url %q: %v", endPoint, err),
+		}
 	}
 	if u.Scheme == "" {
 		u.Scheme = "https"
 	}
 
 	*endPointPointer = u.String()
+
+	return nil
+}
+
+// ValidateNSEmptySecretName validates a secret name is provided for cloud namespacestore
+func ValidateNSEmptySecretName(ns nbv1.NamespaceStore) error {
+	switch ns.Spec.Type {
+	case nbv1.NSStoreTypeAWSS3:
+		if len(ns.Spec.AWSS3.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the namespacestore, please provide secret name",
+			}
+		}
+	case nbv1.NSStoreTypeS3Compatible:
+		if len(ns.Spec.S3Compatible.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the namespacestore, please provide secret name",
+			}
+		}
+	case nbv1.NSStoreTypeIBMCos:
+		if len(ns.Spec.IBMCos.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the namespacestore, please provide secret name",
+			}
+		}
+	case nbv1.NSStoreTypeAzureBlob:
+		if len(ns.Spec.AzureBlob.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the namespacestore, please provide secret name",
+			}
+		}
+	case nbv1.NSStoreTypeNSFS:
+		break
+	default:
+		return util.ValidationError{
+			Msg: "Invalid Namespacestore type, please provide a valid Namespacestore type",
+		}
+	}
+	return nil
+}
+
+// ValidateTargetBucketChange validates the user is not trying to update the namespacestore target bucket
+func ValidateTargetBucketChange(ns nbv1.NamespaceStore, oldNs nbv1.NamespaceStore) error {
+	switch ns.Spec.Type {
+	case nbv1.NSStoreTypeAWSS3:
+		if oldNs.Spec.AWSS3.TargetBucket != ns.Spec.AWSS3.TargetBucket {
+			return util.ValidationError{
+				Msg: "Changing a NamespaceStore target bucket is unsupported",
+			}
+		}
+	case nbv1.NSStoreTypeS3Compatible:
+		if oldNs.Spec.S3Compatible.TargetBucket != ns.Spec.S3Compatible.TargetBucket {
+			return util.ValidationError{
+				Msg: "Changing a NamespaceStore target bucket is unsupported",
+			}
+		}
+	case nbv1.NSStoreTypeIBMCos:
+		if oldNs.Spec.IBMCos.TargetBucket != ns.Spec.IBMCos.TargetBucket {
+			return util.ValidationError{
+				Msg: "Changing a NamespaceStore target bucket is unsupported",
+			}
+		}
+	case nbv1.NSStoreTypeAzureBlob:
+		if oldNs.Spec.AzureBlob.TargetBlobContainer != ns.Spec.AzureBlob.TargetBlobContainer {
+			return util.ValidationError{
+				Msg: "Changing a NamespaceStore target bucket is unsupported",
+			}
+		}
+	default:
+		return util.ValidationError{
+			Msg: "Failed to identify NamespaceStore type",
+		}
+	}
+	return nil
+}
+
+// ValidateNamespacestoreDeletion validates the deleted namespacestore not containing data buckets
+func ValidateNamespacestoreDeletion(ns nbv1.NamespaceStore) error {
+	sysClient, err := system.Connect(false)
+	if err != nil {
+		return fmt.Errorf("failed to load noobaa system connection info")
+	}
+	systemInfo, err := sysClient.NBClient.ReadSystemAPI()
+	if err != nil {
+		return fmt.Errorf("failed to call ReadSystemInfo API")
+	}
+
+	for _, nsr := range systemInfo.NamespaceResources {
+		if nsr.Name == ns.Name {
+			if nsr.Undeletable == "IN_USE" {
+				return util.ValidationError{
+					Msg: fmt.Sprintf("cannot complete because nsr %q in %q state", nsr.Name, nsr.Undeletable),
+				}
+			}
+			return nil
+		}
+	}
 
 	return nil
 }

--- a/pkg/namespacestore/validation_test.go
+++ b/pkg/namespacestore/validation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -151,6 +152,10 @@ func getDefaultIBMCosNsStore() nbv1.NamespaceStore {
 			IBMCos: &nbv1.IBMCosSpec{
 				SignatureVersion: nbv1.S3SignatureVersionV4,
 				Endpoint:         defaultEndPointURI,
+				Secret: corev1.SecretReference{
+					Name:      "secret-name",
+					Namespace: "namespace",
+				},
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
@@ -164,6 +169,10 @@ func getDefaultS3CompatibleNsStore() nbv1.NamespaceStore {
 			S3Compatible: &nbv1.S3CompatibleSpec{
 				SignatureVersion: nbv1.S3SignatureVersionV4,
 				Endpoint:         defaultEndPointURI,
+				Secret: corev1.SecretReference{
+					Name:      "secret-name",
+					Namespace: "namespace",
+				},
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{Name: "test1"},


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. move backingstore and namespacestore validations to a single file so that the cli and the operator could use them, also to avoid duplicate code.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
