### PR TITLE
[BACKPORT to 5.10] throw temporary error when INVALID_SCHEMA_PARAMS returned from CheckE…

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -836,11 +836,6 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 
 	res, err := r.NBClient.CheckExternalConnectionAPI(*r.AddExternalConnectionParams)
 	if err != nil {
-		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
-			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
-			}
-		}
 		return err
 	}
 

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -838,7 +838,7 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 	if err != nil {
 		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
 			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return util.NewPersistentError("InvalidConnectionParams", rpcErr.Message)
+				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
 			}
 		}
 		return err

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -636,7 +636,7 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 		logrus.Infof("ReconcileExternalConnection3 %+v", err)
 		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
 			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return util.NewPersistentError("InvalidConnectionParams", rpcErr.Message)
+				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
 			}
 		}
 		return err

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -633,12 +633,6 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 
 	res, err := r.NBClient.CheckExternalConnectionAPI(*r.AddExternalConnectionParams)
 	if err != nil {
-		logrus.Infof("ReconcileExternalConnection3 %+v", err)
-		if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
-			if rpcErr.RPCCode == "INVALID_SCHEMA_PARAMS" {
-				return fmt.Errorf("InvalidSchemaParams  Message=%s", rpcErr.Message)
-			}
-		}
 		return err
 	}
 


### PR DESCRIPTION
### Explain the changes
1. backport of https://github.com/noobaa/noobaa-operator/pull/955 to 5.10
2. backport of https://github.com/noobaa/noobaa-operator/pull/953/files to 5.10

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
