### PR TITLE
NSFS | GetNamespaceStoreSecret - fix nil pointer dereference on NSFS namespacestore

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1747,7 +1747,7 @@ func GetNamespaceStoreSecret(ns *nbv1.NamespaceStore) (*corev1.SecretReference, 
 	if err != nil {
 		return nil, err
 	}
-	if secretRef.Namespace == "" {
+	if secretRef != nil && secretRef.Namespace == "" {
 		secretRef.Namespace = ns.Namespace
 	}
 	return secretRef, nil


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. In util.GetNamespaceStoreSecret() added a check for secretRef != nil before accessing secretRef.Namespace, because secretRef is nil when type of namespacestore is NSFS.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2091641

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
