### PR TITLE
Increase postgres max connections

### DIFF
--- a/deploy/internal/configmap-postgres-db.yaml
+++ b/deploy/internal/configmap-postgres-db.yaml
@@ -11,7 +11,7 @@ data:
     huge_pages = off
 
     # postgres tuning
-    max_connections = 300
+    max_connections = 600
     shared_buffers = 1GB
     effective_cache_size = 3GB
     maintenance_work_mem = 256MB

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3112,7 +3112,7 @@ metadata:
 data: {}
 `
 
-const Sha256_deploy_internal_configmap_postgres_db_yaml = "d35c0d8efb46f8ff6a5be4ca66a4e462cff69b60c6fa9e315fb61308e6e84215"
+const Sha256_deploy_internal_configmap_postgres_db_yaml = "afe8a865abf2b033229df9dcea392abc1cb27df965d5ff0181f6d931504dce4e"
 
 const File_deploy_internal_configmap_postgres_db_yaml = `apiVersion: v1
 kind: ConfigMap
@@ -3127,7 +3127,7 @@ data:
     huge_pages = off
 
     # postgres tuning
-    max_connections = 300
+    max_connections = 600
     shared_buffers = 1GB
     effective_cache_size = 3GB
     maintenance_work_mem = 256MB


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Increased number of max_connections due to 'too many clients' and similar error messages received by Postgres.
Notice: By merging this PR the bottleneck will be increased to 600 connections, https://github.com/noobaa/noobaa-operator/pull/854 should be merged as well.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
