### PR TITLE
[backport to 5.10] create a pv-pool default backing store in azure gov platforms

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.45.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -517,7 +517,7 @@ func (r *Reconciler) ReconcileBackingStoreCredentials() error {
 	if util.IsAWSPlatform() {
 		return r.ReconcileAWSCredentials()
 	}
-	if util.IsAzurePlatform() {
+	if util.IsAzurePlatformNonGovernment() {
 		return r.ReconcileAzureCredentials()
 	}
 	if util.IsGCPPlatform() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -993,13 +993,25 @@ func IsSTSClusterBS(bs *nbv1.BackingStore) bool {
 	return false
 }
 
-// IsAzurePlatform returns true if this cluster is running on Azure
-func IsAzurePlatform() bool {
+// IsAzurePlatformNonGovernment returns true if this cluster is running on Azure and also not on azure government\DOD cloud
+func IsAzurePlatformNonGovernment() bool {
 	nodesList := &corev1.NodeList{}
 	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
 		Panic(fmt.Errorf("failed to list kubernetes nodes"))
 	}
-	isAzure := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "azure")
+	const regionLabel string = "topology.kubernetes.io/region"
+	node := nodesList.Items[0]
+	isAzure := strings.HasPrefix(node.Spec.ProviderID, "azure")
+	if isAzure {
+		nodeLabels := node.GetLabels()
+		region, ok := nodeLabels[regionLabel]
+		if !ok {
+			log.Warnf("did not find the expected label %q on node %q to determine azure region", regionLabel, node.Name)
+		} else if strings.HasPrefix(region, "usgov") || strings.HasPrefix(region, "usdod") {
+			log.Infof("identified the region [%q] as an Azure gov/DOD region", region)
+			return false
+		}
+	}
 	return isAzure
 }
 


### PR DESCRIPTION
* for Azure gov\DOD, creating an Azure default backingstore requires a more complicated solution.
* identifying azure gov\dod regions base on the "topology.kubernetes.io/region" label on the nodes.
* when running on azure gov, IsAzurePlatformNonGovernment returns false. as a result a pv pool backingstore is created in phase 4

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 176d41b0be4fec46710d6824afa1cfc0c8b1ec4d)

### Explain the changes
1. backported https://github.com/noobaa/noobaa-operator/pull/907

### Issues: Fixed #xxx / Gap #xxx
1. fixes https://bugzilla.redhat.com/show_bug.cgi?id=2079504

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
