### PR TITLE
Add Noobaa CR cleanup policy

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -66,3 +66,10 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update

--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -897,6 +897,8 @@ spec:
                 description: CleanupPolicy (optional) Indicates user's policy for
                   deletion
                 properties:
+                  allowNoobaaDeletion:
+                    type: boolean
                   confirmation:
                     description: CleanupConfirmationProperty is a string that specifies
                       cleanup confirmation

--- a/pkg/admission/validate_noobaa.go
+++ b/pkg/admission/validate_noobaa.go
@@ -42,5 +42,6 @@ func (nv *ResourceValidator) ValidateNoobaa() admissionv1.AdmissionReview {
 
 // ValidateDeleteNoobaa runs all the validations tests for DELETE operations
 func (nv *ResourceValidator) ValidateDeleteNoobaa() {
+	nv.Logger.Infof("Validating DELETE operation")
 	nv.SetValidationResult(false, "Deletion of NooBaa resource is prohibited")
 }

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -403,6 +403,9 @@ const (
 // CleanupPolicySpec specifies the cleanup policy
 type CleanupPolicySpec struct {
 	Confirmation CleanupConfirmationProperty `json:"confirmation,omitempty"`
+
+	// +optional
+	AllowNoobaaDeletion bool `json:"allowNoobaaDeletion,omitempty"`
 }
 
 // CleanupConfirmationProperty is a string that specifies cleanup confirmation

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2,7 +2,7 @@ package bundle
 
 const Version = "5.10.0"
 
-const Sha256_deploy_cluster_role_yaml = "b3be23b51cbfad068dcf49bffa5f6af04c99dfc9623e2656f872e5f0643a8aeb"
+const Sha256_deploy_cluster_role_yaml = "b342000bd728bd1661dedbbd00ac9066d560920285b451b2f8f72b830e039098"
 
 const File_deploy_cluster_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -72,6 +72,13 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
 `
 
 const Sha256_deploy_cluster_role_binding_yaml = "15c78355aefdceaf577bd96b4ae949ae424a3febdc8853be0917cf89a63941fc"
@@ -1217,7 +1224,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "8b54bf712425e99e288c40417e1b7d722e86ba551e5d562210cd269215c0ac4a"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "4f713c96db90ca5fe0f6fe5de8eea1fc5bae2d47aa2e57ac8e0a2760c732cdaa"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2118,6 +2125,8 @@ spec:
                 description: CleanupPolicy (optional) Indicates user's policy for
                   deletion
                 properties:
+                  allowNoobaaDeletion:
+                    type: boolean
                   confirmation:
                     description: CleanupConfirmationProperty is a string that specifies
                       cleanup confirmation

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -14,7 +14,6 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/spf13/cobra"
-	admissionv1 "k8s.io/api/admissionregistration/v1"
 )
 
 // CmdInstall returns a CLI command
@@ -132,18 +131,9 @@ func RunUninstall(cmd *cobra.Command, args []string) {
 	log.Printf("Namespace: %s", options.Namespace)
 	log.Printf("")
 	log.Printf("System Delete:")
-	// First ensure that webhook allows NooBaa CR deletion
-	scopeNamespaced := admissionv1.ScopeType("Namespaced")
-	operator.RemoveRuleFromNoobaaAdmissionWebhook(&admissionv1.RuleWithOperations{
-		Operations: []admissionv1.OperationType{admissionv1.Delete},
-		Rule: admissionv1.Rule{
-			APIGroups:   []string{"noobaa.io"},
-			APIVersions: []string{"v1alpha1"},
-			Resources:   []string{"noobaas"},
-			Scope:       &scopeNamespaced,
-		},
-	})
-	// Attempt to delete the system
+	if err := system.RemoveRuleFromNoobaaAdmissionWebhook(system.GetNoobaaCRDeletionAdmissionRule()); err != nil {
+		log.Printf("Failed to remove noobaa admission webhook rule: %v - deletion process may fail", err)
+	}
 	system.RunDelete(cmd, args)
 	log.Printf("")
 	log.Printf("Operator Delete:")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
@@ -471,52 +470,4 @@ func AdmissionWebhookSetup(c *Conf) {
 		},
 	}
 	c.Deployment.Spec.Template.Spec.Volumes = volumes
-}
-
-// RemoveRuleFromNoobaaAdmissionWebhook removes the rule from the noobaa internal admission webhook
-func RemoveRuleFromNoobaaAdmissionWebhook(rule *admissionv1.RuleWithOperations) {
-	wc := util.KubeObject(bundle.File_deploy_internal_admission_webhook_yaml).(*admissionv1.ValidatingWebhookConfiguration)
-
-	removeAdmissionRule(wc, rule)
-
-	// Find the pre-existing admission webhook
-	wcClone := wc.DeepCopy()
-	if _, _, err := util.KubeGet(wcClone); err != nil {
-		return
-	}
-
-	wc.SetResourceVersion(wcClone.GetResourceVersion())
-	util.KubeUpdate(wc)
-}
-
-// removeAdmissionRule removes the matching rule from the given webhook
-func removeAdmissionRule(wc *admissionv1.ValidatingWebhookConfiguration, rule *admissionv1.RuleWithOperations) {
-	for i, r := range wc.Webhooks[0].Rules {
-		if r.Scope == nil && rule.Scope != nil && *rule.Scope != "*" {
-			continue
-		}
-		if rule.Scope == nil && r.Scope != nil && *r.Scope != "*" {
-			continue
-		}
-		if r.Scope != nil && rule.Scope != nil && *r.Scope != *rule.Scope {
-			continue
-		}
-		if !reflect.DeepEqual(r.Operations, rule.Operations) {
-			continue
-		}
-		if !reflect.DeepEqual(r.APIGroups, rule.APIGroups) {
-			continue
-		}
-		if !reflect.DeepEqual(r.APIVersions, rule.APIVersions) {
-			continue
-		}
-		if !reflect.DeepEqual(r.Resources, rule.Resources) {
-			continue
-		}
-
-		wc.Webhooks[0].Rules = append(
-			wc.Webhooks[0].Rules[:i],
-			wc.Webhooks[0].Rules[i+1:]...,
-		)
-	}
 }

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
@@ -61,6 +63,9 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 		"noobaa operator started phase 4/4 - \"Configuring\"",
 	)
 
+	if err := r.ReconcileNoobaaDeletionPolicy(); err != nil {
+		return err
+	}
 	if err := r.ReconcileSystemSecrets(); err != nil {
 		return err
 	}
@@ -94,6 +99,7 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 	if err := r.ReconcileDeploymentEndpointStatus(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -1522,4 +1528,143 @@ func (r *Reconciler) ReconcileNamespaceStores(namespaceResources []nb.NamespaceR
 		}
 	}
 	return nil
+}
+
+// ReconcileNoobaaDeletionPolicy reconciles the deletion policy of a Noobaa resource
+// and configures the noobaa admission controller appropriately.
+func (r *Reconciler) ReconcileNoobaaDeletionPolicy() error {
+	noobaaAdmissionEnabled := os.Getenv("ENABLE_NOOBAA_ADMISSION")
+	if strings.ToLower(noobaaAdmissionEnabled) != "true" {
+		return nil
+	}
+
+	rule := GetNoobaaCRDeletionAdmissionRule()
+
+	if r.NooBaa.Spec.CleanupPolicy.AllowNoobaaDeletion {
+		return RemoveRuleFromNoobaaAdmissionWebhook(rule)
+	}
+
+	return AddRuleToNoobaaAdmissionWebhook(rule)
+}
+
+// RemoveRuleFromNoobaaAdmissionWebhook removes the rule from the noobaa internal admission webhook
+// if it exists
+func RemoveRuleFromNoobaaAdmissionWebhook(rule *admissionv1.RuleWithOperations) error {
+	wc := &admissionv1.ValidatingWebhookConfiguration{}
+	wc.SetName("admission-validation-webhook")
+
+	// Find the pre-existing admission webhook
+	if _, _, err := util.KubeGet(wc); err != nil {
+		return fmt.Errorf("failed to get webhook: %v", err)
+	}
+
+	// If no rule was removed then return
+	if !removeAdmissionRule(wc, rule) {
+		return nil
+	}
+
+	if !util.KubeUpdate(wc) {
+		return fmt.Errorf("failed to update webhook")
+	}
+
+	return nil
+}
+
+// AddRuleToNoobaaAdmissionWebhook adds the rule to the noobaa admission webhook if it
+// doesn't exists
+func AddRuleToNoobaaAdmissionWebhook(rule *admissionv1.RuleWithOperations) error {
+	wc := &admissionv1.ValidatingWebhookConfiguration{}
+	wc.SetName("admission-validation-webhook")
+
+	// Find the pre-existing admission webhook
+	if _, _, err := util.KubeGet(wc); err != nil {
+		return fmt.Errorf("failed to get webhook: %v", err)
+	}
+
+	// If no rule was added then return
+	if !addAdmissionRule(wc, rule) {
+		return nil
+	}
+
+	if !util.KubeUpdate(wc) {
+		return fmt.Errorf("failed to update webhook")
+	}
+
+	return nil
+}
+
+// removeAdmissionRule removes the matching rule from the given webhook and returns true
+// if rule was deleted or else returns false
+func removeAdmissionRule(wc *admissionv1.ValidatingWebhookConfiguration, rule *admissionv1.RuleWithOperations) bool {
+	ruleIdx, found := findAdmissionRule(wc, rule)
+	if !found {
+		return false
+	}
+
+	wc.Webhooks[0].Rules = append(
+		wc.Webhooks[0].Rules[:ruleIdx],
+		wc.Webhooks[0].Rules[ruleIdx+1:]...,
+	)
+
+	return true
+}
+
+// addAdmissionRule takes in pointer to validationwebhookconfiguration and adds the given rule to it and returns true
+// if rule was added or else returns false
+//
+// NOTE: It will not add the rule if it exists
+func addAdmissionRule(wc *admissionv1.ValidatingWebhookConfiguration, rule *admissionv1.RuleWithOperations) bool {
+	_, found := findAdmissionRule(wc, rule)
+	if found {
+		return false
+	}
+
+	wc.Webhooks[0].Rules = append(wc.Webhooks[0].Rules, *rule)
+
+	return true
+}
+
+func findAdmissionRule(wc *admissionv1.ValidatingWebhookConfiguration, rule *admissionv1.RuleWithOperations) (int, bool) {
+	for i, r := range wc.Webhooks[0].Rules {
+		if r.Scope == nil && rule.Scope != nil && *rule.Scope != "*" {
+			continue
+		}
+		if rule.Scope == nil && r.Scope != nil && *r.Scope != "*" {
+			continue
+		}
+		if r.Scope != nil && rule.Scope != nil && *r.Scope != *rule.Scope {
+			continue
+		}
+		if !util.IsArrayUnorderedEqual(r.Operations, rule.Operations, nil) {
+			continue
+		}
+		if !util.IsArrayUnorderedEqual(r.APIGroups, rule.APIGroups, nil) {
+			continue
+		}
+		if !util.IsArrayUnorderedEqual(r.APIVersions, rule.APIVersions, nil) {
+			continue
+		}
+		if !util.IsArrayUnorderedEqual(r.Resources, rule.Resources, nil) {
+			continue
+		}
+
+		return i, true
+	}
+
+	return 0, false
+}
+
+// GetNoobaaCRDeletionAdmissionRule returns the noobaa custom resource deletion admission rule
+func GetNoobaaCRDeletionAdmissionRule() *admissionv1.RuleWithOperations {
+	scopeNamespaced := admissionv1.ScopeType("Namespaced")
+	rule := &admissionv1.RuleWithOperations{
+		Operations: []admissionv1.OperationType{admissionv1.Delete},
+		Rule: admissionv1.Rule{
+			APIGroups:   []string{"noobaa.io"},
+			APIVersions: []string{"v1alpha1"},
+			Resources:   []string{"noobaas"},
+			Scope:       &scopeNamespaced,
+		},
+	}
+	return rule
 }

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -273,6 +273,10 @@ func RunDelete(cmd *cobra.Command, args []string) {
 
 	log.Infof("Notice: Deletion of External secrets should be preformed manually")
 
+	if err := RemoveRuleFromNoobaaAdmissionWebhook(GetNoobaaCRDeletionAdmissionRule()); err != nil {
+		log.Errorf("NooBaa %q failed to update cleanup policy - deletion may fail", options.SystemName)
+	}
+
 	cleanupData, _ := cmd.Flags().GetBool("cleanup_data")
 	objectBuckets := &nbv1.ObjectBucketList{}
 	obcSelector, _ := labels.Parse("noobaa-domain=" + options.SubDomainNS())


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
1. Adds `spec.cleanupPolicy.allowNoobaaDeletion` in NooBaa CR which disables the Noobaa CR deletion prevention feature added in https://github.com/noobaa/noobaa-operator/pull/903.
    1. If no policy is specified, it defaults to `false`.
2. Changes the CLI uninstall flow. Now, `noobaa uninstall` just sets `spec.cleanupPolicy.allowNoobaaDeletion` to `true` which triggers noobaa operator to disable the Noobaa CR deletion feature hence allowing the `uninstall` to proceed as usual.

### Testing Instructions:
1. Install noobaa operator: `nb install --admission -n <ns>`
2. Run: `kubectl delete noobaas.noobaa.io noobaa -n <ns>` - should fail
