### PR TITLE
[5.10] Update the z version in version.go file from 5.10.1 to 5.10.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ out-of-cluster.
 ```shell
 $ noobaa version
 
-INFO[0000] CLI version: 5.10.1
-INFO[0000] noobaa-image: noobaa/noobaa-core:5.10.1
-INFO[0000] operator-image: noobaa/noobaa-operator:5.10.1
+INFO[0000] CLI version: 5.10.6
+INFO[0000] noobaa-image: noobaa/noobaa-core:5.10.6
+INFO[0000] operator-image: noobaa/noobaa-operator:5.10.6
 
 ```
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1,6 +1,6 @@
 package bundle
 
-const Version = "5.10.1"
+const Version = "5.10.6"
 
 const Sha256_deploy_cluster_role_yaml = "b3be23b51cbfad068dcf49bffa5f6af04c99dfc9623e2656f872e5f0643a8aeb"
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 const (
 	// Version is the noobaa-operator version (semver)
-	Version = "5.10.1"
+	Version = "5.10.6"
 )


### PR DESCRIPTION
### Explain the changes
1. Bump the z stream version to 5.10.6(it was pointing to older version)
