### PR TITLE
Map alternate keys value

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -260,7 +260,7 @@ func (r *Reconciler) LoadBackingStoreSecret() error {
 	if util.IsSTSClusterBS(r.BackingStore) {
 		return nil
 	}
-	
+
 	secretRef, err := util.GetBackingStoreSecret(r.BackingStore)
 	if err != nil {
 		return err
@@ -845,25 +845,10 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 }
 
 func (r *Reconciler) fixAlternateKeysNames() {
-
-	alternateAccessKeyNames := []string{"aws_access_key_id", "AccessKey"}
-	alternateSecretKeyNames := []string{"aws_secret_access_key", "SecretKey"}
-
-	if r.Secret.StringData["AWS_ACCESS_KEY_ID"] == "" {
-		for _, key := range alternateAccessKeyNames {
-			if r.Secret.StringData[key] != "" {
-				r.Secret.StringData["AWS_ACCESS_KEY_ID"] = r.Secret.StringData[key]
-				break
-			}
-		}
-	}
-
-	if r.Secret.StringData["AWS_SECRET_ACCESS_KEY"] == "" {
-		for _, key := range alternateSecretKeyNames {
-			if r.Secret.StringData[key] != "" {
-				r.Secret.StringData["AWS_SECRET_ACCESS_KEY"] = r.Secret.StringData[key]
-				break
-			}
+	keyNames := []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}
+	for _, key := range keyNames {
+		if r.Secret.StringData[key] == "" {
+			r.Secret.StringData[key] = util.MapAlternateKeysValue(r.Secret.StringData, key)
 		}
 	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"testing"
+)
+
+// TestMapAlternateKeysValue a tiny test for util.MapAlternateKeysValue()
+func TestMapAlternateKeysValue(t *testing.T) {
+	keyVal := "XXXXX"
+	altKey := "aws_access_key_id"
+	canonicalKey := "AWS_ACCESS_KEY_ID"
+
+	actualAltValue := MapAlternateKeysValue(map[string]string{
+		altKey: keyVal,
+	}, canonicalKey)
+	if actualAltValue != keyVal {
+		t.Fatalf("Alternative key: expected %q, got %q", keyVal, actualAltValue)
+	}
+
+	actualCanonicalValue := MapAlternateKeysValue(map[string]string{
+		canonicalKey: keyVal,
+	}, canonicalKey)
+	if actualCanonicalValue != keyVal {
+		t.Fatalf("Canonical key: expected %q, got %q", keyVal, actualCanonicalValue)
+	}
+}


### PR DESCRIPTION
Fix util.CheckForIdenticalSecretsCreds() for alternative key names

This issue was noted at #992, according to [this comment](https://github.com/noobaa/noobaa-operator/pull/992#issuecomment-1315069219), util.CheckForIdenticalSecretsCreds() uses an empty string `""` as a value for the backing store secret key & id.
Refactor an existing functionality.
