### PR TITLE
Support AWS STS in Noobaa

### DIFF
--- a/deploy/crds/noobaa.io_backingstores_crd.yaml
+++ b/deploy/crds/noobaa.io_backingstores_crd.yaml
@@ -46,6 +46,8 @@ spec:
               awsS3:
                 description: AWSS3Spec specifies a backing store of type aws-s3
                 properties:
+                  awsSTSRoleARN:
+                    type: string
                   region:
                     description: Region is the AWS region
                     type: string
@@ -69,7 +71,6 @@ spec:
                     description: TargetBucket is the name of the target S3 bucket
                     type: string
                 required:
-                - secret
                 - targetBucket
                 type: object
               azureBlob:

--- a/deploy/crds/noobaa.io_namespacestores_crd.yaml
+++ b/deploy/crds/noobaa.io_namespacestores_crd.yaml
@@ -46,6 +46,8 @@ spec:
               awsS3:
                 description: AWSS3Spec specifies a namespace store of type aws-s3
                 properties:
+                  awsSTSRoleARN:
+                    type: string
                   region:
                     description: Region is the AWS region
                     type: string
@@ -69,7 +71,6 @@ spec:
                     description: TargetBucket is the name of the target S3 bucket
                     type: string
                 required:
-                - secret
                 - targetBucket
                 type: object
               azureBlob:

--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -1009,6 +1009,215 @@ spec:
                 - warn
                 - default_level
                 type: integer
+              defaultBackingStoreSpec:
+                description: BackingStoreSpec defines the desired state of BackingStore
+                properties:
+                  awsS3:
+                    description: AWSS3Spec specifies a backing store of type aws-s3
+                    properties:
+                      awsSTSRoleARN:
+                        type: string
+                      region:
+                        description: Region is the AWS region
+                        type: string
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      sslDisabled:
+                        description: SSLDisabled allows to disable SSL and use plain
+                          http
+                        type: boolean
+                      targetBucket:
+                        description: TargetBucket is the name of the target S3 bucket
+                        type: string
+                    required:
+                    - targetBucket
+                    type: object
+                  azureBlob:
+                    description: AzureBlob specifies a backing store of type azure-blob
+                    properties:
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define AccountName and AccountKey as provided
+                          by Azure Blob.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      targetBlobContainer:
+                        description: TargetBlobContainer is the name of the target
+                          Azure Blob container
+                        type: string
+                    required:
+                    - secret
+                    - targetBlobContainer
+                    type: object
+                  googleCloudStorage:
+                    description: GoogleCloudStorage specifies a backing store of type
+                      google-cloud-storage
+                    properties:
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define GoogleServiceAccountPrivateKeyJson
+                          containing the entire json string as provided by Google.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      targetBucket:
+                        description: TargetBucket is the name of the target S3 bucket
+                        type: string
+                    required:
+                    - secret
+                    - targetBucket
+                    type: object
+                  ibmCos:
+                    description: IBMCos specifies a backing store of type ibm-cos
+                    properties:
+                      endpoint:
+                        description: 'Endpoint is the IBM COS compatible endpoint:
+                          http(s)://host:port'
+                        type: string
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define IBM_COS_ACCESS_KEY_ID and IBM_COS_SECRET_ACCESS_KEY
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      signatureVersion:
+                        description: SignatureVersion specifies the client signature
+                          version to use when signing requests.
+                        type: string
+                      targetBucket:
+                        description: TargetBucket is the name of the target IBM COS
+                          bucket
+                        type: string
+                    required:
+                    - endpoint
+                    - secret
+                    - targetBucket
+                    type: object
+                  pvPool:
+                    description: PVPool specifies a backing store of type pv-pool
+                    properties:
+                      numVolumes:
+                        description: NumVolumes is the number of volumes to allocate
+                        type: integer
+                      resources:
+                        description: VolumeResources represents the minimum resources
+                          each volume should have.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      secret:
+                        description: Secret refers to a secret that provides the agent
+                          configuration The secret should define AGENT_CONFIG containing
+                          agent_configuration from noobaa-core.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      storageClass:
+                        description: StorageClass is the name of the storage class
+                          to use for the PV's
+                        type: string
+                    required:
+                    - numVolumes
+                    type: object
+                  s3Compatible:
+                    description: S3Compatible specifies a backing store of type s3-compatible
+                    properties:
+                      endpoint:
+                        description: 'Endpoint is the S3 compatible endpoint: http(s)://host:port'
+                        type: string
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      signatureVersion:
+                        description: SignatureVersion specifies the client signature
+                          version to use when signing requests.
+                        type: string
+                      targetBucket:
+                        description: TargetBucket is the name of the target S3 bucket
+                        type: string
+                    required:
+                    - endpoint
+                    - secret
+                    - targetBucket
+                    type: object
+                  type:
+                    description: Type is an enum of supported types
+                    type: string
+                required:
+                - type
+                type: object
               disableLoadBalancerService:
                 description: DisableLoadBalancerService (optional) sets the service
                   type to ClusterIP instead of LoadBalancer

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -33,6 +33,13 @@ spec:
           secret:
             secretName: noobaa-s3-serving-cert
             optional: true
+        - name: oidc-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: oidc-token
+                expirationSeconds: 3600
+                audience: api
       containers:
         #----------------#
         # CORE CONTAINER #
@@ -47,6 +54,9 @@ spec:
               readOnly: true
             - name: s3-secret
               mountPath: /etc/s3-secret
+              readOnly: true
+            - mountPath: /var/run/secrets/openshift/serviceaccount
+              name: oidc-token
               readOnly: true
           resources:
             requests:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,9 +14,20 @@ spec:
         noobaa-operator: deployment
     spec:
       serviceAccountName: noobaa
+      volumes:
+      - name: oidc-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: oidc-token
+              expirationSeconds: 3600
+              audience: api
       containers:
         - name: noobaa-operator
           image: NOOBAA_OPERATOR_IMAGE
+          volumeMounts:
+          - mountPath: /var/run/secrets/openshift/serviceaccount
+            name: oidc-token
           resources:
             limits:
               cpu: "250m"

--- a/pkg/apis/noobaa/v1alpha1/backingstore_types.go
+++ b/pkg/apis/noobaa/v1alpha1/backingstore_types.go
@@ -148,6 +148,7 @@ type AWSS3Spec struct {
 
 	// Secret refers to a secret that provides the credentials
 	// The secret should define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+	// +optional
 	Secret corev1.SecretReference `json:"secret"`
 
 	// Region is the AWS region
@@ -157,6 +158,9 @@ type AWSS3Spec struct {
 	// SSLDisabled allows to disable SSL and use plain http
 	// +optional
 	SSLDisabled bool `json:"sslDisabled,omitempty"`
+
+	// +optional
+	AWSSTSRoleARN *string `json:"awsSTSRoleARN,omitempty"`
 }
 
 // S3CompatibleSpec specifies a backing store of type s3-compatible

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -117,7 +117,7 @@ type NooBaaSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=all;nsfs;warn;default_level
 	DebugLevel int `json:"debugLevel,omitempty"`
-	
+
 	// PVPoolDefaultStorageClass (optional) overrides the default cluster StorageClass for the pv-pool volumes.
 	// This affects where the system stores data chunks (encrypted).
 	// Updates to this field will only affect new pv-pools,
@@ -175,6 +175,9 @@ type NooBaaSpec struct {
 	// +nullable
 	// +optional
 	DisableLoadBalancerService bool `json:"disableLoadBalancerService,omitempty"`
+
+	// +optional
+	DefaultBackingStoreSpec *BackingStoreSpec `json:"defaultBackingStoreSpec,omitempty"`
 }
 
 // SecuritySpec is security spec to include various security items such as kms
@@ -295,19 +298,19 @@ const (
 // These are NooBaa condition statuses
 const (
 	// External KMS initialized
-	ConditionKMSInit        corev1.ConditionStatus = "Init"
+	ConditionKMSInit corev1.ConditionStatus = "Init"
 
 	// The root key was synchronized from external KMS
-	ConditionKMSSync        corev1.ConditionStatus = "Sync"
+	ConditionKMSSync corev1.ConditionStatus = "Sync"
 
 	// Invalid external KMS definition
-	ConditionKMSInvalid     corev1.ConditionStatus = "Invalid"
+	ConditionKMSInvalid corev1.ConditionStatus = "Invalid"
 
 	// Error reading secret from external KMS
-	ConditionKMSErrorRead   corev1.ConditionStatus = "ErrorRead"
+	ConditionKMSErrorRead corev1.ConditionStatus = "ErrorRead"
 
 	// Error writing initial root key to eternal KMS
-	ConditionKMSErrorWrite  corev1.ConditionStatus = "ErrorWrite"
+	ConditionKMSErrorWrite corev1.ConditionStatus = "ErrorWrite"
 )
 
 // AccountsStatus is the status info of admin account

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -14,6 +14,11 @@ import (
 func (in *AWSS3Spec) DeepCopyInto(out *AWSS3Spec) {
 	*out = *in
 	out.Secret = in.Secret
+	if in.AWSSTSRoleARN != nil {
+		in, out := &in.AWSSTSRoleARN, &out.AWSSTSRoleARN
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -219,7 +224,7 @@ func (in *BackingStoreSpec) DeepCopyInto(out *BackingStoreSpec) {
 	if in.AWSS3 != nil {
 		in, out := &in.AWSS3, &out.AWSS3
 		*out = new(AWSS3Spec)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.S3Compatible != nil {
 		in, out := &in.S3Compatible, &out.S3Compatible
@@ -770,7 +775,7 @@ func (in *NamespaceStoreSpec) DeepCopyInto(out *NamespaceStoreSpec) {
 	if in.AWSS3 != nil {
 		in, out := &in.AWSS3, &out.AWSS3
 		*out = new(AWSS3Spec)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.S3Compatible != nil {
 		in, out := &in.S3Compatible, &out.S3Compatible
@@ -1106,6 +1111,11 @@ func (in *NooBaaSpec) DeepCopyInto(out *NooBaaSpec) {
 			}
 			(*out)[key] = outVal
 		}
+	}
+	if in.DefaultBackingStoreSpec != nil {
+		in, out := &in.DefaultBackingStoreSpec, &out.DefaultBackingStoreSpec
+		*out = new(BackingStoreSpec)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -255,33 +255,35 @@ func (r *Reconciler) ReconcilePhases() error {
 
 // LoadBackingStoreSecret loads the secret to the reconciler struct
 func (r *Reconciler) LoadBackingStoreSecret() error {
-	secretRef := GetBackingStoreSecret(r.BackingStore)
-	if secretRef != nil {
-		r.Secret.Name = secretRef.Name
-		r.Secret.Namespace = secretRef.Namespace
-		if r.Secret.Namespace == "" {
-			r.Secret.Namespace = r.BackingStore.Namespace
-		}
-		if r.Secret.Name == "" {
-			if r.BackingStore.Spec.Type != nbv1.StoreTypePVPool {
-				return util.NewPersistentError("EmptySecretName",
-					"BackingStore Secret reference has an empty name")
+	if !util.IsSTSClusterBS(r.BackingStore) {
+		secretRef := GetBackingStoreSecret(r.BackingStore)
+		if secretRef != nil {
+			r.Secret.Name = secretRef.Name
+			r.Secret.Namespace = secretRef.Namespace
+			if r.Secret.Namespace == "" {
+				r.Secret.Namespace = r.BackingStore.Namespace
 			}
-			r.Secret.Name = fmt.Sprintf("backing-store-%s-%s", nbv1.StoreTypePVPool, r.BackingStore.Name)
-			r.Secret.Namespace = r.BackingStore.Namespace
-			r.Secret.StringData = map[string]string{}
-			r.Secret.Data = nil
-
-			if !util.KubeCheck(r.Secret) {
-				r.Own(r.Secret)
-				if !util.KubeCreateFailExisting(r.Secret) {
+			if r.Secret.Name == "" {
+				if r.BackingStore.Spec.Type != nbv1.StoreTypePVPool {
 					return util.NewPersistentError("EmptySecretName",
-						fmt.Sprintf("Could not create Secret %q in Namespace %q (conflict)", r.Secret.Name, r.Secret.Namespace))
+						"BackingStore Secret reference has an empty name")
 				}
-			}
+				r.Secret.Name = fmt.Sprintf("backing-store-%s-%s", nbv1.StoreTypePVPool, r.BackingStore.Name)
+				r.Secret.Namespace = r.BackingStore.Namespace
+				r.Secret.StringData = map[string]string{}
+				r.Secret.Data = nil
 
+				if !util.KubeCheck(r.Secret) {
+					r.Own(r.Secret)
+					if !util.KubeCreateFailExisting(r.Secret) {
+						return util.NewPersistentError("EmptySecretName",
+							fmt.Sprintf("Could not create Secret %q in Namespace %q (conflict)", r.Secret.Name, r.Secret.Namespace))
+					}
+				}
+
+			}
+			util.KubeCheck(r.Secret)
 		}
-		util.KubeCheck(r.Secret)
 	}
 	return nil
 }
@@ -641,9 +643,14 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 	switch r.BackingStore.Spec.Type {
 
 	case nbv1.StoreTypeAWSS3:
-		conn.EndpointType = nb.EndpointTypeAws
-		conn.Identity = r.Secret.StringData["AWS_ACCESS_KEY_ID"]
-		conn.Secret = r.Secret.StringData["AWS_SECRET_ACCESS_KEY"]
+		if util.IsSTSClusterBS(r.BackingStore) {
+			conn.EndpointType = nb.EndpointTypeAwsSTS
+			conn.AWSSTSARN = *r.BackingStore.Spec.AWSS3.AWSSTSRoleARN
+		} else {
+			conn.EndpointType = nb.EndpointTypeAws
+			conn.Identity = r.Secret.StringData["AWS_ACCESS_KEY_ID"]
+			conn.Secret = r.Secret.StringData["AWS_SECRET_ACCESS_KEY"]
+		}
 		awsS3 := r.BackingStore.Spec.AWSS3
 		u := url.URL{
 			Scheme: "https",
@@ -654,6 +661,7 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		}
 		if awsS3.Region != "" {
 			u.Host = fmt.Sprintf("s3.%s.amazonaws.com", awsS3.Region)
+			conn.Region = awsS3.Region
 		}
 		conn.Endpoint = u.String()
 
@@ -780,10 +788,11 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		return nil, util.NewPersistentError("InvalidType",
 			fmt.Sprintf("Invalid backing store type %q", r.BackingStore.Spec.Type))
 	}
-
-	if !util.IsStringGraphicOrSpacesCharsOnly(conn.Identity) || !util.IsStringGraphicOrSpacesCharsOnly(conn.Secret) {
-		return nil, util.NewPersistentError("InvalidSecret",
-			fmt.Sprintf("Invalid secret containing non graphic characters (perhaps not base64 encoded?) %q", r.Secret.Name))
+	if !util.IsSTSClusterBS(r.BackingStore) {
+		if !util.IsStringGraphicOrSpacesCharsOnly(conn.Identity) || !util.IsStringGraphicOrSpacesCharsOnly(conn.Secret) {
+			return nil, util.NewPersistentError("InvalidSecret",
+				fmt.Sprintf("Invalid secret containing non graphic characters (perhaps not base64 encoded?) %q", r.Secret.Name))
+		}
 	}
 
 	return conn, nil

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -90,7 +90,7 @@ roleRef:
   name: noobaa.noobaa.io
 `
 
-const Sha256_deploy_crds_noobaa_io_backingstores_crd_yaml = "29e4e3ad73831cc5b1b071b8c3573a34e3a7e7eaac121fd6c0bd493d95bd6d76"
+const Sha256_deploy_crds_noobaa_io_backingstores_crd_yaml = "21d7000fc44c8205f57d01bf5a5489e8822d078230ee749876ea86890947b5b9"
 
 const File_deploy_crds_noobaa_io_backingstores_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -140,6 +140,8 @@ spec:
               awsS3:
                 description: AWSS3Spec specifies a backing store of type aws-s3
                 properties:
+                  awsSTSRoleARN:
+                    type: string
                   region:
                     description: Region is the AWS region
                     type: string
@@ -163,7 +165,6 @@ spec:
                     description: TargetBucket is the name of the target S3 bucket
                     type: string
                 required:
-                - secret
                 - targetBucket
                 type: object
               azureBlob:
@@ -714,7 +715,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_namespacestores_crd_yaml = "75ea24de1ab0e53c7cdebe2e1f55fe7cd0dc28f469920d64a8451d5429967c8f"
+const Sha256_deploy_crds_noobaa_io_namespacestores_crd_yaml = "f7541d48fbef88f3eefaa1b70dbbdfdc45182121b6286e2cca2017f09685d009"
 
 const File_deploy_crds_noobaa_io_namespacestores_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -764,6 +765,8 @@ spec:
               awsS3:
                 description: AWSS3Spec specifies a namespace store of type aws-s3
                 properties:
+                  awsSTSRoleARN:
+                    type: string
                   region:
                     description: Region is the AWS region
                     type: string
@@ -787,7 +790,6 @@ spec:
                     description: TargetBucket is the name of the target S3 bucket
                     type: string
                 required:
-                - secret
                 - targetBucket
                 type: object
               azureBlob:
@@ -1196,7 +1198,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "a716415c7ed63a0445c8d79c14898e98733a32e133df23c11b1825418195af53"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "d0e975cb1cad2ce0d5a9e896b378664f378cf1ea22078530f00c4736f91d94c4"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2209,6 +2211,215 @@ spec:
                 - warn
                 - default_level
                 type: integer
+              defaultBackingStoreSpec:
+                description: BackingStoreSpec defines the desired state of BackingStore
+                properties:
+                  awsS3:
+                    description: AWSS3Spec specifies a backing store of type aws-s3
+                    properties:
+                      awsSTSRoleARN:
+                        type: string
+                      region:
+                        description: Region is the AWS region
+                        type: string
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      sslDisabled:
+                        description: SSLDisabled allows to disable SSL and use plain
+                          http
+                        type: boolean
+                      targetBucket:
+                        description: TargetBucket is the name of the target S3 bucket
+                        type: string
+                    required:
+                    - targetBucket
+                    type: object
+                  azureBlob:
+                    description: AzureBlob specifies a backing store of type azure-blob
+                    properties:
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define AccountName and AccountKey as provided
+                          by Azure Blob.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      targetBlobContainer:
+                        description: TargetBlobContainer is the name of the target
+                          Azure Blob container
+                        type: string
+                    required:
+                    - secret
+                    - targetBlobContainer
+                    type: object
+                  googleCloudStorage:
+                    description: GoogleCloudStorage specifies a backing store of type
+                      google-cloud-storage
+                    properties:
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define GoogleServiceAccountPrivateKeyJson
+                          containing the entire json string as provided by Google.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      targetBucket:
+                        description: TargetBucket is the name of the target S3 bucket
+                        type: string
+                    required:
+                    - secret
+                    - targetBucket
+                    type: object
+                  ibmCos:
+                    description: IBMCos specifies a backing store of type ibm-cos
+                    properties:
+                      endpoint:
+                        description: 'Endpoint is the IBM COS compatible endpoint:
+                          http(s)://host:port'
+                        type: string
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define IBM_COS_ACCESS_KEY_ID and IBM_COS_SECRET_ACCESS_KEY
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      signatureVersion:
+                        description: SignatureVersion specifies the client signature
+                          version to use when signing requests.
+                        type: string
+                      targetBucket:
+                        description: TargetBucket is the name of the target IBM COS
+                          bucket
+                        type: string
+                    required:
+                    - endpoint
+                    - secret
+                    - targetBucket
+                    type: object
+                  pvPool:
+                    description: PVPool specifies a backing store of type pv-pool
+                    properties:
+                      numVolumes:
+                        description: NumVolumes is the number of volumes to allocate
+                        type: integer
+                      resources:
+                        description: VolumeResources represents the minimum resources
+                          each volume should have.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      secret:
+                        description: Secret refers to a secret that provides the agent
+                          configuration The secret should define AGENT_CONFIG containing
+                          agent_configuration from noobaa-core.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      storageClass:
+                        description: StorageClass is the name of the storage class
+                          to use for the PV's
+                        type: string
+                    required:
+                    - numVolumes
+                    type: object
+                  s3Compatible:
+                    description: S3Compatible specifies a backing store of type s3-compatible
+                    properties:
+                      endpoint:
+                        description: 'Endpoint is the S3 compatible endpoint: http(s)://host:port'
+                        type: string
+                      secret:
+                        description: Secret refers to a secret that provides the credentials
+                          The secret should define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                      signatureVersion:
+                        description: SignatureVersion specifies the client signature
+                          version to use when signing requests.
+                        type: string
+                      targetBucket:
+                        description: TargetBucket is the name of the target S3 bucket
+                        type: string
+                    required:
+                    - endpoint
+                    - secret
+                    - targetBucket
+                    type: object
+                  type:
+                    description: Type is an enum of supported types
+                    type: string
+                required:
+                - type
+                type: object
               disableLoadBalancerService:
                 description: DisableLoadBalancerService (optional) sets the service
                   type to ClusterIP instead of LoadBalancer
@@ -3529,7 +3740,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "9bf8ab915f3d51fe381dd20307cc917791b8f8a34a0384d6ce28cc2234b09014"
+const Sha256_deploy_internal_statefulset_core_yaml = "3b0aec2d946e02a9d8b44b8f191c335be33a75c8c2d2dc2f04c64cf37ecbfa3f"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -3566,6 +3777,13 @@ spec:
           secret:
             secretName: noobaa-s3-serving-cert
             optional: true
+        - name: oidc-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: oidc-token
+                expirationSeconds: 3600
+                audience: api
       containers:
         #----------------#
         # CORE CONTAINER #
@@ -3580,6 +3798,9 @@ spec:
               readOnly: true
             - name: s3-secret
               mountPath: /etc/s3-secret
+              readOnly: true
+            - mountPath: /var/run/secrets/openshift/serviceaccount
+              name: oidc-token
               readOnly: true
           resources:
             requests:
@@ -4644,7 +4865,7 @@ spec:
   sourceNamespace: default
 `
 
-const Sha256_deploy_operator_yaml = "3030f31026433e2737957a3f153739ce3d1a69cf11813d27b4fd95e7452ee3df"
+const Sha256_deploy_operator_yaml = "2870838f688bf1691d85c64dc5e302eb6575996427c7cfdb7143f322ff0dbd18"
 
 const File_deploy_operator_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4662,9 +4883,20 @@ spec:
         noobaa-operator: deployment
     spec:
       serviceAccountName: noobaa
+      volumes:
+      - name: oidc-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: oidc-token
+              expirationSeconds: 3600
+              audience: api
       containers:
         - name: noobaa-operator
           image: NOOBAA_OPERATOR_IMAGE
+          volumeMounts:
+          - mountPath: /var/run/secrets/openshift/serviceaccount
+            name: oidc-token
           resources:
             limits:
               cpu: "250m"

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -602,6 +602,8 @@ const (
 
 	// EndpointTypeAws enum
 	EndpointTypeAws EndpointType = "AWS"
+	// EndpointTypeAwsSTS enum
+	EndpointTypeAwsSTS EndpointType = "AWSSTS"
 	// EndpointTypeAzure enum
 	EndpointTypeAzure EndpointType = "AZURE"
 	// EndpointTypeGoogle enum
@@ -649,6 +651,8 @@ type AddExternalConnectionParams struct {
 	Identity     string          `json:"identity"`
 	Secret       string          `json:"secret"`
 	AuthMethod   CloudAuthMethod `json:"auth_method,omitempty"`
+	AWSSTSARN    string          `json:"aws_sts_arn,omitempty"`
+	Region       string          `json:"region,omitempty"`
 }
 
 // CheckExternalConnectionReply is the reply of account_api.check_external_connection()

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -168,7 +168,7 @@ func (r *Reconciler) SetDesiredServiceAccount() error {
 
 // SetDesiredServiceMgmt updates the ServiceMgmt as desired for reconciling
 func (r *Reconciler) SetDesiredServiceMgmt() error {
-	if 	r.NooBaa.Spec.DisableLoadBalancerService {
+	if r.NooBaa.Spec.DisableLoadBalancerService {
 		r.ServiceMgmt.Spec.Type = corev1.ServiceTypeClusterIP
 	} else {
 		// It is here in case disableLoadBalancerService is removed from the crd or changed to false
@@ -181,7 +181,7 @@ func (r *Reconciler) SetDesiredServiceMgmt() error {
 
 // SetDesiredServiceS3 updates the ServiceS3 as desired for reconciling
 func (r *Reconciler) SetDesiredServiceS3() error {
-	if 	r.NooBaa.Spec.DisableLoadBalancerService {
+	if r.NooBaa.Spec.DisableLoadBalancerService {
 		r.ServiceS3.Spec.Type = corev1.ServiceTypeClusterIP
 	} else {
 		// It is here in case disableLoadBalancerService is removed from the crd or changed to false
@@ -506,6 +506,11 @@ func (r *Reconciler) ReconcileBackingStoreCredentials() error {
 	// Skip if joining another NooBaa
 	r.Logger.Info("Reconciling Backing Store Credentials")
 	if r.JoinSecret != nil {
+		return nil
+	}
+	// If DefaultBackingStore Spec is set do nothing
+	if r.NooBaa.Spec.DefaultBackingStoreSpec != nil {
+		r.Logger.Info("DefaultBackingStoreSpec found Skipping Reconciling Backing Store Credentials")
 		return nil
 	}
 
@@ -1234,7 +1239,7 @@ func (r *Reconciler) findLocalStorageClass() (string, error) {
 	}
 	if len(lsoStorageClassNames) == 0 {
 		return "", fmt.Errorf("Error: found no LSO storage class and no storage class was marked as default")
-	} 
+	}
 	if len(lsoStorageClassNames) > 1 {
 		return "", fmt.Errorf("Error: found more than one LSO storage class and none was marked as default")
 	}

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -601,8 +601,10 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 		log.Infof("Backing store %s already exists. skipping ReconcileCloudCredentials", r.DefaultBackingStore.Name)
 		return nil
 	}
-
-	if r.CephObjectStoreUser.UID != "" {
+	if r.NooBaa.Spec.DefaultBackingStoreSpec != nil {
+		r.DefaultBackingStore.Spec = *r.NooBaa.Spec.DefaultBackingStoreSpec
+		log.Infof("DefaultBacking store spec %s already exists. skipping ReconcileCloudCredentials", r.DefaultBackingStore.Name)
+	} else if r.CephObjectStoreUser.UID != "" {
 		log.Infof("CephObjectStoreUser %q created. Creating default backing store on ceph objectstore", r.CephObjectStoreUser.Name)
 		if err := r.prepareCephBackingStore(); err != nil {
 			return err

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -960,12 +960,12 @@ func CheckMongoURL(sys *nbv1.NooBaa) error {
 
 // LoadConfigMapFromFlags loads a config-map with values from the cli flags, if provided.
 func LoadConfigMapFromFlags() {
-	if(options.DebugLevel != "default_level") {
+	if options.DebugLevel != "default_level" {
 		cm := util.KubeObject(bundle.File_deploy_internal_configmap_empty_yaml).(*corev1.ConfigMap)
 		cm.Namespace = options.Namespace
 		cm.Name = "noobaa-config"
 
-		DefaultConfigMapData := map[string]string {
+		DefaultConfigMapData := map[string]string{
 			"NOOBAA_LOG_LEVEL": options.DebugLevel,
 		}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -977,6 +977,22 @@ func IsAWSPlatform() bool {
 	return isAWS
 }
 
+// IsSTSClusterNB returns true if it is running on an STS cluster
+func IsSTSClusterNB(nb *nbv1.NooBaa) bool {
+	if nb.Spec.DefaultBackingStoreSpec != nil {
+		return nb.Spec.DefaultBackingStoreSpec.AWSS3.AWSSTSRoleARN != nil
+	}
+	return false
+}
+
+// IsSTSClusterBS returns true if it is running on an STS cluster
+func IsSTSClusterBS(bs *nbv1.BackingStore) bool {
+	if bs.Spec.Type == nbv1.StoreTypeAWSS3 {
+		return bs.Spec.AWSS3.AWSSTSRoleARN != nil
+	}
+	return false
+}
+
 // IsAzurePlatform returns true if this cluster is running on Azure
 func IsAzurePlatform() bool {
 	nodesList := &corev1.NodeList{}
@@ -1531,13 +1547,13 @@ func ValidateQuotaConfig(name string, maxSize string, maxObjects string) error {
 
 // NooBaaCondStatus waits for requested NooBaa CR KMS condition status
 // returns false if timeout
-func NooBaaCondStatus(noobaa* nbv1.NooBaa, s corev1.ConditionStatus) bool {
+func NooBaaCondStatus(noobaa *nbv1.NooBaa, s corev1.ConditionStatus) bool {
 	return NooBaaCondition(noobaa, nbv1.ConditionTypeKMSStatus, s)
 }
 
 // NooBaaCondition waits for requested NooBaa CR KMS condition type & status
 // returns false if timeout
-func NooBaaCondition(noobaa* nbv1.NooBaa, t conditionsv1.ConditionType, s corev1.ConditionStatus) bool {
+func NooBaaCondition(noobaa *nbv1.NooBaa, t conditionsv1.ConditionType, s corev1.ConditionStatus) bool {
 	found := false
 
 	timeout := 120 // seconds


### PR DESCRIPTION
### Explain the changes
1. Added spec field for backing stores crd to include Role ARN for AWS STS
2. Added spec field for noobaa crd to include Role ARN for AWS STS
3. Added Projected Service account token mount to noobaa-operator and nooba-core pods
4. Added function to create AWS STS backing store
5. Added noobaa install cli option `--aws-sts-role-arn`
6. Added check for AWS STS cluster
7. Added Admission Webhook validation for BackingStore
8. Added Validation check for NamespaceStore to not include AWS STS ARN
- [ ] Add unit tests
Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>

### Testing Instructions:
1. Create an STS based Kubernetes or Openshift cluster [see more..](https://docs.openshift.com/container-platform/4.7/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#sts-mode-installing-manual-config_cco-mode-sts)
2. Create Role for S3 full access and assign to Identity Provider which was created during cluster install
3. Use noobaa cli to pass in the ARN for the role created previously 
`nb install --aws-sts-role-arn=arn:aws:iam::261532230807:role/kmajumder_noobaa_sts`
4. Check if the default backing store reaches ready state.
