### PR TITLE
Backport to 5.10: Fix a typo in the admission server cert file

### DIFF
--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -22,7 +22,7 @@ const (
 	port       = "8080"
 	tlscert    = "/etc/certs/tls.cert"
 	tlskey     = "/etc/certs/tls.key"
-	tlscertolm = "/tmp/k8s-webhook-server/serving-certs/tls.cert"
+	tlscertolm = "/tmp/k8s-webhook-server/serving-certs/tls.crt"
 	tlskeyolm  = "/tmp/k8s-webhook-server/serving-certs/tls.key"
 )
 


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>
(cherry picked from commit 5932fb018cffbae06dd59378a411bb8fb5291209)

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
