### PR TITLE
[backport to 5.11] throw temporary error when INVALID_SCHEMA_PARAMS returned from CheckE…

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -924,11 +924,6 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 func (r *Reconciler) CheckExternalConnection(connInfo *nb.CheckExternalConnectionParams) error {
 	res, err := r.NBClient.CheckExternalConnectionAPI(*connInfo)
 	if err != nil {
-		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
-			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
-			}
-		}
 		return err
 	}
 

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -926,7 +926,7 @@ func (r *Reconciler) CheckExternalConnection(connInfo *nb.CheckExternalConnectio
 	if err != nil {
 		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
 			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return util.NewPersistentError("InvalidConnectionParams", rpcErr.Message)
+				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
 			}
 		}
 		return err

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -719,11 +719,6 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 func (r *Reconciler) CheckExternalConnection(connInfo *nb.CheckExternalConnectionParams) error {
 	res, err := r.NBClient.CheckExternalConnectionAPI(*connInfo)
 	if err != nil {
-		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
-			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
-			}
-		}
 		return err
 	}
 

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -721,7 +721,7 @@ func (r *Reconciler) CheckExternalConnection(connInfo *nb.CheckExternalConnectio
 	if err != nil {
 		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
 			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return util.NewPersistentError("InvalidConnectionParams", rpcErr.Message)
+				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
 			}
 		}
 		return err


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. backported PRs #953 and #955

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2101380 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
