### PR TITLE
own OB\OBC CRDs when building bundle image

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -84,6 +84,7 @@ jobs:
           core-image=quay.io/${{ github.event.inputs.branch }}-${{ steps.prep.outputs.version }}${{ steps.suffix.outputs.suffix }} \
           operator-image=quay.io/${{ steps.prep.outputs.operatortags }} \
           db-image=centos/postgresql-12-centos7 \
+          obc-crd="owned" \
           BUNDLE_IMAGE=quay.io/${{ steps.prep.outputs.operatorbundletags }}
 
       - name: Login to Quay.io Registry


### PR DESCRIPTION
### Explain the changes
1. this image is used by ocs operator CI. 
2. required for ocs-operator PR https://github.com/red-hat-storage/ocs-operator/pull/1771

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
