### PR TITLE
Preventing the cli from searching for identical secrets for pvpool 

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -369,7 +369,10 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 		log.Fatalf(`❌ %s %s`, validationErr, cmd.UsageString())
 	}
 
-	suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, util.MapStorTypeToMandatoryProperties[storeType])
+	var suggestedSecret *corev1.Secret = nil
+	if storeType != nbv1.StoreTypePVPool {
+		suggestedSecret = util.CheckForIdenticalSecretsCreds(secret, util.MapStorTypeToMandatoryProperties[storeType])
+	}
 	if suggestedSecret != nil {
 		var decision string
 		log.Printf("Found a Secret in the system with the same credentials (%s)", suggestedSecret.Name)

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -279,7 +279,10 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.NSType, popu
 
 	populate(namespaceStore, secret)
 
-	suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, util.MapStorTypeToMandatoryProperties[nbv1.StoreType(namespaceStore.Spec.Type)])
+	var suggestedSecret *corev1.Secret = nil
+	if storeType != nbv1.NSStoreTypeNSFS {
+		suggestedSecret = util.CheckForIdenticalSecretsCreds(secret, util.MapStorTypeToMandatoryProperties[nbv1.StoreType(namespaceStore.Spec.Type)])
+	}
 	if suggestedSecret != nil {
 		var decision string
 		log.Printf("Found a Secret in the system with the same credentials (%s)", suggestedSecret.Name)


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. check the store type before searching for identical secrets.

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2084503

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
