### PR TITLE
Handle creating backingstore with the CLI and the "--secret-name" option.

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -364,6 +364,12 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 	}
 
 	populate(backStore, secret)
+	if secretName != "" {
+		if !util.KubeCheck(secret) {
+			log.Fatalf(`❌ Could not find the suggested secret: name %q namespace %q`, secret.Name, secret.Namespace)
+			return
+		}
+	}
 
 	validationErr := validations.ValidateBackingStore(*backStore)
 	if validationErr != nil {

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -327,6 +327,12 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.NSType, popu
 	}
 
 	populate(namespaceStore, secret)
+	if secretName != "" {
+		if !util.KubeCheck(secret) {
+			log.Fatalf(`❌ Could not find the suggested secret: name %q namespace %q`, secret.Name, secret.Namespace)
+			return
+		}
+	}
 
 	suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, string(nbv1.StoreType(namespaceStore.Spec.Type)))
 	if suggestedSecret != nil {
@@ -445,7 +451,7 @@ func RunCreateAWSSTSS3(cmd *cobra.Command, args []string) {
 	namespaceStore := o.(*nbv1.NamespaceStore)
 	namespaceStore.Name = name
 	namespaceStore.Namespace = options.Namespace
-	namespaceStore.Spec =  nbv1.NamespaceStoreSpec{Type: nbv1.NSStoreTypeAWSS3}
+	namespaceStore.Spec = nbv1.NamespaceStoreSpec{Type: nbv1.NSStoreTypeAWSS3}
 
 	if !util.KubeCheck(sys) {
 		log.Fatalf(`❌ Could not find NooBaa system %q in namespace %q`, sys.Name, sys.Namespace)
@@ -478,7 +484,6 @@ func RunCreateAWSSTSS3(cmd *cobra.Command, args []string) {
 		RunStatus(cmd, args)
 	}
 }
-
 
 // RunCreateS3Compatible runs a CLI command
 func RunCreateS3Compatible(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Handle creating backingstore with the CLI and the "--secret-name" option.

The issue symptom, described in the BZ below, is that creating backingstores fails with `"Note that using more than one secret with the same credentials is not supported"`.  Later AWS S3 operations generate `AccessDenied` error.

According to Ben Eli's great analysis, this only happens if we create backing stores with the MCG CLI and the "--secret-name" option.

This change passes the secret pointed by the "--secret-name" option to [`util.CheckForIdenticalSecretsCreds()`](https://github.com/noobaa/noobaa-operator/blob/24022e21a3881fb64d2ddf1eccf799eb4c6c4f01/pkg/util/util.go#L1818) instead of the default `fmt.Sprintf("backing-store-%s-%s", storeType, name)` one.

### Fixed
-  https://bugzilla.redhat.com/show_bug.cgi?id=2121353

