### PR TITLE
[Backport to 5.12] Handle creating backingstore with the CLI and the "--secret-name" option

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -364,6 +364,12 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 	}
 
 	populate(backStore, secret)
+	if secretName != "" {
+		if !util.KubeCheck(secret) {
+			log.Fatalf(`❌ Could not find the suggested secret: name %q namespace %q`, secret.Name, secret.Namespace)
+			return
+		}
+	}
 
 	validationErr := validations.ValidateBackingStore(*backStore)
 	if validationErr != nil {

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -327,6 +327,12 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.NSType, popu
 	}
 
 	populate(namespaceStore, secret)
+	if secretName != "" {
+		if !util.KubeCheck(secret) {
+			log.Fatalf(`❌ Could not find the suggested secret: name %q namespace %q`, secret.Name, secret.Namespace)
+			return
+		}
+	}
 
 	suggestedSecret := util.CheckForIdenticalSecretsCreds(secret, string(nbv1.StoreType(namespaceStore.Spec.Type)))
 	if suggestedSecret != nil {
@@ -445,7 +451,7 @@ func RunCreateAWSSTSS3(cmd *cobra.Command, args []string) {
 	namespaceStore := o.(*nbv1.NamespaceStore)
 	namespaceStore.Name = name
 	namespaceStore.Namespace = options.Namespace
-	namespaceStore.Spec =  nbv1.NamespaceStoreSpec{Type: nbv1.NSStoreTypeAWSS3}
+	namespaceStore.Spec = nbv1.NamespaceStoreSpec{Type: nbv1.NSStoreTypeAWSS3}
 
 	if !util.KubeCheck(sys) {
 		log.Fatalf(`❌ Could not find NooBaa system %q in namespace %q`, sys.Name, sys.Namespace)
@@ -478,7 +484,6 @@ func RunCreateAWSSTSS3(cmd *cobra.Command, args []string) {
 		RunStatus(cmd, args)
 	}
 }
-
 
 // RunCreateS3Compatible runs a CLI command
 func RunCreateS3Compatible(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=2121353

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>
(cherry picked from commit 41cbb87ebfe52dcd809cb5ae3e705b1cdceb8c0b)

### Explain the changes
1. backport of https://github.com/noobaa/noobaa-operator/pull/992

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
