### PR TITLE
added set-debug-level command to CLI

### DIFF
--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -55,6 +55,7 @@ type Client interface {
 	UpdateEndpointGroupAPI(UpdateEndpointGroupParams) error
 
 	RegisterToCluster() error
+	PublishToCluster(PublishToClusterParams) error
 
 	PutBucketReplicationAPI(BucketReplicationParams) error
 	ValidateReplicationAPI(BucketReplicationParams) error
@@ -382,9 +383,15 @@ func (c *RPCClient) UpdateEndpointGroupAPI(params UpdateEndpointGroupParams) err
 	return c.Call(req, nil)
 }
 
-// RegisterToCluster calls redirector_api.RegisterToCluster()
+// RegisterToCluster calls redirector_api.register_to_cluster()
 func (c *RPCClient) RegisterToCluster() error {
 	req := &RPCMessage{API: "redirector_api", Method: "register_to_cluster"}
+	return c.Call(req, nil)
+}
+
+// PublishToCluster calls redirector_api.publish_to_cluster()
+func (c *RPCClient) PublishToCluster(params PublishToClusterParams) error {
+	req := &RPCMessage{API: "redirector_api", Method: "publish_to_cluster", Params: params}
 	return c.Call(req, nil)
 }
 

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -722,6 +722,20 @@ type UpdateEndpointGroupParams struct {
 	EndpointRange IntRange `json:"endpoint_range"`
 }
 
+// SetDebugLevelParams - params for debug_api.set_debug_level
+type SetDebugLevelParams struct {
+	Module string `json:"module"`
+	Level  int    `json:"level"`
+}
+
+// PublishToClusterParams are the parmas for redirector_api.publish_to_cluster
+type PublishToClusterParams struct {
+	Target        string      `json:"target"`
+	MethodAPI     string      `json:"method_api"`
+	MethodName    string      `json:"method_name"`
+	RequestParams interface{} `json:"request_params"`
+}
+
 // BigIntToHumanBytes returns a human readable bytes string
 func BigIntToHumanBytes(bi *BigInt) string {
 	return IntToHumanBytes(bi.N + (bi.Peta * petaInBytes))


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. added CLI command `set-debug-level` under `system`. 
   ``` 
   noobaa system set-debug-level [level]
   ```
2. level can be 0-5 or `warn`
3. implemented by using `publish_to_cluster` to send `debug_api.set_debug_level` to all registered processes. 
4. this setting is not persistent and is only applied to the currently running core and endpoints pods

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
