### PR TITLE
added an option to own OB\OBC in noobaa CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ OUTPUT ?= build/_output
 BIN ?= $(OUTPUT)/bin
 OLM ?= $(OUTPUT)/olm
 MANIFESTS ?= $(OUTPUT)/manifests
+obc-crd ?= required
 VENV ?= $(OUTPUT)/venv
 
 # OPERATOR_SDK_VERSION is for build perpuse only, the dependencies themself are 
@@ -141,7 +142,7 @@ gen-olm: $(OPERATOR_SDK) gen
 
 gen-odf-package: cli
 	rm -rf $(MANIFESTS)
-	MANIFESTS="$(MANIFESTS)" CSV_NAME="$(csv-name)" SKIP_RANGE="$(skip-range)" REPLACES="$(replaces)" CORE_IMAGE="$(core-image)" DB_IMAGE="$(db-image)" OPERATOR_IMAGE="$(operator-image)" build/gen-odf-package.sh
+	MANIFESTS="$(MANIFESTS)" CSV_NAME="$(csv-name)" SKIP_RANGE="$(skip-range)" REPLACES="$(replaces)" CORE_IMAGE="$(core-image)" DB_IMAGE="$(db-image)" OPERATOR_IMAGE="$(operator-image)" OBC_CRD="$(obc-crd)" build/gen-odf-package.sh
 	@echo "✅ gen-odf-package"
 .PHONY: gen-odf-package
 

--- a/build/gen-odf-package.sh
+++ b/build/gen-odf-package.sh
@@ -14,7 +14,8 @@ fi
 --replaces "${REPLACES}" \
 --noobaa-image ${CORE_IMAGE} \
 --db-image ${DB_IMAGE} \
---operator-image ${OPERATOR_IMAGE}
+--operator-image ${OPERATOR_IMAGE} \
+--obc-crd=${OBC_CRD} 
 
 temp_csv=$(mktemp)
 

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	obAPI "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bundle"
 	"github.com/noobaa/noobaa-operator/v5/pkg/crd"
@@ -32,8 +33,18 @@ import (
 type unObj = map[string]interface{}
 type unArr = []interface{}
 
+const (
+	// OBCOwned is the value owned for the obc-crd flag
+	OBCOwned string = "owned"
+	// OBCRequired is the default value for the obc-crd flag
+	OBCRequired string = "required"
+	// OBCNone is the value none for the obc-crd flag
+	OBCNone string = "none"
+)
+
 type generateCSVParams struct {
 	IsForODF  bool
+	OBCMode   string
 	SkipRange string
 	Replaces  string
 }
@@ -66,6 +77,7 @@ func CmdCatalog() *cobra.Command {
 	}
 	cmd.Flags().String("dir", "./build/_output/olm", "The output dir for the OLM package")
 	cmd.Flags().Bool("odf", false, "Build package according to ODF requirements")
+	cmd.Flags().String("obc-crd", OBCRequired, "Determine if the OB/OBC CRDs are required, owned, or none")
 	cmd.Flags().String("csv-name", "", "File name for the CSV YAML")
 	cmd.Flags().String("skip-range", "", "set the olm.skipRange annotation in the CSV")
 	cmd.Flags().String("replaces", "", "set the replaces property in the CSV")
@@ -156,10 +168,16 @@ func RunCatalog(cmd *cobra.Command, args []string) {
 	var versionDir string
 
 	forODF, _ := cmd.Flags().GetBool("odf")
+	obcMode, _ := cmd.Flags().GetString("obc-crd")
+	if obcMode != OBCOwned && obcMode != OBCRequired && obcMode != OBCNone {
+		log.Fatalf(`Invalid value for --obc-crd: %s. should be [%s|%s|%s]`, obcMode, OBCOwned, OBCRequired, OBCNone)
+	}
+
 	skipRange, _ := cmd.Flags().GetString("skip-range")
 	replaces, _ := cmd.Flags().GetString("replaces")
 	csvParams := &generateCSVParams{
 		IsForODF:  forODF,
+		OBCMode:   obcMode,
 		SkipRange: skipRange,
 		Replaces:  replaces,
 	}
@@ -192,7 +210,7 @@ func RunCatalog(cmd *cobra.Command, args []string) {
 	}
 	util.Panic(util.WriteYamlFile(csvFileName, GenerateCSV(opConf, csvParams)))
 	crd.ForEachCRD(func(c *crd.CRD) {
-		if c.Spec.Group == nbv1.SchemeGroupVersion.Group {
+		if c.Spec.Group == nbv1.SchemeGroupVersion.Group || (csvParams.OBCMode == OBCOwned && c.Spec.Group == obAPI.Domain) {
 			util.Panic(util.WriteYamlFile(versionDir+c.Name+".crd.yaml", c))
 		}
 	})
@@ -662,8 +680,15 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 				operv1.APIResourceReference{Name: "statefulsets.apps", Kind: "StatefulSet", Version: "v1"},
 			},
 		}
+
 		if c.Spec.Group == nbv1.SchemeGroupVersion.Group {
 			csv.Spec.CustomResourceDefinitions.Owned = append(csv.Spec.CustomResourceDefinitions.Owned, crdDesc)
+		} else if c.Spec.Group == obAPI.Domain {
+			if csvParams.OBCMode == OBCOwned {
+				csv.Spec.CustomResourceDefinitions.Owned = append(csv.Spec.CustomResourceDefinitions.Owned, crdDesc)
+			} else if csvParams.OBCMode == OBCRequired {
+				csv.Spec.CustomResourceDefinitions.Required = append(csv.Spec.CustomResourceDefinitions.Required, crdDesc)
+			}
 		} else {
 			csv.Spec.CustomResourceDefinitions.Required = append(csv.Spec.CustomResourceDefinitions.Required, crdDesc)
 		}


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
* added --obc-crd flag to olm catalog CLI - can be either owned\required\none
* added obc-crd var to Makefile which is used by gen-odf-package target
* default behavior is "required", same as it was before

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
