### PR TITLE
Bumped the version in golangci-lint.yml to fix the GH Action lint.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.45.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
### Explain the changes
- Bumped the version in golangci-lint.yml to fix the GH Action lint.

Signed-off-by: liranmauda <liran.mauda@gmail.com>
