### PR TITLE
Adding CLI flags is for creating nsfs account

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1091,7 +1091,29 @@ func IsValidS3BucketName(name string) bool {
 	return validBucketNameRegex.MatchString(name)
 }
 
-// GetFlagStringOrPrompt returns flag value but if empty will promtp to read from stdin
+// GetFlagIntOrPrompt returns flag value but if empty will prompt to read from stdin
+func GetFlagIntOrPrompt(cmd *cobra.Command, flag string) int {
+	val, _ := cmd.Flags().GetInt(flag)
+	if val != -1 {
+		return val
+	}
+	fmt.Printf("Enter %s: ", flag)
+	_, err := fmt.Scan(&val)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "expected integer") {
+			log.Fatalf(`❌ The flag %s must be an integer`, flag)
+		}
+	}
+
+	Panic(err)
+	if val == -1 {
+		log.Fatalf(`❌ Missing %s %s`, flag, cmd.UsageString())
+	}
+	return val
+}
+
+// GetFlagStringOrPrompt returns flag value but if empty will prompt to read from stdin
 func GetFlagStringOrPrompt(cmd *cobra.Command, flag string) string {
 	str, _ := cmd.Flags().GetString(flag)
 	if str != "" {


### PR DESCRIPTION
### Explain the changes

1.  Adding CLI flags is for creating nsfs account
2. Adding `uid`,`gid`,`new_buckets_path` and, `nsfs_only` flags to change the defaults.
3. Add GetFlaIntOrPrompt function to util that checks if the flag is -1 and if it is getting the input from stdin

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2047250

### Testing Instructions:
1. create an account via the CLI using those flags and see that it is an nsfs account
