### PR TITLE
Fix noobaaaccount to be able to get also namespacestore as a resource

### DIFF
--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -586,6 +586,8 @@ function account_cycle {
     account_regenerate_keys "operator@noobaa.io"
     # testing account reset password
     account_reset_password "admin@noobaa.io"
+    # testing nsfs accounts
+    account_nsfs_cycle
     echo_time "✅  noobaa account cycle is done"
 }
 
@@ -648,6 +650,20 @@ function get_admin_password {
         fi
     done < <(yes | test_noobaa status)
     echo ${password}
+}
+
+function account_nsfs_cycle {
+    local default_resource= "fs1"
+    # Creating namespacestore to use by the account 
+    test_noobaa namespacestore create nsfs ${default_resource} --pvc-name='nsfs-vol' --fs-backend='GPFS'
+    # Testing that we can create account using namespacestore
+    test_noobaa account create fsaccount1 --full_permission --default_resource ${default_resource} --nsfs_account_config --uid 123 --gid 456
+    # should fail if the default_resource does not exists
+    test_noobaa should_fail account create fsaccount2 --full_permission --default_resource not_exists --nsfs_account_config --uid 123 --gid 456
+    # should fail if the uid is not a number   
+    test_noobaa should_fail account create fsaccount3 --full_permission --default_resource ${default_resource} --nsfs_account_config --uid fail --gid 456
+    # should fail if the gid is not a number
+    test_noobaa should_fail account create fsaccount4 --full_permission --default_resource ${default_resource} --nsfs_account_config --uid 123 --gid fail
 }
 
 function delete_backingstore_path {


### PR DESCRIPTION
### Explain the changes
- Fix noobaaaccount CLI to be able to get also namespacestore as a resource

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2047250

### Testing Instructions:
1. create nsfs namespacestore
```
$ noobaa namespacestore create nsfs fs1 --pvc-name=‘nsfs-vol’ --fs-backend=‘GPFS’
...
INFO[0003] :white_check_mark: NamespaceStore “fs1” Phase is Ready
# NamespaceStore spec:
nsfs:
  fsBackend: GPFS
  pvcName: nsfs-vol
  subPath: “”
type: nsfs

```
2. create nsfs account and see that it is possible to use that  nsfs namespacestore
```
$ noobaa account create --default_resource fs1 --nsfs_account_config --nsfs_only --full_permission --uid 342 --gid 987 testaccount2
...
INFO[0007] :white_check_mark: NooBaaAccount “testaccount2” Phase is Ready
# NooBaaAccount spec:
allow_bucket_creation: true
allowed_buckets:
  full_permission: true
  permission_list: []
default_resource: fs1
nsfs_account_config:
  gid: 987
  new_buckets_path: /
  nsfs_only: true
  uid: 342
INFO[0007] :white_check_mark: Exists: Secret “noobaa-account-testaccount2"
Connection info:
  AWS_ACCESS_KEY_ID      :  **************
  AWS_SECRET_ACCESS_KEY  : **************
```

- [x] Tests added