### PR TITLE
golangci lint 1.48.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,11 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45.2
+          version: v1.48.0
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/pkg/admission/validator.go
+++ b/pkg/admission/validator.go
@@ -3,7 +3,7 @@ package admission
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
@@ -28,7 +28,7 @@ func (gs *ServerHandler) serve(w http.ResponseWriter, r *http.Request) {
 	var arResponse admissionv1.AdmissionReview
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -3,7 +3,7 @@ package backingstore
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -618,7 +618,7 @@ func RunCreateGoogleCloudStorage(cmd *cobra.Command, args []string) {
 
 		if secretName == "" {
 			privateKeyJSONFile := util.GetFlagStringOrPrompt(cmd, "private-key-json-file")
-			bytes, err := ioutil.ReadFile(privateKeyJSONFile)
+			bytes, err := os.ReadFile(privateKeyJSONFile)
 			if err != nil {
 				log.Fatalf("Failed to read file %q: %v", privateKeyJSONFile, err)
 			}

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,7 +43,7 @@ func main() {
 				return nil
 			}
 			name := compiledNameRE.ReplaceAllString(path, "_")
-			bytes, err := ioutil.ReadFile(filepath.Clean(path))
+			bytes, err := os.ReadFile(filepath.Clean(path))
 			fatal(err)
 			sha256Bytes := sha256.Sum256(bytes)
 			sha256Hex := hex.EncodeToString(sha256Bytes[:])

--- a/pkg/nb/rpc_http.go
+++ b/pkg/nb/rpc_http.go
@@ -3,7 +3,7 @@ package nb
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -57,7 +57,7 @@ func (c *RPCConnHTTP) Call(req *RPCMessage, res RPCResponse) error {
 		return err
 	}
 
-	resBytes, err := ioutil.ReadAll(httpResponse.Body)
+	resBytes, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/nb/rpc_ws.go
+++ b/pkg/nb/rpc_ws.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 	"time"
 
@@ -112,7 +111,7 @@ func (c *RPCConnWS) ConnectUnderLock() error {
 	}
 
 	logrus.Infof("RPC: Connecting websocket (%p) %+v", c, c)
-	dialCtx, dialCancel := context.WithTimeout(context.Background(), connectTimeout) 
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer dialCancel()
 	ws, _, err := websocket.Dial(dialCtx, c.Address, &websocket.DialOptions{HTTPClient: &c.RPC.HTTPClient})
 	if err != nil {
@@ -321,7 +320,7 @@ func (c *RPCConnWS) ReadMessage() (*RPCMessage, error) {
 
 	// Read message buffers if any
 	if msg.Buffers != nil && len(msg.Buffers) > 0 {
-		buffers, err := ioutil.ReadAll(reader)
+		buffers, err := io.ReadAll(reader)
 		// if err != nil && err.Error() != "failed to read: cannot use EOFed reader" {
 		if err != nil {
 			return nil, err

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -3,7 +3,6 @@ package olm
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -206,7 +205,7 @@ func RunCatalog(cmd *cobra.Command, args []string) {
 
 	util.Panic(os.MkdirAll(versionDir, 0755))
 	if !forODF {
-		util.Panic(ioutil.WriteFile(dir+"noobaa-operator.package.yaml", pkgBytes, 0644))
+		util.Panic(os.WriteFile(dir+"noobaa-operator.package.yaml", pkgBytes, 0644))
 	}
 	util.Panic(util.WriteYamlFile(csvFileName, GenerateCSV(opConf, csvParams)))
 	crd.ForEachCRD(func(c *crd.CRD) {

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -751,7 +751,7 @@ func (r *Reconciler) prepareAWSSTSBackingStore() error {
 	if err != nil {
 		return err
 	}
-	bytes, err := ioutil.ReadFile(projectedServiceAccountTokenFile)
+	bytes, err := os.ReadFile(projectedServiceAccountTokenFile)
 	if err != nil {
 		r.Logger.Errorf("Failed to read file %q: %v", projectedServiceAccountTokenFile, err)
 		return err

--- a/pkg/util/kms/kms_vault.go
+++ b/pkg/util/kms/kms_vault.go
@@ -2,7 +2,6 @@ package kms
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
@@ -14,18 +13,18 @@ import (
 
 // Vault authentication config options
 const (
-	VaultAddr               = "VAULT_ADDR"
-	VaultCaCert             = "VAULT_CACERT"
-	VaultClientCert         = "VAULT_CLIENT_CERT"
-	VaultClientKey          = "VAULT_CLIENT_KEY"
-	VaultSkipVerify         = "VAULT_SKIP_VERIFY"
-	VaultToken              = "VAULT_TOKEN"
-	RootSecretPath          = "NOOBAA_ROOT_SECRET_PATH"
+	VaultAddr       = "VAULT_ADDR"
+	VaultCaCert     = "VAULT_CACERT"
+	VaultClientCert = "VAULT_CLIENT_CERT"
+	VaultClientKey  = "VAULT_CLIENT_KEY"
+	VaultSkipVerify = "VAULT_SKIP_VERIFY"
+	VaultToken      = "VAULT_TOKEN"
+	RootSecretPath  = "NOOBAA_ROOT_SECRET_PATH"
 )
 
 // Vault is a vault driver
 type Vault struct {
-	UID string  // NooBaa system UID
+	UID string // NooBaa system UID
 }
 
 // NewVault is vault driver constructor
@@ -33,7 +32,7 @@ func NewVault(
 	name string,
 	namespace string,
 	uid string,
-) (Driver) {
+) Driver {
 	return &Vault{uid}
 }
 
@@ -104,7 +103,7 @@ func (v *Vault) DeleteContext() map[string]string {
 //
 
 // tlsConfig create temp files with TLS keys and certs
-func tlsConfig(config map[string]interface{}, namespace string) (error) {
+func tlsConfig(config map[string]interface{}, namespace string) error {
 	secret := &corev1.Secret{}
 	secret.Namespace = namespace
 
@@ -153,13 +152,13 @@ func writeCrtsToFile(secretName string, namespace string, secretValue []byte, en
 	}
 
 	// Generate a temp file
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to generate temp file for k8s secret %q content, %v", secretName, err)
 	}
 
 	// Write into a file
-	err = ioutil.WriteFile(file.Name(), secretValue, 0444)
+	err = os.WriteFile(file.Name(), secretValue, 0444)
 	if err != nil {
 		return "", fmt.Errorf("failed to write k8s secret %q content to a file %v", secretName, err)
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -133,7 +132,7 @@ func AddToRootCAs(localCertFile string) error {
 	}
 
 	// Read in the cert file
-	certs, err := ioutil.ReadFile(localCertFile)
+	certs, err := os.ReadFile(localCertFile)
 	if err != nil {
 		log.Errorf("Failed to append %q to RootCAs: %v", localCertFile, err)
 		return err
@@ -1198,7 +1197,7 @@ func DiscoverOAuthEndpoints() (*OAuth2Endpoints, error) {
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -1528,7 +1527,7 @@ func DeleteStorageClass(sc *storagev1.StorageClass) error {
 func LoadBucketReplicationJSON(replicationJSONFilePath string) (string, error) {
 
 	logrus.Infof("loading bucket replication %v", replicationJSONFilePath)
-	bytes, err := ioutil.ReadFile(replicationJSONFilePath)
+	bytes, err := os.ReadFile(replicationJSONFilePath)
 	if err != nil {
 		return "", fmt.Errorf("Failed to read file %q: %v", replicationJSONFilePath, err)
 	}


### PR DESCRIPTION
Several PRs are failing, see for instance https://github.com/noobaa/noobaa-operator/pull/970, https://github.com/noobaa/noobaa-operator/pull/964

- Bump golangci lint to 1.48.0
- Handle ioutil deprecation
