### PR TITLE
Add noobaa admission controller to prevent CR deletion

### DIFF
--- a/deploy/internal/admission-webhook.yaml
+++ b/deploy/internal/admission-webhook.yaml
@@ -31,6 +31,13 @@ webhooks:
       resources:   
       - "noobaaaccounts"
       scope: "Namespaced"
+    - apiGroups:   ["noobaa.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  
+      - "DELETE"
+      resources:   
+      - "noobaas"
+      scope: "Namespaced"
     sideEffects: None
     clientConfig:
       service:

--- a/pkg/admission/validate_noobaa.go
+++ b/pkg/admission/validate_noobaa.go
@@ -1,0 +1,46 @@
+package admission
+
+import (
+	"github.com/sirupsen/logrus"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewNoobaaValidator initializes a NoobaaValidator to be used for loading and validating a noobaa resource
+func NewNoobaaValidator(arRequest admissionv1.AdmissionReview) *ResourceValidator {
+	nv := &ResourceValidator{
+		Logger:    logrus.WithField("admission noobaa validation", arRequest.Request.Namespace),
+		arRequest: &arRequest,
+		arResponse: &admissionv1.AdmissionReview{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AdmissionReview",
+				APIVersion: "admission.k8s.io/v1",
+			},
+			Response: &admissionv1.AdmissionResponse{
+				UID:     arRequest.Request.UID,
+				Allowed: true,
+				Result: &metav1.Status{
+					Message: "allowed",
+				},
+			},
+		},
+	}
+	return nv
+}
+
+// ValidateNoobaa call appropriate validations based on the operation
+func (nv *ResourceValidator) ValidateNoobaa() admissionv1.AdmissionReview {
+	switch nv.arRequest.Request.Operation {
+	case admissionv1.Delete:
+		nv.ValidateDeleteNoobaa()
+	default:
+		nv.Logger.Errorf("No action registered for the operation type: %v", nv.arRequest.Request.Operation)
+	}
+
+	return *nv.arResponse
+}
+
+// ValidateDeleteNoobaa runs all the validations tests for DELETE operations
+func (nv *ResourceValidator) ValidateDeleteNoobaa() {
+	nv.SetValidationResult(false, "Deletion of NooBaa resource is prohibited")
+}

--- a/pkg/admission/validator.go
+++ b/pkg/admission/validator.go
@@ -61,6 +61,8 @@ func (gs *ServerHandler) serve(w http.ResponseWriter, r *http.Request) {
 		arResponse = NewBucketClassValidator(arRequest).ValidateBucketClass()
 	case "noobaaaccounts":
 		arResponse = NewNoobaaAccountValidator(arRequest).ValidateNoobaAaccount()
+	case "noobaas":
+		arResponse = NewNoobaaValidator(arRequest).ValidateNoobaa()
 	default:
 		log.Error("failed to identify resource type")
 		http.Error(w, "incorrect resource", http.StatusBadRequest)

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2986,7 +2986,7 @@ metadata:
 spec: {}
 `
 
-const Sha256_deploy_internal_admission_webhook_yaml = "0a6723515b4d26c49de29573430caad20ed4eb56b6860ee21d5f374f45b34876"
+const Sha256_deploy_internal_admission_webhook_yaml = "a9d71b881748ed66ec0447d16a41fc7004a3db0634e455f10e5ed41f4c010f47"
 
 const File_deploy_internal_admission_webhook_yaml = `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -3020,6 +3020,13 @@ webhooks:
       - "UPDATE"
       resources:   
       - "noobaaaccounts"
+      scope: "Namespaced"
+    - apiGroups:   ["noobaa.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  
+      - "DELETE"
+      resources:   
+      - "noobaas"
       scope: "Namespaced"
     sideEffects: None
     clientConfig:

--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -23,6 +23,7 @@ function post_install_tests {
     check_deletes
     delete_replication_files
     check_pgdb_config_override
+    test_noobaa_cr_deletion
 }
 
 function main {

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -953,3 +953,20 @@ function check_dbdump {
     # Remove diagnostics and dump files
     rm -rf /tmp/$rand_dir
 }
+
+function test_noobaa_cr_deletion() {
+    local resp
+    resp=$(kubectl -n ${NAMESPACE} delete noobaas.noobaa.io noobaa 2>&1 >/dev/null)
+    if [ $? -ne 0 ]; then
+        echo $resp
+        if [[ $resp == *"Deletion of NooBaa resource is prohibited"* ]]; then
+            echo_time "✅  Noobaa CR deletion test passed"
+        else
+            echo_time "❌  Noobaa CR deletion test failed"
+            exit 1
+        fi
+    else
+        echo_time "❌  Noobaa CR deletion test failed: kubectl delete returned 0"
+        exit 1
+    fi
+}


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
1. Adds admission controller for Noobaa CR - Prevents resource deletion
2. Preserve the uninstall functionality by altering the WebhookConfiguration before uninstalling.

### Fixes: BZ #1981732

### Testing Instructions:
1. Install noobaa `noobaa install -n <ns> --admission`
2. Attempt to delete Noobaa CR `kubectl delete noobaas.noobaa.io -n<ns> noobaa` => Request should fail with error.
4. Uninstall noobaa `noobaa uninstall -n <ns>` => Should uninstall noobaa

- [ ] Doc added/updated
- [x] Tests added
