### PR TITLE
Support OCP injected CA

### DIFF
--- a/deploy/internal/configmap-ca-inject.yaml
+++ b/deploy/internal/configmap-ca-inject.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: noobaa-ca-inject
+data: {}

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3153,6 +3153,17 @@ spec:
     skipServiceCheck: true
 `
 
+const Sha256_deploy_internal_configmap_ca_inject_yaml = "75f8ab503a683bcebd2ed6a2c9f8da0a4c174a62b4e6ca7e97ebc3da847ca866"
+
+const File_deploy_internal_configmap_ca_inject_yaml = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: noobaa-ca-inject
+data: {}
+`
+
 const Sha256_deploy_internal_configmap_empty_yaml = "6405c531c6522ecd54808f5cb531c1001b9ad01a73917427c523a92be44f348f"
 
 const File_deploy_internal_configmap_empty_yaml = `apiVersion: v1

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -49,6 +49,10 @@ func (r *Reconciler) ReconcilePhaseCreating() error {
 			r.NooBaaMongoDB.Name, r.NooBaaMongoDB.Spec.ServiceName)
 	}
 
+	if err := r.ReconcileCAInject(); err != nil {
+		return err
+	}
+
 	if err := r.ReconcileObject(r.ServiceAccount, r.SetDesiredServiceAccount); err != nil {
 		return err
 	}
@@ -470,7 +474,15 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 			if r.NooBaa.Spec.CoreResources != nil {
 				c.Resources = *r.NooBaa.Spec.CoreResources
 			}
-		}
+			if util.KubeCheckQuiet(r.CaBundleConf) {
+				configMapVolumeMounts := []corev1.VolumeMount {{
+					Name:      r.CaBundleConf.Name,
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					ReadOnly: true,
+				}}
+				util.MergeVolumeMountList(&c.VolumeMounts, &configMapVolumeMounts)
+			}
+}
 	}
 	if r.NooBaa.Spec.ImagePullSecret == nil {
 		podSpec.ImagePullSecrets =
@@ -515,6 +527,24 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 		replicas = int32(0)
 	}
 	r.CoreApp.Spec.Replicas = &replicas
+
+	if util.KubeCheckQuiet(r.CaBundleConf) {
+		configMapVolumes := []corev1.Volume {{
+			Name: r.CaBundleConf.Name,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: r.CaBundleConf.Name,
+					},
+					Items: []corev1.KeyToPath{{
+						Key:  "ca-bundle.crt",
+						Path: "tls-ca-bundle.pem",
+					}},
+				},
+			},
+		}}
+		util.MergeVolumeList(&podSpec.Volumes, &configMapVolumes)
+	}
 	return nil
 }
 
@@ -715,6 +745,24 @@ func (r *Reconciler) ReconcileIBMCredentials() error {
 	if r.IBMCloudCOSCreds.UID == "" {
 		r.Logger.Infof("%q secret is not present", r.IBMCloudCOSCreds.Name)
 		return nil
+	}
+	return nil
+}
+
+// ReconcileCAInject checks if a namespace called openshift-config exist (OCP)
+// if so creates a cofig map for OCP to inject supported CAs to
+func (r *Reconciler) ReconcileCAInject() error {
+	ocpConfigNamespace := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-config",
+		},
+	}
+	if util.KubeCheckQuiet(ocpConfigNamespace) {
+		r.Logger.Infof("Found openshift-config ns - will reconcile CA inject configmap: %q", r.CaBundleConf.Name)
+		if err := r.ReconcileObject(r.CaBundleConf, nil); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -419,6 +419,30 @@ func (r *Reconciler) setDesiredEndpointMounts(podSpec *corev1.PodSpec, container
 	podSpec.Volumes = r.DefaultDeploymentEndpoint.Volumes
 	container.VolumeMounts = r.DefaultDeploymentEndpoint.Containers[0].VolumeMounts
 
+	if util.KubeCheckQuiet(r.CaBundleConf) {
+		configMapVolumes := []corev1.Volume {{
+			Name: r.CaBundleConf.Name,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: r.CaBundleConf.Name,
+					},
+					Items: []corev1.KeyToPath{{
+						Key:  "ca-bundle.crt",
+						Path: "tls-ca-bundle.pem",
+					}},
+				},
+			},
+		}}
+		util.MergeVolumeList(&podSpec.Volumes, &configMapVolumes)
+		configMapVolumeMounts := []corev1.VolumeMount {{
+			Name:      r.CaBundleConf.Name,
+			MountPath: "/etc/pki/ca-trust/extracted/pem",
+			ReadOnly: true,
+		}}
+		util.MergeVolumeMountList(&container.VolumeMounts, &configMapVolumeMounts)
+	}
+
 	for _, nsStore := range namespaceStoreList.Items {
 		// Since namespacestore is able to get a rejected state on runtime errors,
 		// we want to skip namespacestores with invalid configuration only.

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -113,6 +113,7 @@ type Reconciler struct {
 	HPAEndpoint               *autoscalingv1.HorizontalPodAutoscaler
 	JoinSecret                *corev1.Secret
 	UpgradeJob                *batchv1.Job
+	CaBundleConf              *corev1.ConfigMap
 }
 
 // NewReconciler initializes a reconciler to be used for loading or reconciling a noobaa system
@@ -169,6 +170,7 @@ func NewReconciler(
 		DeploymentEndpoint:  util.KubeObject(bundle.File_deploy_internal_deployment_endpoint_yaml).(*appsv1.Deployment),
 		HPAEndpoint:         util.KubeObject(bundle.File_deploy_internal_hpa_endpoint_yaml).(*autoscalingv1.HorizontalPodAutoscaler),
 		UpgradeJob:          util.KubeObject(bundle.File_deploy_internal_job_upgrade_db_yaml).(*batchv1.Job),
+		CaBundleConf:        util.KubeObject(bundle.File_deploy_internal_configmap_ca_inject_yaml).(*corev1.ConfigMap),
 	}
 
 	// Set Namespace
@@ -211,6 +213,7 @@ func NewReconciler(
 	r.DeploymentEndpoint.Namespace = r.Request.Namespace
 	r.HPAEndpoint.Namespace = r.Request.Namespace
 	r.UpgradeJob.Namespace = r.Request.Namespace
+	r.CaBundleConf.Namespace = r.Request.Namespace
 
 	// Set Names
 	r.NooBaa.Name = r.Request.Name
@@ -250,6 +253,7 @@ func NewReconciler(
 	r.DeploymentEndpoint.Name = r.Request.Name + "-endpoint"
 	r.HPAEndpoint.Name = r.Request.Name + "-endpoint"
 	r.UpgradeJob.Name = r.Request.Name + "-upgrade-job"
+	r.CaBundleConf.Name = r.Request.Name + "-ca-inject"
 
 	// Set the target service for routes.
 	r.RouteMgmt.Spec.To.Name = r.ServiceMgmt.Name


### PR DESCRIPTION
Signed-off-by: jackyalbo <jalbo@redhat.com>

### Explain the changes
following this documentation: https://docs.openshift.com/container-platform/4.11/networking/configuring-a-custom-pki.html
1. Add support for OCP CA Inject in case we have namespace openshift-config in the cluster
2. It will create a config map name noobaa-inject-ca, which OCP will inject with system supported CA
3. It will attach this config map under "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2121104

### Testing Instructions:
1. Add a backingstore to a compatible S3 which uses a self sign cert.
2. Install the self signed certificate to OCP (following above doc)
3. see that there is no issue with self signed certs when creating backingstore, and when trying to write to it (using OBC) 

- [ ] Doc added/updated
- [ ] Tests added
