### PR TITLE
Support PostgresDB config override from NooBaa CR

### DIFF
--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -929,6 +929,10 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              dbConf:
+                description: DBConf (optional) overrides the default postgresql db
+                  config
+                type: string
               dbImage:
                 description: DBImage (optional) overrides the default image for the
                   db container

--- a/doc/noobaa-crd.md
+++ b/doc/noobaa-crd.md
@@ -219,3 +219,29 @@ The operator will detect deletion of a system CR, and will followup by deleting 
 This is done by connecting owner references and letting Garbage Collection do the rest as described here:
 
 https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/
+
+# Database Configuration
+
+NooBaa allows database configuration via `dbConf` field under `spec` in the NooBaa CR. This field accepts string which can contain custom database configuration.
+
+## Example
+Following example will change PostgreSQL database `max_connections` to 1000 (default being 600).
+
+```yaml
+apiVersion: noobaa.io/v1alpha1
+kind: NooBaa
+metadata:
+  name: noobaa
+  namespace: noobaa
+spec:
+  image: noobaa/noobaa-core:5.9.0
+  dbImage: centos/postgresql-12-centos7
+  dbType: postgres
+  dbConf: |+
+    max_connections = 1000
+```
+
+## Notes
+1. `dbConf` field will have no effect if `dbType` is not "postgres".
+2. `dbConf` configuration is not validated.
+3. NooBaa uses `ConfigMap` to pass database configuration to the databases. Althought the ConfigMap is editable, it should not and cannot be used to pass custom database overrides. The reason being that NooBaa operator, as part of its reconcile process will overwrite the ConfigMap to the default values.

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -81,6 +81,10 @@ type NooBaaSpec struct {
 	// +optional
 	DBImage *string `json:"dbImage,omitempty"`
 
+	// DBConf (optional) overrides the default postgresql db config
+	// +optional
+	DBConf *string `json:"dbConf,omitempty"`
+
 	// DBType (optional) overrides the default type image for the db container
 	// +optional
 	// +kubebuilder:validation:Enum=mongodb;postgres

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -1040,6 +1040,11 @@ func (in *NooBaaSpec) DeepCopyInto(out *NooBaaSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DBConf != nil {
+		in, out := &in.DBConf, &out.DBConf
+		*out = new(string)
+		**out = **in
+	}
 	if in.CoreResources != nil {
 		in, out := &in.CoreResources, &out.CoreResources
 		*out = new(corev1.ResourceRequirements)

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1217,7 +1217,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "1a69fb4b66bd89d1073e4d1659a91c05e2e7f9acacfdd0c941c9a8a460dc0912"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "85f16eb011f71179da009e729a7e32ad8a886a092cc896d2869edd30c358ad97"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2150,6 +2150,10 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              dbConf:
+                description: DBConf (optional) overrides the default postgresql db
+                  config
+                type: string
               dbImage:
                 description: DBImage (optional) overrides the default image for the
                   db container

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -853,6 +853,15 @@ func (r *Reconciler) ReconcileDBConfigMap(cm *corev1.ConfigMap, desiredFunc func
 func (r *Reconciler) SetDesiredPostgresDBConf() error {
 	dbConfigYaml := util.KubeObject(bundle.File_deploy_internal_configmap_postgres_db_yaml).(*corev1.ConfigMap)
 	r.PostgresDBConf.Data = dbConfigYaml.Data
+
+	overrideField := "noobaa-postgres.conf"
+	operator := r.NooBaa
+	if operator.Spec.DBConf != nil {
+		// If the user has specified a custom "dbConf" in the NooBaa CR then proceed to append that configuration
+		// to the pre-defined configuration
+		r.PostgresDBConf.Data[overrideField] = dbConfigYaml.Data[overrideField] + "\n" + *operator.Spec.DBConf
+	}
+
 	return nil
 }
 

--- a/pkg/validations/backingstore_validations.go
+++ b/pkg/validations/backingstore_validations.go
@@ -11,9 +11,9 @@ import (
 
 // const configuration values for the validation checks
 const (
-	MinimumVolumeSize       = 16 * 1024 * 1024 * 1024 // 16Gi
-	MaximumPvpoolNameLength = 43
-	MaximumVolumeCount      = 20
+	MinimumVolumeSize       int64 = 16 * 1024 * 1024 * 1024 // 16Gi
+	MaximumPvpoolNameLength       = 43
+	MaximumVolumeCount            = 20
 )
 
 // ValidateBackingStore validates create validations on resource Backinstore

--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -66,6 +66,7 @@ function post_install_tests {
     account_cycle
     check_deletes
     delete_replication_files
+    check_pgdb_config_override
 }
 
 function main {


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
- This PR allows users to provide postgresql database overrides via NooBaa CR. To achieve so, a new field in the NooBaa CRD had to be added.

### Issues: Fixed #xxx
This PR potentially fixes #793

### Testing Instructions:
1. Deploy operator and operator-catalogue image generated from this PR in a Kubernetes cluster.
2. Run `kubectl edit noobaas.noobaa.io noobaa -n <namespace>`
3. Under `spec` add the following (or any postgresql config):

    ```yaml
    ...
    dbConf: |
      max_connections = 600
    ...
    ```
4. Save the changes
5. Check the db config map to confirm the overrides were indeed applied by running `kubectl get cm noobaa-postgres-config -n <namespace> -o=go-template='{{index .data "noobaa-postgres.conf"}}'`

### Notes For Reviewers
- https://github.com/noobaa/noobaa-operator/issues/793#issuecomment-1033745079 by @dannyzaken mentions this particular approach.
- https://github.com/noobaa/noobaa-operator/issues/793#issuecomment-1033745079 also points out a concern associated with this approach, the concern being: "Will postgresql handle duplicate keys appropriately?". The PR relies on the assumption that it will, following were the reasons to believe so:
    - https://www.postgresql.org/message-id/4F69EB52.7070606@mr-paradox.net thread, where the database users have been relying on this for a while.
    - `postgres.conf`'s `include` directives doesn't appear to be removing duplicate keys: https://github.com/postgres/postgres/blob/master/src/backend/utils/misc/guc-file.l#L735
- PR changes the NooBaa CRD

### Limitations/Caveats
1. Any config passed to `dbConf` is appended to config map without any validation or checks.
2. The field is respected only if the database type is `postgres`, the name of the field doesn't conveys the same.
3. "noobaa-postgres.conf" name is hardcoded and will be the entry in the data that will be modified.
4. The field name `dbConf` could have been `pgDBConf`.