### PR TITLE
🪳 Move status account and services instances creation upon first reference

### DIFF
--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -23,6 +23,12 @@ func (r *Reconciler) ReconcilePhaseConnecting() error {
 		"noobaa operator started phase 3/4 - \"Connecting\"",
 	)
 
+	// Make sure services status instance exists
+	// see https://bugzilla.redhat.com/show_bug.cgi?id=2125775
+	if r.NooBaa.Status.Services == nil {
+		r.NooBaa.Status.Services = &nbv1.ServicesStatus{}
+	}
+
 	if r.JoinSecret == nil {
 		r.CheckServiceStatus(r.ServiceMgmt, r.RouteMgmt, &r.NooBaa.Status.Services.ServiceMgmt, "mgmt-https")
 	}

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -110,6 +110,9 @@ func (r *Reconciler) ReconcileSystemSecrets() error {
 		}
 
 		// Point the admin account secret reference to the admin secret.
+		if r.NooBaa.Status.Accounts == nil {
+			r.NooBaa.Status.Accounts = &nbv1.AccountsStatus{}
+		}
 		r.NooBaa.Status.Accounts.Admin.SecretRef.Name = r.SecretAdmin.Name
 		r.NooBaa.Status.Accounts.Admin.SecretRef.Namespace = r.SecretAdmin.Namespace
 	}

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -987,13 +987,6 @@ func CheckSystem(sys *nbv1.NooBaa) bool {
 		}
 	}
 
-	if sys.Status.Accounts == nil {
-		sys.Status.Accounts = &nbv1.AccountsStatus{}
-	}
-	if sys.Status.Services == nil {
-		sys.Status.Services = &nbv1.ServicesStatus{}
-	}
-
 	// a hack to better set the DBType in cases where DBType is not set.
 	// if dbtype is not set, try to infer it from the db image. this only update dbtype in memory
 	if sys.Spec.DBType == "" {


### PR DESCRIPTION
Move status account and services instances creation upon first referenced

See https://bugzilla.redhat.com/show_bug.cgi?id=2125775 
According to the bug, the status services could be nil upon initial reference. Refactor the code to ensure that the status account and services instances are created upon initial reference.

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>