### PR TITLE
Fixed default secret for backingstore

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -892,7 +892,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 			if secret.Namespace == "" {
 				secret.Namespace = backStore.Namespace
 			}
-			if !util.KubeCheck(secret) {
+			if backStore.Spec.Type != nbv1.StoreTypePVPool && !util.KubeCheck(secret) {
 				log.Errorf(`❌ Could not get Secret %q in namespace %q`,
 					secret.Name, secret.Namespace)
 			}
@@ -907,7 +907,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	util.Panic(err)
 	fmt.Print(string(output))
 	fmt.Println()
-	if secretRef != nil {
+	if secretRef != nil && secret.Name != "" {
 		_, err = sigyaml.Marshal(secret.StringData)
 		util.Panic(err)
 		fmt.Println()

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -634,6 +634,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 		fmt.Printf("AWS_ACCESS_KEY_ID     : %s\n", nb.MaskedString(secret.StringData["AWS_ACCESS_KEY_ID"]))
 		fmt.Printf("AWS_SECRET_ACCESS_KEY : %s\n", nb.MaskedString(secret.StringData["AWS_SECRET_ACCESS_KEY"]))
 	}
+	fmt.Println("")
 
 }
 


### PR DESCRIPTION
### Explain the changes
1. Set the default secret as a combination of backingstore spec type and
name for default backing store.

Fixes: #683 

### Testing Instructions:
1. Run the `noobaa backingstore status noobaa-default-backing-store` command, it won't panic.

Signed-off-by: nik-redhat <nladha@redhat.com>
