### PR TITLE
Multi Namespace BucketClass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,3 +230,23 @@ test-admission: vendor
 	ginkgo -v pkg/admission/test/integ
 	@echo "✅ test-admission"
 .PHONY: test-admission
+
+test-bucketclass: vendor
+	ginkgo -v pkg/bucketclass pkg/controller/bucketclass
+	@echo "✅ test-bucketclass"
+.PHONY: test-bucketclass
+
+test-obc: vendor
+	ginkgo -v pkg/obc
+	@echo "✅ test-obc"
+.PHONY: test-obc
+
+test-operator: vendor
+	ginkgo -v pkg/operator
+	@echo "✅ test-operator"
+.PHONY: test-operator
+
+test-util: vendor
+	ginkgo -v pkg/util
+	@echo "✅ test-util"
+.PHONY: test-util

--- a/doc/bucket-class-crd.md
+++ b/doc/bucket-class-crd.md
@@ -296,3 +296,25 @@ spec:
       resource: azure-blob-ns
   replicationPolicy: [{ "rule_id": "rule-1", "destination_bucket": "first.bucket", "filter": {"prefix": "ba"}}]
 ```
+
+BucketClass in namespace other than NooBaa System namespace, here `<TARGET-NOOBAA-SYSTEM-NAMESPACE>` is the namespace where NooBaa system is deployed:
+
+```shell
+TODO
+```
+
+```yaml
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  labels:
+    noobaa-operator: <TARGET-NOOBAA-SYSTEM-NAMESPACE>
+    app: noobaa
+  name: bc
+  namespace: noobaa
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - noobaa-test-backing-store
+```

--- a/doc/obc-provisioner.md
+++ b/doc/obc-provisioner.md
@@ -57,7 +57,7 @@ spec:
 
 # OBC with specific BucketClass
 
-Applications that require a bucket from a specific BucketClass can create an OBC with the default StorageClass, but override the BucketClass specifically for that claim using the `spec.additionalConfig.bucketclass` property.
+Applications that require a bucket from a specific BucketClass can create an OBC with the default StorageClass, but override the BucketClass specifically for that claim using the `spec.additionalConfig.bucketclass` property. The BucketClass can exist either in the same namespace as that of OBC or it can exist in NooBaa system namespace. In case of a conflict, BucketClass that exists in the OBC namespace will take priority over the BucketClass in NooBaa system.
 
 Example:
 

--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,7 +28,7 @@ const (
 
 // RunAdmissionServer starts the admission https server
 func RunAdmissionServer() {
-	namespace, _ := util.GetWatchNamespace()
+	namespace := options.Namespace
 	log := logrus.WithField("admission server", namespace)
 
 	_, ok := os.LookupEnv("NOOBAA_CLI_DEPLOYMENT")

--- a/pkg/admission/validate_bucketclass.go
+++ b/pkg/admission/validate_bucketclass.go
@@ -38,6 +38,8 @@ func (bcv *ResourceValidator) ValidateBucketClass() admissionv1.AdmissionReview 
 	switch bcv.arRequest.Request.Operation {
 	case admissionv1.Create:
 		bcv.ValidateCreateBC()
+	case admissionv1.Update:
+		bcv.ValidateUpdateBC()
 	default:
 		bcv.Logger.Error("Failed to identify bucketclass operation type")
 	}
@@ -75,5 +77,16 @@ func (bcv *ResourceValidator) ValidateCreateBC() {
 			bcv.SetValidationResult(false, err.Error())
 			return
 		}
+	}
+}
+
+// ValidateUpdateBC runs all the validations tests for UPDATE operations
+func (bcv *ResourceValidator) ValidateUpdateBC() {
+	oldBC := bcv.DeserializeBC(bcv.arRequest.Request.OldObject.Raw)
+	newBC := bcv.DeserializeBC(bcv.arRequest.Request.Object.Raw)
+
+	if err := validations.ValidateImmutLabelChange(newBC, oldBC, map[string]struct{}{"noobaa-operator": {}}); err != nil {
+		bcv.SetValidationResult(false, err.Error())
+		return
 	}
 }

--- a/pkg/admission/validator.go
+++ b/pkg/admission/validator.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/sirupsen/logrus"
 	admissionv1 "k8s.io/api/admission/v1"
 )
@@ -23,7 +23,7 @@ type ServerHandler struct {
 }
 
 func (gs *ServerHandler) serve(w http.ResponseWriter, r *http.Request) {
-	namespace, _ := util.GetWatchNamespace()
+	namespace := options.Namespace
 	log := logrus.WithField("admission validator", namespace)
 	var arResponse admissionv1.AdmissionReview
 	var body []byte

--- a/pkg/bucketclass/reconciler.go
+++ b/pkg/bucketclass/reconciler.go
@@ -61,7 +61,7 @@ func NewReconciler(
 
 	// Set Namespace
 	r.BucketClass.Namespace = r.Request.Namespace
-	r.NooBaa.Namespace = r.Request.Namespace
+	r.NooBaa.Namespace = options.Namespace
 
 	// Set Names
 	r.BucketClass.Name = r.Request.Name
@@ -242,7 +242,7 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 				TypeMeta: metav1.TypeMeta{Kind: "NamespaceStore"},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
-					Namespace: options.Namespace,
+					Namespace: r.NooBaa.Namespace,
 				},
 			}
 			if !util.KubeCheck(nsStore) {

--- a/pkg/controller/add_bucketclass.go
+++ b/pkg/controller/add_bucketclass.go
@@ -5,6 +5,7 @@ import (
 )
 
 func init() {
-	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, bucketclass.Add)
+	// AddToClusterScopedManagerFuncs is a list of functions to create controllers and add them to
+	// cluster scoped manager.
+	AddToClusterScopedManagerFuncs = append(AddToClusterScopedManagerFuncs, bucketclass.Add)
 }

--- a/pkg/controller/backingstore/backingstore_controller.go
+++ b/pkg/controller/backingstore/backingstore_controller.go
@@ -62,8 +62,7 @@ func Add(mgr manager.Manager) error {
 	// Watch for changes on resources to trigger reconcile
 	ownerHandler := &handler.EnqueueRequestForOwner{IsController: true, OwnerType: &nbv1.BackingStore{}}
 
-	err = c.Watch(&source.Kind{Type: &nbv1.BackingStore{}}, &handler.EnqueueRequestForObject{},
-		backingStorePredicate, &logEventsPredicate)
+	err = c.Watch(&source.Kind{Type: &nbv1.BackingStore{}}, &handler.EnqueueRequestForObject{}, backingStorePredicate, &logEventsPredicate)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/bucketclass/bucketclass_controller.go
+++ b/pkg/controller/bucketclass/bucketclass_controller.go
@@ -5,11 +5,13 @@ import (
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -52,34 +54,67 @@ func Add(mgr manager.Manager) error {
 
 	// Watch for changes on resources to trigger reconcile
 	err = c.Watch(&source.Kind{Type: &nbv1.BucketClass{}}, &handler.EnqueueRequestForObject{},
-		bucketClassPredicate, &logEventsPredicate)
+		ignoreUnmatchedProvisioner(options.Namespace), bucketClassPredicate, &logEventsPredicate)
 	if err != nil {
 		return err
 	}
 
 	backingStoreHandler := handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-			return bucketclass.MapBackingstoreToBucketclasses(types.NamespacedName{
-				Name:      obj.GetName(),
-				Namespace: obj.GetNamespace(),
-			})
-		},
+		return bucketclass.MapBackingstoreToBucketclasses(types.NamespacedName{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+		})
+	},
 	)
-	err = c.Watch(&source.Kind{Type: &nbv1.BackingStore{}}, backingStoreHandler, logEventsPredicate)
+	err = c.Watch(&source.Kind{Type: &nbv1.BackingStore{}}, backingStoreHandler,
+		util.IgnoreIfNotInNamespace(options.Namespace), logEventsPredicate)
 	if err != nil {
 		return err
 	}
 
 	namespaceStoreHandler := handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-			return bucketclass.MapNamespacestoreToBucketclasses(types.NamespacedName{
-				Name:      obj.GetName(),
-				Namespace: obj.GetNamespace(),
-			})
-		},
+		return bucketclass.MapNamespacestoreToBucketclasses(types.NamespacedName{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+		})
+	},
 	)
-	err = c.Watch(&source.Kind{Type: &nbv1.NamespaceStore{}}, namespaceStoreHandler, logEventsPredicate)
+	err = c.Watch(&source.Kind{Type: &nbv1.NamespaceStore{}}, namespaceStoreHandler,
+		util.IgnoreIfNotInNamespace(options.Namespace), logEventsPredicate)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func ignoreUnmatchedProvisioner(noobaaOperatorNamespace string) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isObjectForProvisioner(e.Object, noobaaOperatorNamespace)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isObjectForProvisioner(e.Object, noobaaOperatorNamespace)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isObjectForProvisioner(e.ObjectNew, noobaaOperatorNamespace)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isObjectForProvisioner(e.Object, noobaaOperatorNamespace)
+		},
+	}
+}
+
+func isObjectForProvisioner(obj client.Object, noobaaOperatorNamespace string) bool {
+	noobaaOperatorLabel := "noobaa-operator"
+	provisionerLable, ok := obj.GetLabels()[noobaaOperatorLabel]
+	if !ok {
+		// If the object doesn't have the provisioner label, it is only for the provisioner
+		// if it is in the provisioner namespace
+		return obj.GetNamespace() == noobaaOperatorNamespace
+	}
+
+	// If the object has the provisioner label, it is only for the provisioner
+	// if the label value is the provisioner namespace
+	return provisionerLable == noobaaOperatorNamespace
 }

--- a/pkg/controller/bucketclass/bucketclass_suite_test.go
+++ b/pkg/controller/bucketclass/bucketclass_suite_test.go
@@ -1,0 +1,13 @@
+package bucketclass_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBucketclass(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bucketclass Suite")
+}

--- a/pkg/controller/bucketclass/bucketclass_test.go
+++ b/pkg/controller/bucketclass/bucketclass_test.go
@@ -1,0 +1,70 @@
+package bucketclass
+
+import (
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// systemNS is the namespace which is used in the unit tests to describe
+	// noobaa system namespace
+	systemNS = "test"
+)
+
+var _ = Describe("Verify Bucketclass provisioner actions", func() {
+	Context("When bucketclass is in the same namespace as NooBaa system", func() {
+		It("should allow object for the provisioner", func() {
+			obj := &nbv1.BucketClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: systemNS,
+				},
+			}
+
+			Expect(isObjectForProvisioner(obj, systemNS)).To(BeTrue())
+		})
+	})
+
+	Context("When bucketclass is not in the same namespace as NooBaa system", func() {
+		It("should disallow object for the provisioner", func() {
+			obj := &nbv1.BucketClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "random",
+				},
+			}
+
+			Expect(isObjectForProvisioner(obj, systemNS)).To(BeFalse())
+		})
+	})
+
+	Context("When bucketclass is not in the same namespace as NooBaa system: Valid provisioner label", func() {
+		It("should allow object for the provisioner", func() {
+			obj := &nbv1.BucketClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "random",
+					Labels: map[string]string{
+						"noobaa-operator": systemNS,
+					},
+				},
+			}
+
+			Expect(isObjectForProvisioner(obj, systemNS)).To(BeTrue())
+		})
+	})
+
+	Context("When bucketclass is not in the same namespace as NooBaa system: Invalid provisioner label", func() {
+		It("should disallow object for the provisioner", func() {
+			obj := &nbv1.BucketClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "random",
+					Labels: map[string]string{
+						"noobaa-operator": "xyz",
+					},
+				},
+			}
+
+			Expect(isObjectForProvisioner(obj, systemNS)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,12 +7,26 @@ import (
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error
 
-// AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
-	for _, f := range AddToManagerFuncs {
+// AddToClusterScopedManagerFuncs is a list of functions to add all Controllers which
+// need access to a cluster scoped manager
+var AddToClusterScopedManagerFuncs []func(manager.Manager) error
+
+// addToManager takes a manager and a list of functions and adds them to the given manager
+func addToManager(m manager.Manager, funcs []func(manager.Manager) error) error {
+	for _, f := range funcs {
 		if err := f(m); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// AddToManager adds all Controllers to the Manager
+func AddToManager(m manager.Manager) error {
+	return addToManager(m, AddToManagerFuncs)
+}
+
+// AddToClusterScopedManager adds all Controllers which need access to a cluster scoped manager
+func AddToClusterScopedManager(m manager.Manager) error {
+	return addToManager(m, AddToClusterScopedManagerFuncs)
 }

--- a/pkg/controller/ha/ha_controller.go
+++ b/pkg/controller/ha/ha_controller.go
@@ -42,7 +42,7 @@ func deletePodsOnStartup(client client.Client) error {
 		if !nodeIsReady(&node) {
 			pd := hac.PodDeleter{Client: client, NodeName: node.Name}
 			if err := pd.DeletePodsOnNode(); err != nil {
-				return errors.Errorf("failed to delete noobaa pods on the node %v in namespace %v", node.Name, options.Namespace)	
+				return errors.Errorf("failed to delete noobaa pods on the node %v in namespace %v", node.Name, options.Namespace)
 			}
 		}
 	}
@@ -75,7 +75,7 @@ func Add(mgr manager.Manager) error {
 	opts := controller.Options{
 		MaxConcurrentReconciles: 1,
 		Reconciler: reconcile.Func(
-			func(ctx context.Context,req reconcile.Request) (reconcile.Result, error) {
+			func(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 				return hac.NewHAC(
 					req.NamespacedName,
 					mgr.GetClient(),

--- a/pkg/controller/namespacestore/namespacestore_controller.go
+++ b/pkg/controller/namespacestore/namespacestore_controller.go
@@ -60,7 +60,7 @@ func Add(mgr manager.Manager) error {
 
 	secretsHandler := handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
 		return namespacestore.MapSecretToNamespaceStores(types.NamespacedName{
-			Name: obj.GetName(),
+			Name:      obj.GetName(),
 			Namespace: obj.GetNamespace(),
 		})
 	})

--- a/pkg/controller/noobaa/noobaa_controller.go
+++ b/pkg/controller/noobaa/noobaa_controller.go
@@ -104,17 +104,17 @@ func Add(mgr manager.Manager) error {
 	}
 
 	storageClassHandler := handler.EnqueueRequestsFromMapFunc(func(mo client.Object) []reconcile.Request {
-			sc, ok := mo.(*storagev1.StorageClass)
-			if !ok || sc.Provisioner != options.ObjectBucketProvisionerName() {
-				return nil
-			}
-			return []reconcile.Request{{
-				NamespacedName: types.NamespacedName{
-					Name:      options.SystemName,
-					Namespace: options.Namespace,
-				},
-			}}
-		},
+		sc, ok := mo.(*storagev1.StorageClass)
+		if !ok || sc.Provisioner != options.ObjectBucketProvisionerName() {
+			return nil
+		}
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Name:      options.SystemName,
+				Namespace: options.Namespace,
+			},
+		}}
+	},
 	)
 
 	// Watch for StorageClass changes to trigger reconcile and recreate it when deleted

--- a/pkg/obc/obc_suite_test.go
+++ b/pkg/obc/obc_suite_test.go
@@ -1,0 +1,13 @@
+package obc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestObc(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Obc Suite")
+}

--- a/pkg/obc/obc_test.go
+++ b/pkg/obc/obc_test.go
@@ -1,0 +1,161 @@
+package obc
+
+import (
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("OBC referenced BucketClass", func() {
+	Context("When a bucketclass exists in the same namespace that of OBC", func() {
+		It("should return the BucketClass wth namespace to be the same as that of OBC", func() {
+			obcNS := "obc-ns"
+			systemNS := "test"
+
+			obc := &nbv1.ObjectBucketClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: obcNS,
+				},
+				Spec: nbv1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{
+						"bucketclass": "bc1",
+					},
+				},
+			}
+
+			ns, ok := getBucketClass(
+				obc,
+				nil,
+				systemNS,
+				func(o client.Object) bool {
+					return o.GetNamespace() == obcNS
+				},
+			)
+
+			Expect(ok).To(BeTrue())
+			Expect(ns.GetNamespace()).To(Equal(obcNS))
+		})
+	})
+
+	Context("When a bucketclass exists in the system namespace", func() {
+		It("should return the BucketClass's namespace to be the same as that of system", func() {
+			obcNS := "obc-ns"
+			systemNS := "test"
+
+			obc := &nbv1.ObjectBucketClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: obcNS,
+				},
+				Spec: nbv1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{
+						"bucketclass": "bc1",
+					},
+				},
+			}
+
+			bc, ok := getBucketClass(
+				obc,
+				nil,
+				systemNS,
+				func(o client.Object) bool {
+					return o.GetNamespace() == systemNS
+				},
+			)
+
+			Expect(ok).To(BeTrue())
+			Expect(bc.GetNamespace()).To(Equal(systemNS))
+		})
+	})
+
+	Context("When a bucketclass exists in the system namespace as well as OBC namespace", func() {
+		It("should return the BucketClass's namespace to be the same as that of OBC", func() {
+			obcNS := "obc-ns"
+			systemNS := "test"
+
+			obc := &nbv1.ObjectBucketClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: obcNS,
+				},
+				Spec: nbv1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{
+						"bucketclass": "bc1",
+					},
+				},
+			}
+
+			bc, ok := getBucketClass(
+				obc,
+				nil,
+				systemNS,
+				func(o client.Object) bool {
+					return o.GetNamespace() == systemNS || o.GetNamespace() == obcNS
+				},
+			)
+
+			Expect(ok).To(BeTrue())
+			Expect(bc.GetNamespace()).To(Equal(obcNS))
+		})
+	})
+
+	Context("When a bucketclass does not exists in system namespace or OBC namespace", func() {
+		It("should return the BucketClass's namespace to be the same as that of system namespace with \"ok\" set to false", func() {
+			obcNS := "obc-ns"
+			systemNS := "test"
+
+			obc := &nbv1.ObjectBucketClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: obcNS,
+				},
+				Spec: nbv1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{
+						"bucketclass": "bc1",
+					},
+				},
+			}
+
+			bc, ok := getBucketClass(
+				obc,
+				nil,
+				systemNS,
+				func(o client.Object) bool {
+					return false
+				},
+			)
+
+			Expect(ok).To(BeFalse())
+			Expect(bc.GetNamespace()).To(Equal(systemNS))
+		})
+	})
+
+	Context("When a bucketclass is not specified in the OBC", func() {
+		It("should return empty string for namespace and \"exists\" set to false", func() {
+			obcNS := "obc-ns"
+			systemNS := "test"
+
+			obc := &nbv1.ObjectBucketClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: obcNS,
+				},
+				Spec: nbv1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{
+						"bucketclass": "",
+					},
+				},
+			}
+
+			bc, ok := getBucketClass(
+				obc,
+				nil,
+				systemNS,
+				func(o client.Object) bool {
+					return false
+				},
+			)
+
+			Expect(ok).To(BeFalse())
+			Expect(bc.GetNamespace()).To(Equal(""))
+		})
+	})
+})

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -131,10 +131,13 @@ func RunInstall(cmd *cobra.Command, args []string) {
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
 		operatorContainer := c.Deployment.Spec.Template.Spec.Containers[0]
-		operatorContainer.Env = append(operatorContainer.Env, corev1.EnvVar{
-			Name:  "NOOBAA_CLI_DEPLOYMENT",
-			Value: "true",
-		})
+		operatorContainer.Env = append(
+			operatorContainer.Env,
+			corev1.EnvVar{
+				Name:  "NOOBAA_CLI_DEPLOYMENT",
+				Value: "true",
+			},
+		)
 		c.Deployment.Spec.Template.Spec.Containers[0].Env = operatorContainer.Env
 		util.KubeCreateSkipExisting(c.Deployment)
 	}
@@ -296,7 +299,7 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.ClusterRole.Namespace = options.Namespace
 	c.Deployment.Namespace = options.Namespace
 
-	c.ClusterRole.Name = options.SubDomainNS()
+	configureClusterRole(c.ClusterRole)
 	c.ClusterRoleBinding.Name = c.ClusterRole.Name
 	c.ClusterRoleBinding.RoleRef.Name = c.ClusterRole.Name
 	for i := range c.ClusterRoleBinding.Subjects {
@@ -480,4 +483,8 @@ func AdmissionWebhookSetup(c *Conf) {
 		},
 	}
 	c.Deployment.Spec.Template.Spec.Volumes = volumes
+}
+
+func configureClusterRole(cr *rbacv1.ClusterRole) {
+	cr.Name = options.SubDomainNS()
 }

--- a/pkg/operator/operator_suite_test.go
+++ b/pkg/operator/operator_suite_test.go
@@ -1,0 +1,13 @@
+package operator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOperator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Suite")
+}

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -1,0 +1,7 @@
+package operator
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Operator Suite", func() {})

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -137,6 +137,16 @@ func ObjectBucketProvisionerName() string {
 	return SubDomainNS() + "/obc"
 }
 
+// WatchNamespace returns the namespace which NooBaa operator will watch for changes
+func WatchNamespace() string {
+	ns, err := util.GetWatchNamespace()
+	if err == nil {
+		return ns
+	}
+
+	return Namespace
+}
+
 // FlagSet defines the
 var FlagSet = pflag.NewFlagSet("noobaa", pflag.ContinueOnError)
 

--- a/pkg/util/predicates.go
+++ b/pkg/util/predicates.go
@@ -165,3 +165,38 @@ func (p LogEventsPredicate) Generic(e event.GenericEvent) bool {
 	}
 	return true
 }
+
+// IgnoreIfNotInNamespace returns a predicate function that ignores the object
+// if it is not in the given namespace
+func IgnoreIfNotInNamespace(ns string) *predicate.Funcs {
+	return &predicate.Funcs{
+		CreateFunc: func(ce event.CreateEvent) bool {
+			if ce.Object == nil {
+				return false
+			}
+
+			return ce.Object.GetNamespace() == ns
+		},
+		DeleteFunc: func(de event.DeleteEvent) bool {
+			if de.Object == nil {
+				return false
+			}
+
+			return de.Object.GetNamespace() == ns
+		},
+		UpdateFunc: func(ue event.UpdateEvent) bool {
+			if ue.ObjectNew == nil {
+				return false
+			}
+
+			return ue.ObjectNew.GetNamespace() == ns
+		},
+		GenericFunc: func(ge event.GenericEvent) bool {
+			if ge.Object == nil {
+				return false
+			}
+
+			return ge.Object.GetNamespace() == ns
+		},
+	}
+}

--- a/pkg/util/predicates_test.go
+++ b/pkg/util/predicates_test.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = ginkgo.Describe("Predicates Suite", func() {
+	ginkgo.Context("IgnoreIfNotInNamespace", func() {
+		ginkgo.It("should return true if the object is in the same namespace", func() {
+			ns := "test"
+			obj := &nbv1.NooBaa{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+				},
+			}
+
+			funcs := IgnoreIfNotInNamespace(ns)
+
+			gomega.Expect(funcs.CreateFunc(event.CreateEvent{Object: obj})).To(gomega.BeTrue())
+			gomega.Expect(funcs.DeleteFunc(event.DeleteEvent{Object: obj})).To(gomega.BeTrue())
+			gomega.Expect(funcs.UpdateFunc(event.UpdateEvent{ObjectNew: obj})).To(gomega.BeTrue())
+			gomega.Expect(funcs.GenericFunc(event.GenericEvent{Object: obj})).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should return false if the object is in different namespace", func() {
+			ns := "test"
+			obj := &nbv1.NooBaa{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "random",
+				},
+			}
+
+			funcs := IgnoreIfNotInNamespace(ns)
+
+			gomega.Expect(funcs.CreateFunc(event.CreateEvent{Object: obj})).To(gomega.BeFalse())
+			gomega.Expect(funcs.DeleteFunc(event.DeleteEvent{Object: obj})).To(gomega.BeFalse())
+			gomega.Expect(funcs.UpdateFunc(event.UpdateEvent{ObjectNew: obj})).To(gomega.BeFalse())
+			gomega.Expect(funcs.GenericFunc(event.GenericEvent{Object: obj})).To(gomega.BeFalse())
+		})
+	})
+})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1325,6 +1325,7 @@ func WriteYamlFile(name string, obj runtime.Object, moreObjects ...runtime.Objec
 // Contains checks if string array arr contains string s
 func Contains(s string, arr []string) bool {
 	for _, b := range arr {
+		b = strings.TrimSpace(b)
 		if b == s {
 			return true
 		}
@@ -1506,9 +1507,7 @@ func GetWatchNamespace() (string, error) {
 	if !found {
 		return "", fmt.Errorf("%s must be set", WatchNamespaceEnvVar)
 	}
-	if len(ns) == 0 {
-		return "", fmt.Errorf("%s must not be empty", WatchNamespaceEnvVar)
-	}
+
 	return ns, nil
 }
 

--- a/pkg/util/util_suite_test.go
+++ b/pkg/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/pkg/validations/bucketclass_validation.go
+++ b/pkg/validations/bucketclass_validation.go
@@ -27,6 +27,26 @@ func ValidateBucketClass(bc *nbv1.BucketClass) error {
 	return ValidateQuotaConfig(bc.Name, bc.Spec.Quota)
 }
 
+// ValidateImmutLabelChange validates that immutable labels are not changed
+func ValidateImmutLabelChange(bc *nbv1.BucketClass, oldBC *nbv1.BucketClass, immuts map[string]struct{}) error {
+	if bc == nil || oldBC == nil {
+		return nil
+	}
+
+	for immutableLabel := range immuts {
+		val1 := oldBC.GetLabels()[immutableLabel]
+		val2 := bc.GetLabels()[immutableLabel]
+
+		if val1 != val2 {
+			return util.ValidationError{
+				Msg: fmt.Sprintf("immutable label %q cannot be changed", immutableLabel),
+			}
+		}
+	}
+
+	return nil
+}
+
 // ValidateQuotaConfig validates the quota values
 func ValidateQuotaConfig(bcName string, quota *nbv1.Quota) error {
 	if quota == nil {

--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -26,6 +26,7 @@ function post_install_tests {
     check_pgdb_config_override
     test_noobaa_cr_deletion
     test_noobaa_loadbalancer_source_subnet
+    test_multinamespace_bucketclass
 }
 
 function main {


### PR DESCRIPTION
### Explain the changes
This PR intends to add support for creating BucketClass in any namespace. The changes are made only in the controllers, if approved then appropriate changes will be propagated to NooBaa CLI in another PR.

**Brief Overview**
With this PR:
- noobaa operator has 2 managers now:
    - First manager is namespace scoped and monitors the namespace scoped objects (rest of NooBaa resources).
    - Second manager is cluster scoped and monitors entire cluster (for now BucketClass only).
- BucketClass can be created in any namespace.
    - BucketClass can choose noobaa system by using `"noobaa-operator"` label in the `metadata`.
    - If no label is specified then NooBaa system is searched in the namespace of the BucketClass. This ensures backwards compatibility.
    - BucketClass with invalid provisioners are ignored.
- OBC can refer to BucketClass in either their namespace or in NooBaa system namespace
    - If there is a conflict, BucketClass in OBC namespace is chosen over BucketClass in NooBaa system namespace.
   

### Testing Instructions:
1. `make test-cli-flow`

- [x] Doc added/updated
- [x] Tests added
