### PR TITLE
Added option to show/hide secrets in status output

### DIFF
--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -217,13 +217,13 @@ func RunRegenerate(cmd *cobra.Command, args []string) {
 	log.Printf("You are about to regenerate an OBC's security credentials.")
 	log.Printf("This will invalidate all connections between S3 clients and NooBaa which are connected using the current credentials.")
 	log.Printf("are you sure? y/n")
-	
+
 	for {
 		fmt.Scanln(&decision)
 		if decision == "y" {
 			break
 		} else if decision == "n" {
-			return 
+			return
 		}
 	}
 
@@ -232,7 +232,7 @@ func RunRegenerate(cmd *cobra.Command, args []string) {
 		appNamespace = options.Namespace
 	}
 
-	name :=  args[0]
+	name := args[0]
 
 	obc := util.KubeObject(bundle.File_deploy_obc_objectbucket_v1alpha1_objectbucketclaim_cr_yaml).(*nbv1.ObjectBucketClaim)
 	ob := util.KubeObject(bundle.File_deploy_obc_objectbucket_v1alpha1_objectbucket_cr_yaml).(*nbv1.ObjectBucket)
@@ -250,7 +250,7 @@ func RunRegenerate(cmd *cobra.Command, args []string) {
 		ob.Name = fmt.Sprintf("obc-%s-%s", appNamespace, name)
 	}
 
-	if !util.KubeCheck(ob){
+	if !util.KubeCheck(ob) {
 		log.Fatalf(`❌ Could not find OB %q`, ob.Name)
 	}
 
@@ -262,7 +262,7 @@ func RunRegenerate(cmd *cobra.Command, args []string) {
 	}
 
 	RunStatus(cmd, args)
-	
+
 }
 
 // RunDelete runs a CLI command
@@ -383,8 +383,13 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	credsEnv := ""
 	for k, v := range secret.StringData {
 		if v != "" {
-			fmt.Printf("  %-22s : %s\n", k, v)
-			credsEnv += k + "=" + v + " "
+			if options.ShowSecrets {
+				fmt.Printf("  %-22s : %s\n", k, v)
+				credsEnv += k + "=" + v + " "
+			} else {
+				fmt.Printf("  %-22s : %s\n", k, nb.MaskedString(v))
+				credsEnv += k + "=" + string(nb.MaskedString(v)) + " "
+			}
 		}
 	}
 	fmt.Printf("\n")
@@ -531,7 +536,7 @@ func GenerateAccountKeys(name string, accountName string) error {
 	}
 
 	err = sysClient.NBClient.GenerateAccountKeysAPI(nb.GenerateAccountKeysParams{
-		Email:	accountName,
+		Email: accountName,
 	})
 	if err != nil {
 		return err
@@ -544,7 +549,7 @@ func GenerateAccountKeys(name string, accountName string) error {
 	if err != nil {
 		return err
 	}
- 
+
 	accessKeys = accountInfo.AccessKeys[0]
 
 	secret.StringData = map[string]string{}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -116,6 +116,9 @@ var DisableLoadBalancerService = false
 // AdmissionWebhook is used for deploying the system with admission validation webhook
 var AdmissionWebhook = false
 
+// ShowSecrets is used to show the secrets in the status output
+var ShowSecrets = false
+
 // SubDomainNS returns a unique subdomain for the namespace
 func SubDomainNS() string {
 	return Namespace + ".noobaa.io"
@@ -192,5 +195,9 @@ func init() {
 	FlagSet.BoolVar(
 		&AdmissionWebhook, "admission",
 		false, "Install the system with admission validation webhook",
+	)
+	FlagSet.BoolVar(
+		&ShowSecrets, "show-secrets",
+		false, "Show the secrets in the status output",
 	)
 }

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -577,7 +577,11 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	util.KubeCheck(secret)
 
 	fmt.Println("")
-	fmt.Printf("%s password : %s\n", secret.StringData["email"], secret.StringData["password"])
+	if options.ShowSecrets {
+		fmt.Printf("%s password : %s\n", secret.StringData["email"], secret.StringData["password"])
+	} else {
+		fmt.Printf("%s password : %s\n", secret.StringData["email"], nb.MaskedString(secret.StringData["password"]))
+	}
 
 	fmt.Println("")
 	fmt.Println("#-----------------#")
@@ -610,9 +614,14 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	fmt.Println("#- S3 Credentials -#")
 	fmt.Println("#------------------#")
 	fmt.Println("")
-	fmt.Printf("AWS_ACCESS_KEY_ID     : %s\n", secret.StringData["AWS_ACCESS_KEY_ID"])
-	fmt.Printf("AWS_SECRET_ACCESS_KEY : %s\n", secret.StringData["AWS_SECRET_ACCESS_KEY"])
-	fmt.Println("")
+	if options.ShowSecrets {
+		fmt.Printf("AWS_ACCESS_KEY_ID     : %s\n", secret.StringData["AWS_ACCESS_KEY_ID"])
+		fmt.Printf("AWS_SECRET_ACCESS_KEY : %s\n", secret.StringData["AWS_SECRET_ACCESS_KEY"])
+	} else {
+		fmt.Printf("AWS_ACCESS_KEY_ID     : %s\n", nb.MaskedString(secret.StringData["AWS_ACCESS_KEY_ID"]))
+		fmt.Printf("AWS_SECRET_ACCESS_KEY : %s\n", nb.MaskedString(secret.StringData["AWS_SECRET_ACCESS_KEY"]))
+	}
+
 }
 
 // RunReconcile runs a CLI command

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -275,7 +275,7 @@ function aws_credentials {
         then
             eval $(echo ${line//\"/} | sed -e 's/ //g' -e 's/:/=/g')
         fi
-    done < <(test_noobaa silence status)
+    done < <(test_noobaa silence status --show-secrets)
     if [ -z ${AWS_ACCESS_KEY_ID} ] || [ -z ${AWS_SECRET_ACCESS_KEY} ]
     then
         echo_time "❌  Could not get AWS credentials, Exiting"
@@ -655,7 +655,7 @@ function account_regenerate_keys {
             then
                 eval $(echo ${line//\"/} | sed -e 's/ //g' -e 's/:/=/g')
             fi
-        done < <(test_noobaa account status ${account})
+        done < <(test_noobaa account status ${account} --show-secrets)
     fi
 
     local ACCESS_KEY_ID_before=${AWS_ACCESS_KEY_ID}
@@ -666,7 +666,7 @@ function account_regenerate_keys {
         then
             eval $(echo ${line//\"/} | sed -e 's/ //g' -e 's/:/=/g')
         fi
-    done < <(yes | test_noobaa account regenerate ${account})
+    done < <(yes | test_noobaa account regenerate ${account} --show-secrets)
 
     if [ "${AWS_ACCESS_KEY_ID}" == "${ACCESS_KEY_ID_before}" ]
     then
@@ -702,7 +702,7 @@ function get_admin_password {
         then
             password=$(echo ${line//\"/} | awk -F ":" '{print $2}')
         fi
-    done < <(yes | test_noobaa status)
+    done < <(yes | test_noobaa status --show-secrets)
     echo ${password}
 }
 


### PR DESCRIPTION
### Explain the changes
Masked the ACCESS_KEYS and passwords to * by default, in status output.
And, if the `--show-secrets` flag is passed to the command the secrets
are shown.

Fixes: #928

### Testing Instructions:
1. Try running the command `noobaa status` after successful installation, you should see the secrets as `*`
2. Run the same command, but this time with the `--show-secrets` flag. The secrets will be visible.

Signed-off-by: nik-redhat <nladha@redhat.com> 

