### PR TITLE
Update diagnostics to support both kubectl and oc

### DIFF
--- a/pkg/diagnose/diagnose.go
+++ b/pkg/diagnose/diagnose.go
@@ -22,9 +22,10 @@ import (
 
 // Collector configuration for diagnostics
 type Collector struct {
-	folderName string
-	kubeconfig string
-	log        *logrus.Entry
+	folderName  string
+	kubeconfig  string
+	kubeCommand string
+	log         *logrus.Entry
 }
 
 // Cmd returns a CLI command
@@ -58,6 +59,9 @@ func RunCollect(cmd *cobra.Command, args []string) {
 	if err != nil {
 		c.log.Fatalf(`❌ Could not create directory %s, reason: %s`, c.folderName, err)
 	}
+
+	c.kubeCommand = util.GetAvailabeKubeCli();
+
 
 	// Define to select only noobaa pods within the namespace
 	podSelector, _ := labels.Parse("app=noobaa")
@@ -121,7 +125,7 @@ func (c *Collector) CollectCRs() {
 
 // CollectDescribe collects output of the "describe pod" of a single pod
 func (c *Collector) CollectDescribe(Kind string, Name string) {
-	cmd := exec.Command("kubectl", "describe", Kind, "-n", options.Namespace, Name)
+	cmd := exec.Command(c.kubeCommand, "describe", Kind, "-n", options.Namespace, Name)
 	// handle custom path for kubeconfig file,
 	// see --kubeconfig cli options
 	if len(c.kubeconfig) > 0 {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1552,4 +1553,26 @@ func NooBaaCondition(noobaa* nbv1.NooBaa, t conditionsv1.ConditionType, s corev1
 	}
 
 	return found
+}
+
+// GetAvailabeKubeCli will check which k8s cli command is availabe in the system: oc or kubectl
+// returns one of: "oc" or "kubectl"
+func GetAvailabeKubeCli() string {
+	kubeCommand := "kubectl"
+	cmd := exec.Command(kubeCommand)
+	err := cmd.Run(); 
+	if err == nil {
+		log.Printf("✅ kubectl exists - will use it for diagnostics\n")
+	} else {
+		log.Printf("❌ Could not find kubectl, will try to use oc instead, error: %s\n", err)
+		kubeCommand := "oc"
+		cmd = exec.Command(kubeCommand)
+		err = cmd.Run(); 
+		if err == nil {
+			log.Printf("✅ oc exists - will use it for diagnostics\n")
+		} else {
+			log.Fatalf("❌ Could not find both kubectl and oc, will stop running diagnostics, error: %s", err)
+		}
+	}
+	return kubeCommand
 }


### PR DESCRIPTION
Signed-off-by: jackyalbo <jalbo@redhat.com>

### Explain the changes
1.  We have issue with using kubectl in mustgather - will be using kubectl if we have it in diagnostics, otherwise oc.
2.  If both don't exist we will fail the diagnostic.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2026342

### Testing Instructions:
1. 
