### PR TITLE
Fixed issue #961 - require OBC in CSV when csvParams=nil

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -684,11 +684,11 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 		if c.Spec.Group == nbv1.SchemeGroupVersion.Group {
 			csv.Spec.CustomResourceDefinitions.Owned = append(csv.Spec.CustomResourceDefinitions.Owned, crdDesc)
 		} else if c.Spec.Group == obAPI.Domain {
-			if csvParams.OBCMode == OBCOwned {
+			if csvParams != nil && csvParams.OBCMode == OBCOwned {
 				csv.Spec.CustomResourceDefinitions.Owned = append(csv.Spec.CustomResourceDefinitions.Owned, crdDesc)
-			} else if csvParams.OBCMode == OBCRequired {
+			} else if csvParams == nil || csvParams.OBCMode == OBCRequired {
 				csv.Spec.CustomResourceDefinitions.Required = append(csv.Spec.CustomResourceDefinitions.Required, crdDesc)
-			}
+			} // else OBCMode == OBCNone, do nothing
 		} else {
 			csv.Spec.CustomResourceDefinitions.Required = append(csv.Spec.CustomResourceDefinitions.Required, crdDesc)
 		}


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. fixes a bug introduced in PR #960 
2. when `csvParams == nil`, the default is to require OBC

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #961

### Testing Instructions:
1. run `noobaa olm csv` 
2. the command should print the CSV instead of crashing 

- [ ] Doc added/updated
- [ ] Tests added
