### PR TITLE
Fix typo in the admission server cert file name

### DIFF
--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -22,7 +22,7 @@ const (
 	port       = "8080"
 	tlscert    = "/etc/certs/tls.cert"
 	tlskey     = "/etc/certs/tls.key"
-	tlscertolm = "/tmp/k8s-webhook-server/serving-certs/tls.cert"
+	tlscertolm = "/tmp/k8s-webhook-server/serving-certs/tls.crt"
 	tlskeyolm  = "/tmp/k8s-webhook-server/serving-certs/tls.key"
 )
 


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. fixing a typo error in the admission webhook cert file name.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2049029

### Testing Instructions:
1. 
