### PR TITLE
Add Regenerate S3 Credentials for OBC to the CLI

### DIFF
--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -27,6 +27,7 @@ func Cmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		CmdCreate(),
+		CmdRegenerate(),
 		CmdDelete(),
 		CmdStatus(),
 		CmdList(),
@@ -55,6 +56,16 @@ func CmdCreate() *cobra.Command {
 		"Set quota max objects quantity config to requested bucket")
 	cmd.Flags().String("max-size", "",
 		"Set quota max size config to requested bucket")
+	return cmd
+}
+
+// CmdRegenerate returns a CLI command
+func CmdRegenerate() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "regenerate <bucket-claim-name>",
+		Short: "Regenerate OBC S3 Credentials",
+		Run:   RunRegenerate,
+	}
 	return cmd
 }
 
@@ -192,6 +203,66 @@ func RunCreate(cmd *cobra.Command, args []string) {
 		log.Printf("")
 		RunStatus(cmd, args)
 	}
+}
+
+// RunRegenerate runs a CLI command
+func RunRegenerate(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+
+	if len(args) != 1 || args[0] == "" {
+		log.Fatalf(`❌ Missing expected arguments: <bucket-claim-name> %s`, cmd.UsageString())
+	}
+
+	var decision string
+	log.Printf("You are about to regenerate an OBC's security credentials.")
+	log.Printf("This will invalidate all connections between S3 clients and NooBaa which are connected using the current credentials.")
+	log.Printf("are you sure? y/n")
+	
+	for {
+		fmt.Scanln(&decision)
+		if decision == "y" {
+			break
+		} else if decision == "n" {
+			return 
+		}
+	}
+
+	appNamespace, _ := cmd.Flags().GetString("app-namespace")
+	if appNamespace == "" {
+		appNamespace = options.Namespace
+	}
+
+	name :=  args[0]
+
+	obc := util.KubeObject(bundle.File_deploy_obc_objectbucket_v1alpha1_objectbucketclaim_cr_yaml).(*nbv1.ObjectBucketClaim)
+	ob := util.KubeObject(bundle.File_deploy_obc_objectbucket_v1alpha1_objectbucket_cr_yaml).(*nbv1.ObjectBucket)
+	obc.Name = name
+	obc.Namespace = appNamespace
+
+	if !util.KubeCheck(obc) {
+		log.Fatalf(`❌ Could not find OBC %q in namespace %q`,
+			obc.Name, obc.Namespace)
+	}
+
+	if obc.Spec.ObjectBucketName != "" {
+		ob.Name = obc.Spec.ObjectBucketName
+	} else {
+		ob.Name = fmt.Sprintf("obc-%s-%s", appNamespace, name)
+	}
+
+	if !util.KubeCheck(ob){
+		log.Fatalf(`❌ Could not find OB %q`, ob.Name)
+	}
+
+	accountName := ob.Spec.AdditionalState["account"]
+
+	err := GenerateAccountKeys(name, accountName)
+	if err != nil {
+		log.Fatalf(`❌ Could not regenerate credentials for %q: %v`, name, err)
+	}
+
+	RunStatus(cmd, args)
+	
 }
 
 // RunDelete runs a CLI command
@@ -434,4 +505,60 @@ func CheckPhase(obc *nbv1.ObjectBucketClaim) {
 	default:
 		log.Printf("⏳ OBC %q Phase is %q", obc.Name, obc.Status.Phase)
 	}
+}
+
+// GenerateAccountKeys regenerate noobaa OBC account S3 keys
+func GenerateAccountKeys(name string, accountName string) error {
+	log := util.Logger()
+
+	if accountName == "" {
+		log.Fatalf(`❌  account name cannot be empty.\n`)
+	}
+
+	var accessKeys nb.S3AccessKeys
+
+	sysClient, err := system.Connect(true)
+	if err != nil {
+		return err
+	}
+
+	// Checking that we can find the secret before we are calling the RPC to change the credentials.
+	secret := util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret)
+	secret.Namespace = options.Namespace
+	secret.Name = name
+	if !util.KubeCheckQuiet(secret) {
+		log.Fatalf(`❌  Could not find secret: %s, will not regenerate keys.`, secret.Name)
+	}
+
+	err = sysClient.NBClient.GenerateAccountKeysAPI(nb.GenerateAccountKeysParams{
+		Email:	accountName,
+	})
+	if err != nil {
+		return err
+	}
+
+	// GenerateAccountKeysAPI have no replay so we need to read the account in order to get the new credentials
+	accountInfo, err := sysClient.NBClient.ReadAccountAPI(nb.ReadAccountParams{
+		Email: accountName,
+	})
+	if err != nil {
+		return err
+	}
+ 
+	accessKeys = accountInfo.AccessKeys[0]
+
+	secret.StringData = map[string]string{}
+	secret.StringData["AWS_ACCESS_KEY_ID"] = accessKeys.AccessKey
+	secret.StringData["AWS_SECRET_ACCESS_KEY"] = accessKeys.SecretKey
+
+	//If we will not be able to update the secret we will print the credentials as they allready been changed by the RPC
+	if !util.KubeUpdate(secret) {
+		log.Printf(`❌  Please write the new credentials for OBC %s:`, name)
+		fmt.Printf("\nAWS_ACCESS_KEY_ID     : %s\n", accessKeys.AccessKey)
+		fmt.Printf("AWS_SECRET_ACCESS_KEY : %s\n\n", accessKeys.SecretKey)
+		log.Fatalf(`❌  Failed to update the secret %s with the new accessKeys`, secret.Name)
+	}
+
+	log.Printf("✅ Successfully reganerate s3 credentials for the OBC %q", name)
+	return nil
 }


### PR DESCRIPTION
### Explain the changes
- Add Regenerate S3 Credentials for OBC to the CLI
- Fixed the RPC call for list accounts

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Testing Instructions:
1.  Regenerate OBC credentials
2. See that s3 ops are working with the new credentials
