### PR TITLE
Separate resource validations to a different package

### DIFF
--- a/pkg/admission/test/unit/admission_unit_test.go
+++ b/pkg/admission/test/unit/admission_unit_test.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
-	"github.com/noobaa/noobaa-operator/v5/pkg/backingstore"
-	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bundle"
-	"github.com/noobaa/noobaa-operator/v5/pkg/namespacestore"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -43,7 +41,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 							},
 						},
 					}
-					err = backingstore.ValidateBSEmptySecretName(*bs)
+					err = validations.ValidateBSEmptySecretName(*bs)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Failed creating the Backingstore, please provide secret name"))
 				})
@@ -58,7 +56,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 							},
 						},
 					}
-					err = backingstore.ValidateBSEmptySecretName(*bs)
+					err = validations.ValidateBSEmptySecretName(*bs)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -75,7 +73,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateBackingStore(*bs)
+					err = validations.ValidateBackingStore(*bs)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Invalid Backingstore type, please provide a valid Backingstore type"))
 				})
@@ -91,7 +89,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateBackingStore(*bs)
+					err = validations.ValidateBackingStore(*bs)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -104,7 +102,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						Type: nbv1.StoreTypePVPool,
 					}
 
-					err = backingstore.ValidatePvpoolNameLength(*bs)
+					err = validations.ValidatePvpoolNameLength(*bs)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Unsupported BackingStore name length, please provide a name shorter then 43 characters"))
 				})
@@ -115,7 +113,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						Type: nbv1.StoreTypePVPool,
 					}
 
-					err = backingstore.ValidatePvpoolNameLength(*bs)
+					err = validations.ValidatePvpoolNameLength(*bs)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -128,7 +126,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateMinVolumeCount(*bs)
+					err = validations.ValidateMinVolumeCount(*bs)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Unsupported volume count, the minimum supported volume count is 1"))
 
@@ -141,7 +139,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateMinVolumeCount(*bs)
+					err = validations.ValidateMinVolumeCount(*bs)
 					Ω(err).ShouldNot(HaveOccurred())
 
 				})
@@ -155,7 +153,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateMaxVolumeCount(*bs)
+					err = validations.ValidateMaxVolumeCount(*bs)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Unsupported volume count, the maximum supported volume count is 20"))
 
@@ -168,7 +166,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateMaxVolumeCount(*bs)
+					err = validations.ValidateMaxVolumeCount(*bs)
 					Ω(err).ShouldNot(HaveOccurred())
 
 				})
@@ -186,7 +184,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidatePvpoolMinVolSize(*bs)
+					err = validations.ValidatePvpoolMinVolSize(*bs)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Invalid volume size, minimum volume size is 16Gi"))
 				})
@@ -203,7 +201,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidatePvpoolMinVolSize(*bs)
+					err = validations.ValidatePvpoolMinVolSize(*bs)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -222,7 +220,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateSigVersion(bs.Spec.S3Compatible.SignatureVersion)
+					err = validations.ValidateSigVersion(bs.Spec.S3Compatible.SignatureVersion)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Invalid S3 compatible Backingstore signature version, please choose either v2/v4"))
 				})
@@ -239,7 +237,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateSigVersion(bs.Spec.S3Compatible.SignatureVersion)
+					err = validations.ValidateSigVersion(bs.Spec.S3Compatible.SignatureVersion)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -274,7 +272,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidatePvpoolScaleDown(*bs, *updatedBS)
+					err = validations.ValidatePvpoolScaleDown(*bs, *updatedBS)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Scaling down the number of nodes is not currently supported"))
 				})
@@ -294,7 +292,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidatePvpoolScaleDown(*bs, *updatedBS)
+					err = validations.ValidatePvpoolScaleDown(*bs, *updatedBS)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -316,7 +314,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateTargetBucketChange(*bs, *updatedBS)
+					err = validations.ValidateTargetBSBucketChange(*bs, *updatedBS)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Changing a Backingstore target bucket is unsupported"))
 				})
@@ -336,7 +334,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 						},
 					}
 
-					err = backingstore.ValidateTargetBucketChange(*bs, *updatedBS)
+					err = validations.ValidateTargetBSBucketChange(*bs, *updatedBS)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -371,7 +369,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							},
 						},
 					}
-					err = namespacestore.ValidateNSEmptySecretName(*ns)
+					err = validations.ValidateNSEmptySecretName(*ns)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Failed creating the namespacestore, please provide secret name"))
 				})
@@ -386,7 +384,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							},
 						},
 					}
-					err = namespacestore.ValidateNSEmptySecretName(*ns)
+					err = validations.ValidateNSEmptySecretName(*ns)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -402,7 +400,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							},
 						},
 					}
-					err = namespacestore.ValidateNamespaceStore(ns)
+					err = validations.ValidateNamespaceStore(ns)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Invalid Namespacestore type, please provide a valid Namespacestore type"))
 				})
@@ -417,7 +415,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							},
 						},
 					}
-					err = namespacestore.ValidateNamespaceStore(ns)
+					err = validations.ValidateNamespaceStore(ns)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -431,7 +429,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							PvcName: "",
 						},
 					}
-					err = namespacestore.ValidateNsStoreNSFS(ns)
+					err = validations.ValidateNsStoreNSFS(ns)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("PvcName must not be empty"))
 				})
@@ -442,7 +440,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							PvcName: "pvc-name",
 						},
 					}
-					err = namespacestore.ValidateNsStoreNSFS(ns)
+					err = validations.ValidateNsStoreNSFS(ns)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -455,7 +453,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							SubPath: "/path",
 						},
 					}
-					err = namespacestore.ValidateNsStoreNSFS(ns)
+					err = validations.ValidateNsStoreNSFS(ns)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("SubPath /path must be a relative path"))
 				})
@@ -467,7 +465,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							SubPath: "../path",
 						},
 					}
-					err = namespacestore.ValidateNsStoreNSFS(ns)
+					err = validations.ValidateNsStoreNSFS(ns)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("SubPath ../path must not contain '..'"))
 				})
@@ -479,7 +477,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 							SubPath: "valid/sub/path",
 						},
 					}
-					err = namespacestore.ValidateNsStoreNSFS(ns)
+					err = validations.ValidateNsStoreNSFS(ns)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -494,7 +492,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 					}
 					ns.Name = "nsfs-too-long-name-should-fail-after-exceeding-63-characters"
 					mountPath := "/nsfs/" + ns.Name
-					err = namespacestore.ValidateNsStoreNSFS(ns)
+					err = validations.ValidateNsStoreNSFS(ns)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal(fmt.Sprintf("MountPath %v must be no more than 63 characters", mountPath)))
 				})
@@ -507,7 +505,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 						},
 					}
 					ns.Name = "nsfs-not-too-long-name"
-					err = namespacestore.ValidateNsStoreNSFS(ns)
+					err = validations.ValidateNsStoreNSFS(ns)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -542,7 +540,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 						},
 					}
 
-					err = namespacestore.ValidateTargetBucketChange(*ns, *updatedNS)
+					err = validations.ValidateTargetNSBucketChange(*ns, *updatedNS)
 					Ω(err).Should(HaveOccurred())
 					Expect(err.Error()).To(Equal("Changing a NamespaceStore target bucket is unsupported"))
 				})
@@ -562,7 +560,7 @@ var _ = Describe("NamespaceStore admission unit tests", func() {
 						},
 					}
 
-					err = namespacestore.ValidateTargetBucketChange(*ns, *updatedNS)
+					err = validations.ValidateTargetNSBucketChange(*ns, *updatedNS)
 					Ω(err).ShouldNot(HaveOccurred())
 				})
 			})
@@ -597,7 +595,7 @@ var _ = Describe("BucketClass admission unit tests", func() {
 						BackingStores: []string{"bs-name"},
 					}},
 				}
-				err = bucketclass.ValidateTiersNumber(bc.Spec.PlacementPolicy.Tiers)
+				err = validations.ValidateTiersNumber(bc.Spec.PlacementPolicy.Tiers)
 				Ω(err).Should(HaveOccurred())
 				Expect(err.Error()).To(Equal("unsupported number of tiers, bucketclass supports only 1 or 2 tiers"))
 			})
@@ -611,7 +609,7 @@ var _ = Describe("BucketClass admission unit tests", func() {
 						BackingStores: []string{"bs-name"},
 					}},
 				}
-				err = bucketclass.ValidateTiersNumber(bc.Spec.PlacementPolicy.Tiers)
+				err = validations.ValidateTiersNumber(bc.Spec.PlacementPolicy.Tiers)
 				Ω(err).ShouldNot(HaveOccurred())
 			})
 		})
@@ -621,7 +619,7 @@ var _ = Describe("BucketClass admission unit tests", func() {
 					MaxSize:    "2Gi",
 					MaxObjects: "-1",
 				}
-				err = bucketclass.ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
+				err = validations.ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
 				Ω(err).Should(HaveOccurred())
 				Expect(err.Error()).To(Equal("ob \"bc-name\" validation error: invalid maxObjects value. O or any positive number "))
 			})
@@ -630,7 +628,7 @@ var _ = Describe("BucketClass admission unit tests", func() {
 					MaxSize:    "-1Gi",
 					MaxObjects: "10",
 				}
-				err = bucketclass.ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
+				err = validations.ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
 				Ω(err).Should(HaveOccurred())
 				Expect(err.Error()).To(Equal("ob \"bc-name\" validation error: invalid obcMaxSizeValue value: min 1Gi, max 1023Pi, 0 to remove quota"))
 			})
@@ -639,7 +637,7 @@ var _ = Describe("BucketClass admission unit tests", func() {
 					MaxSize:    "20Gi",
 					MaxObjects: "10",
 				}
-				err = bucketclass.ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
+				err = validations.ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
 				Ω(err).ShouldNot(HaveOccurred())
 			})
 		})

--- a/pkg/admission/validate_bucketclass.go
+++ b/pkg/admission/validate_bucketclass.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
-	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 	"github.com/sirupsen/logrus"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,18 +60,18 @@ func (bcv *ResourceValidator) ValidateCreateBC() {
 		return
 	}
 
-	if err := bucketclass.ValidateQuotaConfig(bc.Name, bc.Spec.Quota); err != nil && util.IsValidationError(err) {
+	if err := validations.ValidateQuotaConfig(bc.Name, bc.Spec.Quota); err != nil && util.IsValidationError(err) {
 		bcv.SetValidationResult(false, err.Error())
 		return
 	}
 	if bc.Spec.NamespacePolicy != nil {
-		if err := bucketclass.ValidateNSFSSingleBC(bc); err != nil && util.IsValidationError(err) {
+		if err := validations.ValidateNSFSSingleBC(bc); err != nil && util.IsValidationError(err) {
 			bcv.SetValidationResult(false, err.Error())
 			return
 		}
 	}
 	if bc.Spec.PlacementPolicy != nil {
-		if err := bucketclass.ValidateTiersNumber(bc.Spec.PlacementPolicy.Tiers); err != nil {
+		if err := validations.ValidateTiersNumber(bc.Spec.PlacementPolicy.Tiers); err != nil {
 			bcv.SetValidationResult(false, err.Error())
 			return
 		}

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -13,6 +13,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -363,7 +364,7 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 
 	populate(backStore, secret)
 
-	validationErr := ValidateBackingStore(*backStore)
+	validationErr := validations.ValidateBackingStore(*backStore)
 	if validationErr != nil {
 		log.Fatalf(`❌ %s %s`, validationErr, cmd.UsageString())
 	}

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/sirupsen/logrus"
@@ -331,7 +332,7 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 		"noobaa operator started phase 1/3 - \"Verifying\"",
 	)
 
-	err := ValidateBackingStore(*r.BackingStore)
+	err := validations.ValidateBackingStore(*r.BackingStore)
 	if err != nil {
 		return util.NewPersistentError("BackingStoreValidationError", err.Error())
 	}

--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -11,6 +11,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -327,7 +328,7 @@ func createCommonBucketclass(cmd *cobra.Command, args []string, bucketClassType 
 
 	namespaceStoresArr, backingStoresArr := populate(bucketClass)
 
-	err = ValidateBucketClass(bucketClass)
+	err = validations.ValidateBucketClass(bucketClass)
 	if err != nil {
 		log.Fatalf(`❌ Bucket class validation failed %q`, err)
 	}

--- a/pkg/bucketclass/reconciler.go
+++ b/pkg/bucketclass/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -199,7 +200,7 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 		"noobaa operator started phase 1/2 - \"Verifying\"",
 	)
 
-	err := ValidateBucketClass(r.BucketClass)
+	err := validations.ValidateBucketClass(r.BucketClass)
 	if err != nil {
 		return util.NewPersistentError("ValidationError", err.Error())
 	}
@@ -234,7 +235,7 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 		}
 	}
 	if r.BucketClass.Spec.NamespacePolicy != nil {
-		namespaceStoresArr := GetBucketclassNamespaceStoreArray(r.BucketClass)
+		namespaceStoresArr := validations.GetBucketclassNamespaceStoreArray(r.BucketClass)
 		// check that namespace stores exists and their phase it ready
 		for _, name := range namespaceStoresArr {
 			nsStore := &nbv1.NamespaceStore{

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -277,7 +278,7 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.NSType, popu
 
 	populate(namespaceStore, secret)
 
-	validationErr := ValidateNamespaceStore(namespaceStore)
+	validationErr := validations.ValidateNamespaceStore(namespaceStore)
 	if validationErr != nil {
 		log.Fatalf(`❌ %s %s`, validationErr, cmd.UsageString())
 	}

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -264,7 +265,7 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 		"noobaa operator started phase 1/3 - \"Verifying\"",
 	)
 
-	err := ValidateNamespaceStore(r.NamespaceStore)
+	err := validations.ValidateNamespaceStore(r.NamespaceStore)
 	if err != nil {
 		return util.NewPersistentError("NamespaceStoreValidationError", err.Error())
 	}

--- a/pkg/namespacestore/validation_test.go
+++ b/pkg/namespacestore/validation_test.go
@@ -6,33 +6,40 @@ import (
 	"testing"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// const configuration values for the validation checks
+const (
+	defaultEndPointURI     = "https://127.0.0.1:6443"
+	MaximumMountPathLength = 63
 )
 
 func TestNamespaceStoreNSFS(t *testing.T) {
 
 	//Valid namespacestore
 	defaultNs := getDefaultNSFSNsStore()
-	err := ValidateNamespaceStore(&defaultNs)
+	err := validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Valid namespacestore validation is failed")
 
 	//Pvcname is empty
 	defaultNs = getDefaultNSFSNsStore()
 	defaultNs.Spec.NSFS.PvcName = ""
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertError(t, err, "Validation empty pvcName is failed")
 
 	//SubPath is not relative
 	defaultNs = getDefaultNSFSNsStore()
 	defaultNs.Spec.NSFS.SubPath = "/"
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertError(t, err, "Validation relative subPath %s is failed", defaultNs.Spec.NSFS.SubPath)
 
 	//SubPath contains '..'
 	defaultNs = getDefaultNSFSNsStore()
 	defaultNs.Spec.NSFS.SubPath = "test/../test2"
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertError(t, err, "Validation relative subPath %s is failed", defaultNs.Spec.NSFS.SubPath)
 
 }
@@ -41,31 +48,31 @@ func TestNamespaceStoreS3Compatible(t *testing.T) {
 
 	//Valid namespacestore
 	defaultNs := getDefaultS3CompatibleNsStore()
-	err := ValidateNamespaceStore(&defaultNs)
+	err := validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Valid namespacestore validation is failed")
 
 	//Signature version is empty
 	defaultNs = getDefaultS3CompatibleNsStore()
 	defaultNs.Spec.S3Compatible.SignatureVersion = ""
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Empty sugnature version validation is failed")
 
 	//Valid v2 signature version
 	defaultNs = getDefaultS3CompatibleNsStore()
 	defaultNs.Spec.S3Compatible.SignatureVersion = "v2"
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Valid sugnature version %s validation is failed", defaultNs.Spec.S3Compatible.SignatureVersion)
 
 	//Ivalid signature version
 	defaultNs = getDefaultS3CompatibleNsStore()
 	defaultNs.Spec.S3Compatible.SignatureVersion = "v5"
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertError(t, err, "Invalid sugnature version %s validation is failed", defaultNs.Spec.S3Compatible.SignatureVersion)
 
 	//Empty endPoint
 	defaultNs = getDefaultS3CompatibleNsStore()
 	defaultNs.Spec.S3Compatible.Endpoint = ""
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Empty endPoint validation is failed")
 	AssertEqual(t, defaultEndPointURI, defaultNs.Spec.S3Compatible.Endpoint,
 		"EndPoint has no the default value, %s : %s", defaultNs.Spec.S3Compatible.Endpoint, defaultEndPointURI)
@@ -73,7 +80,7 @@ func TestNamespaceStoreS3Compatible(t *testing.T) {
 	//Invalid endPoint
 	defaultNs = getDefaultS3CompatibleNsStore()
 	defaultNs.Spec.S3Compatible.Endpoint = "hostname:port"
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertError(t, err, "Invalid endPoint %s validation is failed", defaultNs.Spec.S3Compatible.Endpoint)
 
 }
@@ -82,31 +89,31 @@ func TestNamespaceStoreIBMCos(t *testing.T) {
 
 	//Valid namespacestore
 	defaultNs := getDefaultIBMCosNsStore()
-	err := ValidateNamespaceStore(&defaultNs)
+	err := validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Valid namespacestore validation is failed")
 
 	//Signature version is empty
 	defaultNs = getDefaultIBMCosNsStore()
 	defaultNs.Spec.IBMCos.SignatureVersion = ""
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Empty sugnature version validation is failed")
 
 	//Valid v2 signature version
 	defaultNs = getDefaultIBMCosNsStore()
 	defaultNs.Spec.IBMCos.SignatureVersion = "v2"
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Valid sugnature version %s validation is failed", defaultNs.Spec.IBMCos.SignatureVersion)
 
 	//Ivalid signature version
 	defaultNs = getDefaultIBMCosNsStore()
 	defaultNs.Spec.IBMCos.SignatureVersion = "v5"
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertError(t, err, "Invalid sugnature version %s validation is failed", defaultNs.Spec.IBMCos.SignatureVersion)
 
 	//Empty endPoint
 	defaultNs = getDefaultIBMCosNsStore()
 	defaultNs.Spec.IBMCos.Endpoint = ""
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertNotError(t, err, "Empty endPoint validation is failed")
 	AssertEqual(t, defaultEndPointURI, defaultNs.Spec.IBMCos.Endpoint,
 		"EndPoint has no the default value, %s : %s", defaultNs.Spec.IBMCos.Endpoint, defaultEndPointURI)
@@ -114,7 +121,7 @@ func TestNamespaceStoreIBMCos(t *testing.T) {
 	//Invalid endPoint
 	defaultNs = getDefaultIBMCosNsStore()
 	defaultNs.Spec.IBMCos.Endpoint = "hostname:port"
-	err = ValidateNamespaceStore(&defaultNs)
+	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertError(t, err, "Invalid endPoint %s validation is failed", defaultNs.Spec.IBMCos.Endpoint)
 
 }

--- a/pkg/validations/bucketclass_validation.go
+++ b/pkg/validations/bucketclass_validation.go
@@ -1,4 +1,4 @@
-package bucketclass
+package validations
 
 import (
 	"fmt"


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. move all the resource validations to a dedicated package, so it can be used from everywhere in the code without worrying about dependencies errors. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
