### PR TITLE
always install operator sdk for x86. no arm build for v0.17.2

### DIFF
--- a/build/install-operator-sdk.sh
+++ b/build/install-operator-sdk.sh
@@ -20,7 +20,7 @@ then
     fi
 fi
 
-PLATFORM="$(uname)"
+PLATFORM="x86_64"
 ARCHITECTURE="$(uname -m)"
 if [ "${PLATFORM}" == "Darwin" ] 
 then 


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. When building on M1 macs, the identified platform is arm64, but for the version of operator-sdk we use (v0.17.2) there is no arm release.
2. x86 build is running fine on M1 macs using the built in translation (Rosetta)  

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
