### PR TITLE
changed the way image existence is checked in manual-build workflow

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Update Core Release
         id: update-release
         run: |
-          curl --silent -f -lSL "https://index.docker.io/v1/repositories/noobaa/noobaa-core/tags/${{ github.event.inputs.branch }}-${{ steps.prep.outputs.version }}${{ steps.suffix.outputs.suffix }}" > /dev/null || exit 1
+          docker manifest inspect noobaa/noobaa-core:${{ github.event.inputs.branch }}-${{ steps.prep.outputs.version }}${{ steps.suffix.outputs.suffix }} > /dev/null || exit 1
           echo "::found version ${{ github.event.inputs.branch }}-${{ steps.prep.outputs.version }}${{ steps.suffix.outputs.suffix }}, updating image version"
 
       - name: Login to DockerHub Registry


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. This PR fixes failures in nightly builds. testing for image existence with direct requests to `index.docker.io` now fails with 410
2. testing for noobaa-core image existence with `docker manifest inspect` command, which is independent of docker API directly.
3. based on this [stack overflow answer](https://stackoverflow.com/a/52077346)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
