### PR TITLE
Fix AWS STS checkExternalConnection to pass AWSSTSARN

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -889,6 +889,7 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 		Identity:     r.AddExternalConnectionParams.Identity,
 		Secret:       r.AddExternalConnectionParams.Secret,
 		AuthMethod:   r.AddExternalConnectionParams.AuthMethod,
+		AWSSTSARN:    r.AddExternalConnectionParams.AWSSTSARN,
 	}
 
 	if r.UpdateExternalConnectionParams != nil {

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -684,6 +684,7 @@ type CheckExternalConnectionParams struct {
 	Identity               string          `json:"identity"`
 	Secret                 string          `json:"secret"`
 	AuthMethod             CloudAuthMethod `json:"auth_method,omitempty"`
+	AWSSTSARN              string          `json:"aws_sts_arn,omitempty"`
 	IgnoreNameAlreadyExist bool            `json:"ignore_name_already_exist,omitempty"`
 }
 


### PR DESCRIPTION
Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>

### Explain the changes
1. Added `AWSSTSARN` field to CheckExternalConnectionsParams
2. Added AWSSTSARN value from AddExternalConnectionParams to CheckExternalConnectionsParams

### Issues: Fixed #xxx / Gap #xxx
1. The CheckExternalConnectionsApi was not passing the RoleArn for existing target bucket.

### Testing Instructions:
1. Use noobaa cli to deploy a AWS STS default backingstore
2. Example : nb system create  --default-backingstore-spec="{\"type\": \"aws-s3\", \"awsS3\": {\"awsSTSRoleARN\": \"arn:aws:iam::261532230807:role/kmajumder_noobaa_sts\", \"region\": \"ap-south-1\",\"targetBucket\":\"nb-target-bucket-1\"}}"

- [ ] Doc added/updated
- [ ] Tests added
