### PR TITLE
Fixed Tech Debt for AWS STS support

### DIFF
--- a/pkg/admission/test/unit/admission_unit_test.go
+++ b/pkg/admission/test/unit/admission_unit_test.go
@@ -43,7 +43,7 @@ var _ = Describe("BackingStore admission unit tests", func() {
 					}
 					err = validations.ValidateBSEmptySecretName(*bs)
 					Ω(err).Should(HaveOccurred())
-					Expect(err.Error()).To(Equal("Failed creating the Backingstore, please provide secret name"))
+					Expect(err.Error()).To(Equal("Failed creating the Backingstore, please provide a valid ARN or secret name"))
 				})
 				It("Should Allow", func() {
 					bs.Spec = nbv1.BackingStoreSpec{

--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -10,6 +10,7 @@ import (
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 )
 
 // ReconcilePhaseVerifying runs the reconcile verify phase
@@ -129,6 +130,16 @@ func (r *Reconciler) CheckSystemCR() error {
 	err = CheckMongoURL(r.NooBaa)
 	if err != nil {
 		return util.NewPersistentError("InvalidMongoDbURL", fmt.Sprintf(`%s`, err))
+	}
+	// Validate the DefaultBackingStore Spec
+	if r.NooBaa.Spec.DefaultBackingStoreSpec != nil {
+		bs := nbv1.BackingStore{
+			Spec: *r.NooBaa.Spec.DefaultBackingStoreSpec,
+		}
+		err = validations.ValidateBackingStore(bs)
+		if err != nil {
+			return util.NewPersistentError("InvalidDefaultBackingStoreSpec", fmt.Sprintf(`%s`, err))
+		}
 	}
 
 	return nil

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -37,12 +38,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 const (
-	ibmEndpoint = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
-	ibmLocation = "%s-standard"
-	ibmCOSCred  = "ibm-cloud-cos-creds"
+	ibmEndpoint                      = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
+	ibmLocation                      = "%s-standard"
+	ibmCOSCred                       = "ibm-cloud-cos-creds"
+	projectedServiceAccountTokenFile = "/var/run/secrets/openshift/serviceaccount/oidc-token"
 )
 
 type gcpAuthJSON struct {
@@ -603,6 +606,16 @@ func (r *Reconciler) ReconcileDefaultBackingStore() error {
 	}
 	if r.NooBaa.Spec.DefaultBackingStoreSpec != nil {
 		r.DefaultBackingStore.Spec = *r.NooBaa.Spec.DefaultBackingStoreSpec
+		if util.IsSTSClusterBS(r.DefaultBackingStore) {
+			if r.DefaultBackingStore.Spec.AWSS3.TargetBucket == "" {
+				log.Info("No TargetBucket for AWS STS type BackingStore creating one.")
+				r.DefaultBackingStore.Spec.AWSS3.TargetBucket = r.generateBackingStoreTargetName()
+				if err := r.prepareAWSSTSBackingStore(); err != nil {
+					return err
+				}
+			}
+		}
+
 		log.Infof("DefaultBacking store spec %s already exists. skipping ReconcileCloudCredentials", r.DefaultBackingStore.Name)
 	} else if r.CephObjectStoreUser.UID != "" {
 		log.Infof("CephObjectStoreUser %q created. Creating default backing store on ceph objectstore", r.CephObjectStoreUser.Name)
@@ -717,6 +730,52 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 	r.DefaultBackingStore.Spec.AWSS3.Secret.Name = cloudCredsSecret.Name
 	r.DefaultBackingStore.Spec.AWSS3.Secret.Namespace = cloudCredsSecret.Namespace
 	r.DefaultBackingStore.Spec.AWSS3.Region = region
+	return nil
+}
+
+func (r *Reconciler) prepareAWSSTSBackingStore() error {
+	region, err := util.GetAWSRegion()
+	if err != nil {
+		r.Recorder.Eventf(r.NooBaa, corev1.EventTypeWarning, "DefaultBackingStoreFailure",
+			"Failed to get AWSRegion. using	 us-east-1 as the default region. %q", err)
+		region = "us-east-1"
+	}
+	r.Logger.Infof("identified aws region %s", region)
+	sess, err := session.NewSession(&aws.Config{
+		Region: &region,
+	})
+	if err != nil {
+		return err
+	}
+	bytes, err := ioutil.ReadFile(projectedServiceAccountTokenFile)
+	if err != nil {
+		r.Logger.Errorf("Failed to read file %q: %v", projectedServiceAccountTokenFile, err)
+		return err
+	}
+	webIdentitytoken := string(bytes)
+	svc := sts.New(sess)
+	webIdentityOutput, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          r.DefaultBackingStore.Spec.AWSS3.AWSSTSRoleARN,
+		RoleSessionName:  &r.AWSSTSRoleSessionName,
+		WebIdentityToken: &webIdentitytoken,
+	})
+	if err != nil {
+		r.Logger.Errorf("Unable to assume role for ARN %q : %v", *r.NooBaa.Spec.DefaultBackingStoreSpec.AWSS3.AWSSTSRoleARN, err)
+		return err
+	}
+
+	s3Config := &aws.Config{
+		Credentials: credentials.NewStaticCredentials(
+			*webIdentityOutput.Credentials.AccessKeyId,
+			*webIdentityOutput.Credentials.SecretAccessKey,
+			*webIdentityOutput.Credentials.SessionToken,
+		),
+		Region: &region,
+	}
+	bucketName := r.DefaultBackingStore.Spec.AWSS3.TargetBucket
+	if err := r.createS3BucketForBackingStore(s3Config, bucketName); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -60,6 +60,7 @@ func CmdCreate() *cobra.Command {
 	cmd.Flags().String("db-resources", "", "DB resources JSON")
 	cmd.Flags().String("endpoint-resources", "", "Endpoint resources JSON")
 	cmd.Flags().Bool("use-obc-cleanup-policy", false, "Create NooBaa system with obc cleanup policy")
+	cmd.Flags().String("default-backingstore-spec", "", "Create Noobaa System with DefaultBackingStore Spec")
 	return cmd
 }
 
@@ -220,6 +221,8 @@ func RunCreate(cmd *cobra.Command, args []string) {
 	dbResourcesJSON, _ := cmd.Flags().GetString("db-resources")
 	endpointResourcesJSON, _ := cmd.Flags().GetString("endpoint-resources")
 	useOBCCleanupPolicy, _ := cmd.Flags().GetBool("use-obc-cleanup-policy")
+	defaultBackingStoreSpecJSON, _ := cmd.Flags().GetString("default-backingstore-spec")
+
 	if useOBCCleanupPolicy {
 		sys.Spec.CleanupPolicy.Confirmation = nbv1.DeleteOBCConfirmation
 	}
@@ -237,6 +240,10 @@ func RunCreate(cmd *cobra.Command, args []string) {
 			}
 		}
 		util.Panic(json.Unmarshal([]byte(endpointResourcesJSON), &sys.Spec.Endpoints.Resources))
+	}
+	if defaultBackingStoreSpecJSON != "" {
+		util.Panic(json.Unmarshal([]byte(defaultBackingStoreSpecJSON), &sys.Spec.DefaultBackingStoreSpec))
+
 	}
 
 	err := CheckMongoURL(sys)

--- a/pkg/validations/backingstore_validations.go
+++ b/pkg/validations/backingstore_validations.go
@@ -54,8 +54,8 @@ func ValidateBSEmptySecretName(bs nbv1.BackingStore) error {
 	switch bs.Spec.Type {
 	case nbv1.StoreTypeAWSS3:
 		if len(bs.Spec.AWSS3.Secret.Name) == 0 {
-			return util.ValidationError{
-				Msg: "Failed creating the Backingstore, please provide secret name",
+			if err := ValidateAWSSTSARN(bs); err != nil {
+				return err
 			}
 		}
 	case nbv1.StoreTypeS3Compatible:
@@ -87,6 +87,18 @@ func ValidateBSEmptySecretName(bs nbv1.BackingStore) error {
 	default:
 		return util.ValidationError{
 			Msg: "Invalid Backingstore type, please provide a valid Backingstore type",
+		}
+	}
+	return nil
+}
+
+// ValidateAWSSTSARN validates the existence of the AWS STS ARN string
+func ValidateAWSSTSARN(bs nbv1.BackingStore) error {
+	if bs.Spec.AWSS3 != nil {
+		if bs.Spec.AWSS3.AWSSTSRoleARN == nil {
+			return util.ValidationError{
+				Msg: "Failed creating the Backingstore, please provide a valid ARN or secret name",
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
### Explain the changes
This change fixes the Tech Debt introduced by AWS STS 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2041891

### Issues: Fixed 2041891
1.Validations for  DefaultBackingStore under Noobaa Spec. 
2. If TargetBucket is not supplied as part of Noobaa Spec, operator needs to create it before creating the backing store.
3. Validations to check for TargetBucket in DefaultBackingStore under Noobaa Spec.
4. CLI options to create AWS STS based default backing store
Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>
### Testing Instructions:
1. Use noobaa cli to deploy a AWS STS default backingstore
2. Example : nb system create  --default-backingstore-spec="{\"type\": \"aws-s3\", \"awsS3\": {\"awsSTSRoleARN\": \"arn:aws:iam::261532230807:role/kmajumder_noobaa_sts\", \"region\": \"ap-south-1\",\"targetBucket\":\"nb-target-bucket-1\"}}"
