### PR TITLE
changed default TTL to 0 for cache buckets

### DIFF
--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -140,7 +140,7 @@ func CmdCreateCacheNamespaceBucketclass() *cobra.Command {
 	// cache namespace policy
 	cmd.Flags().String("hub-resource", "",
 		"Set the namespace read and write resource")
-	cmd.Flags().Uint32("ttl", 60000,
+	cmd.Flags().Uint32("ttl", 0,
 		"Set the namespace cache ttl")
 
 	// placement policy flags


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. changed default TTL to 0 for cache buckets
2. 0 is a better default since it is less likely to cause inconsistency with the remote bucket. reads are always validated against the hub.
### Issues: Fixed #xxx / Gap #xxx
1. Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=2024107

### Testing Instructions:
1. 
