### PR TITLE
Remove RPC error type check

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -924,11 +924,6 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 func (r *Reconciler) CheckExternalConnection(connInfo *nb.CheckExternalConnectionParams) error {
 	res, err := r.NBClient.CheckExternalConnectionAPI(*connInfo)
 	if err != nil {
-		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
-			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
-			}
-		}
 		return err
 	}
 

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -719,11 +719,6 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 func (r *Reconciler) CheckExternalConnection(connInfo *nb.CheckExternalConnectionParams) error {
 	res, err := r.NBClient.CheckExternalConnectionAPI(*connInfo)
 	if err != nil {
-		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
-			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
-			}
-		}
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. remove RPC error type check returned from check_external_connection call, any RPC error should trigger a temporary error and there is no need to check if it's a `INVALID_SCHEMA_PARAMS` error.

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2101380

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
