### PR TITLE
Add noobaa-odf-ui service account's role rules

### DIFF
--- a/deploy/role_ui.yaml
+++ b/deploy/role_ui.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: noobaa-odf-ui
+rules:
+  - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - noobaa.io
+    resources:
+      - noobaas
+      - bucketclasses

--- a/deploy/service_account_ui.yaml
+++ b/deploy/service_account_ui.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: noobaa-odf-ui

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5238,6 +5238,24 @@ rules:
   - use
 `
 
+const Sha256_deploy_role_ui_yaml = "49d210f2ec7facbd486e6ac96515c1d2886f26afe6f7155be3994b4f0b1d0311"
+
+const File_deploy_role_ui_yaml = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: noobaa-odf-ui
+rules:
+  - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - noobaa.io
+    resources:
+      - noobaas
+      - bucketclasses
+`
+
 const Sha256_deploy_scc_yaml = "cbb071961f7dd77e5bdca7e36b89e1e1982265c4e7dc95f00109d0acc64a3c06"
 
 const File_deploy_scc_yaml = `apiVersion: security.openshift.io/v1
@@ -5338,5 +5356,13 @@ const File_deploy_service_account_endpoint_yaml = `apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: noobaa-endpoint
+`
+
+const Sha256_deploy_service_account_ui_yaml = "d6cb0e92fdb350148399e1ac42bfa640e254bdbb295c9a15dc9edfd4335e73f6"
+
+const File_deploy_service_account_ui_yaml = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: noobaa-odf-ui
 `
 

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -245,6 +245,11 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 			ServiceAccountName: opConf.SAEndpoint.Name,
 			Rules:              opConf.RoleEndpoint.Rules,
 		})
+	csv.Spec.InstallStrategy.StrategySpec.Permissions = append(csv.Spec.InstallStrategy.StrategySpec.Permissions,
+		operv1.StrategyDeploymentPermissions{
+			ServiceAccountName: opConf.SAUI.Name,
+			Rules:              opConf.RoleUI.Rules,
+		})
 	csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = []operv1.StrategyDeploymentSpec{}
 	csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = append(csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs,
 		operv1.StrategyDeploymentSpec{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -237,9 +237,11 @@ func RunYaml(cmd *cobra.Command, args []string) {
 type Conf struct {
 	NS                         *corev1.Namespace
 	SA                         *corev1.ServiceAccount
+	SAUI                       *corev1.ServiceAccount
 	SAEndpoint                 *corev1.ServiceAccount
 	Role                       *rbacv1.Role
 	RoleEndpoint               *rbacv1.Role
+	RoleUI                     *rbacv1.Role
 	RoleBinding                *rbacv1.RoleBinding
 	RoleBindingEndpoint        *rbacv1.RoleBinding
 	ClusterRole                *rbacv1.ClusterRole
@@ -259,8 +261,10 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.NS = util.KubeObject(bundle.File_deploy_namespace_yaml).(*corev1.Namespace)
 	c.SA = util.KubeObject(bundle.File_deploy_service_account_yaml).(*corev1.ServiceAccount)
 	c.SAEndpoint = util.KubeObject(bundle.File_deploy_service_account_endpoint_yaml).(*corev1.ServiceAccount)
+	c.SAUI = util.KubeObject(bundle.File_deploy_service_account_ui_yaml).(*corev1.ServiceAccount)
 	c.Role = util.KubeObject(bundle.File_deploy_role_yaml).(*rbacv1.Role)
 	c.RoleEndpoint = util.KubeObject(bundle.File_deploy_role_endpoint_yaml).(*rbacv1.Role)
+	c.RoleUI = util.KubeObject(bundle.File_deploy_role_ui_yaml).(*rbacv1.Role)
 	c.RoleBinding = util.KubeObject(bundle.File_deploy_role_binding_yaml).(*rbacv1.RoleBinding)
 	c.RoleBindingEndpoint = util.KubeObject(bundle.File_deploy_role_binding_endpoint_yaml).(*rbacv1.RoleBinding)
 	c.ClusterRole = util.KubeObject(bundle.File_deploy_cluster_role_yaml).(*rbacv1.ClusterRole)


### PR DESCRIPTION
### Add noobaa-odf-ui service account's role rules
### Test:

- Run "noobaa olm csv"

Expected generated YAML should contain the following permission:

```yaml
  ...
  install:
    spec:
      permissions:
      ...
      - rules:
        - apiGroups:
          - noobaa.io
          resources:
          - noobaas
          - bucketclasses
          verbs:
          - get
          - watch
          - list
        serviceAccountName: noobaa-odf-ui
```
See https://bugzilla.redhat.com/show_bug.cgi?id=2031705