### PR TITLE
Add insecureEdgeTerminationPolicy to the route-s3.yaml

### DIFF
--- a/deploy/internal/route-s3.yaml
+++ b/deploy/internal/route-s3.yaml
@@ -8,6 +8,7 @@ spec:
   port:
     targetPort: s3-https
   tls:
+    insecureEdgeTerminationPolicy: Allow
     termination: reencrypt
   to:
     kind: Service

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3669,7 +3669,7 @@ spec:
   wildcardPolicy: None
 `
 
-const Sha256_deploy_internal_route_s3_yaml = "e5d832cf3912c648ab4b799ded80a70eaec9fc13d6181726d934af99f71a6686"
+const Sha256_deploy_internal_route_s3_yaml = "16050267fd5cb0a34ff7b4d849a601d2583da1a11394a94f38c4f066c1613f34"
 
 const File_deploy_internal_route_s3_yaml = `apiVersion: route.openshift.io/v1
 kind: Route
@@ -3681,6 +3681,7 @@ spec:
   port:
     targetPort: s3-https
   tls:
+    insecureEdgeTerminationPolicy: Allow
     termination: reencrypt
   to:
     kind: Service


### PR DESCRIPTION
### Explain the changes
- Add insecureEdgeTerminationPolicy to the route-s3.yaml

https://docs.openshift.com/container-platform/4.9/rest_api/network_apis/route-route-openshift-io-v1.html

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2063691

### Testing Instructions:
1. on an openshift cluster path the route and see that it is not getting reconciled 
```
oc patch route s3 -n openshift-storage --type merge -p '{"spec":{"tls":{"insecureEdgeTerminationPolicy":"Redirect","termination":"reencrypt"}}}'
```
