### PR TITLE
Make STS service optional

### DIFF
--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -1707,7 +1707,6 @@ spec:
                 required:
                 - serviceMgmt
                 - serviceS3
-                - serviceSts
                 type: object
               upgradePhase:
                 description: Upgrade reports the status of the ongoing upgrade process

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -327,7 +327,8 @@ type AccountsStatus struct {
 type ServicesStatus struct {
 	ServiceMgmt ServiceStatus `json:"serviceMgmt"`
 	ServiceS3   ServiceStatus `json:"serviceS3"`
-	ServiceSts  ServiceStatus `json:"serviceSts"`
+	// +optional
+	ServiceSts ServiceStatus `json:"serviceSts,omitempty"`
 }
 
 // UserStatus is the status info of a user secret

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1217,7 +1217,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "4e67ec9309050db9456c89073739b9e4e09bd52fabfcbe4341ab7c98d9ed35bc"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "8b54bf712425e99e288c40417e1b7d722e86ba551e5d562210cd269215c0ac4a"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2928,7 +2928,6 @@ spec:
                 required:
                 - serviceMgmt
                 - serviceS3
-                - serviceSts
                 type: object
               upgradePhase:
                 description: Upgrade reports the status of the ongoing upgrade process


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. OLM upgrade fails on validation of the existing CR and the new CRD because sts service is required in the status section, change it to optional. @iamniting

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
