### PR TITLE
cli doesn't show error when creating a backingstore that isn't available in the commands

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -49,8 +49,9 @@ func Cmd() *cobra.Command {
 // CmdCreate returns a CLI command
 func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create",
+		Use:   "create <backing-store-type> <backing-store-name>",
 		Short: "Create backing store",
+		Run:   RunCreate,
 	}
 	cmd.AddCommand(
 		CmdCreateAWSS3(),
@@ -420,6 +421,18 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 		log.Printf("")
 		log.Printf("")
 		RunStatus(cmd, args)
+	}
+}
+
+// RunCreate runs a cli command
+func RunCreate(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+	if len(args) != 1 || args[0] == "" {
+		log.Fatalf(`❌ Missing expected arguments: <backing-store-type> %s`, cmd.UsageString())
+	}
+	if args[0] != "aws-s3" && args[0] != "aws-sts-s3" && args[0] != "google-cloud-storage" &&
+		args[0] != "azure-blob" && args[0] != "ibm-cos" && args[0] != "pv-pool" && args[0] != "s3-compatible" {
+		log.Fatalf(`❌ Unsupported <backing-store-type> -> %s %s`, args[0], cmd.UsageString())
 	}
 }
 


### PR DESCRIPTION
### Explain the changes
Issue: cli doesn't show error when creating a backingstore that isn't available in the commands

Fix: When trying to create unsupported backingstore, An error should be prompted

Fixes: #274
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>


### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
