### PR TITLE
Fix check identical secrets

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -369,10 +369,7 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 		log.Fatalf(`❌ %s %s`, validationErr, cmd.UsageString())
 	}
 
-	var suggestedSecret *corev1.Secret = nil
-	if storeType != nbv1.StoreTypePVPool {
-		suggestedSecret = util.CheckForIdenticalSecretsCreds(secret, util.MapStorTypeToMandatoryProperties[storeType])
-	}
+	suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, string(storeType))
 	if suggestedSecret != nil {
 		var decision string
 		log.Printf("Found a Secret in the system with the same credentials (%s)", suggestedSecret.Name)

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -293,7 +293,7 @@ func (r *Reconciler) LoadBackingStoreSecret() error {
 					return nil
 				}
 				if secret != nil {
-					suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, util.MapStorTypeToMandatoryProperties[r.BackingStore.Spec.Type])
+					suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, string(r.BackingStore.Spec.Type))
 					if suggestedSecret != nil {
 						secretRef.Name = suggestedSecret.Name
 						secretRef.Namespace = suggestedSecret.Namespace

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -279,10 +279,7 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.NSType, popu
 
 	populate(namespaceStore, secret)
 
-	var suggestedSecret *corev1.Secret = nil
-	if storeType != nbv1.NSStoreTypeNSFS {
-		suggestedSecret = util.CheckForIdenticalSecretsCreds(secret, util.MapStorTypeToMandatoryProperties[nbv1.StoreType(namespaceStore.Spec.Type)])
-	}
+	suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, string(nbv1.StoreType(namespaceStore.Spec.Type)))
 	if suggestedSecret != nil {
 		var decision string
 		log.Printf("Found a Secret in the system with the same credentials (%s)", suggestedSecret.Name)

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -534,7 +534,7 @@ func (r *Reconciler) LoadNamespaceStoreSecret() error {
 		// if found, point this NS secret reference to it.
 		// so if the user will update the credentials, it will trigger updateExternalConnection in all the Namespacestores
 		if secret != nil {
-			suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, util.MapStorTypeToMandatoryProperties[nbv1.StoreType(r.NamespaceStore.Spec.Type)])
+			suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, string(nbv1.StoreType(r.NamespaceStore.Spec.Type)))
 			if suggestedSecret != nil {
 				secretRef.Name = suggestedSecret.Name
 				secretRef.Namespace = suggestedSecret.Namespace


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. this function is not relevant for pvpool and nsfs store types , therefor adding a check in the beginning if the mandatory properties are empty return nil.

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2084503
2. https://bugzilla.redhat.com/show_bug.cgi?id=2091894

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
