### PR TITLE
Add workflow for automated NooBaa releases

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,47 @@
+name: Releaser
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'The base branch to release from'
+        required: true 
+
+permissions:
+  contents: write
+
+jobs:
+  releaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set branch
+        run: echo "BRANCH=${{ github.event.inputs.base_branch }}" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BRANCH }}
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHACTION_GH_PAT }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          HOMEBREW_CORE_REPO: ${{ secrets.HOMEBREW_CORE_REPO }}
+          OCI_ORG: ${{ secrets.OCI_ORG }}
+          OPERATOR_HUB_REPO: "k8s-operatorhub/community-operators"
+          TAG: "1"
+        run: |
+          git config --global user.email "github-action@noobaa.io"
+          git config --global user.name "NooBaa GitHub Action"
+
+          bash build/tools/builder.sh --oci-org $OCI_ORG --gh-org noobaa --gh-repo noobaa-operator || exit 1
+          bash build/tools/releaser.sh --oci-org $OCI_ORG --gh-org noobaa --gh-repo noobaa-operator || exit 1
+      # - name: "Krew Release"
+      #   uses: rajatjindal/krew-release-bot@v0.0.40

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,12 +3,13 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV OPERATOR=/usr/local/bin/noobaa-operator \
     USER_UID=1001 \
     USER_NAME=noobaa-operator
+ARG NOOBAA_BIN_PATH=build/_output/bin/noobaa-operator
 
 # tar is needed for kubectl cp
 RUN microdnf install tar
 
 # install operator binary
-COPY build/_output/bin/noobaa-operator ${OPERATOR}
+COPY ${NOOBAA_BIN_PATH} ${OPERATOR}
 
 # copy scripts
 COPY build/bin /usr/local/bin

--- a/build/tools/builder-pre.sh
+++ b/build/tools/builder-pre.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# NOTE: This script can be run manually but is run anyway by builder.sh before that script starts executing its `main`
+
+# This script will automate the file alteration, which involves
+# 1. Updating the README.md
+# 2. Committing the changes and pushing the changes
+
+set -eux
+set -o pipefail
+
+export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
+
+dir=$(dirname "$0")
+
+# Source the utilities
+source $dir/utils.sh
+
+# Variables
+DRY_RUN=${DRY_RUN:="false"}
+
+# Update the version of noobaa core image, noobaa operator image and CLI version in the README output.
+function update_readme() {
+	local version=$(get_noobaa_version)
+	local core_version="$version" # Assume to be the same as the version of operator
+	local readme_file=README.md
+
+	finline_replace "INFO\[0000\] CLI version: .*" "INFO\[0000\] CLI version: ${version}" $readme_file
+	finline_replace "INFO\[0000\] noobaa-image: .*" "INFO\[0000\] noobaa-image: noobaa\/noobaa-core:${core_version}" $readme_file
+	finline_replace "INFO\[0000\] operator-image: .*" "INFO\[0000\] operator-image: noobaa\/noobaa-operator:${version}" $readme_file
+}
+
+function commit_changes() {
+	if [[ $DRY_RUN == "true" ]]; then
+		echo "DRY_RUN is set to true, skipping commiting changes."
+		return
+	fi
+
+	local version=$(get_noobaa_version 1)
+
+	git add .
+	git commit -m "Automated commit to update README for version: ${version}"
+	git push
+
+	# If TAG=1 is provided, then create a tag
+	if [ -n "$TAG" ]; then
+		git tag -a "${version}" -m "Tag for version ${version}"
+		git push origin "${version}"
+	fi
+}
+
+# Main function
+function main() {
+	update_readme
+	commit_changes
+}
+
+main "$@"

--- a/build/tools/builder.sh
+++ b/build/tools/builder.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+
+# This script is supposed to automate various types of artifact generation that this project has
+# to do.
+# Following types of artifacts are supported:
+# 1. Build a new version of the CLI
+# 2. Build a new version of OCI image
+# 3. Generate Krew manifest
+# 4. Generate Homebrew formula
+
+set -eux
+set -o pipefail
+
+export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
+
+dir=$(dirname "$0")
+
+# Source the utilities
+source $dir/utils.sh
+
+bin_path=$dir/artifacts/bin
+krew_path=$dir/artifacts/krew
+homebrew_path=$dir/artifacts/homebrew
+operator_bundle_path=$dir/artifacts/operator-bundle
+dependencies=(go docker make sha256sum git)
+GH_ORG="noobaa"
+GH_REPO="noobaa-operator"
+DRY_RUN="false"
+
+function parse_args() {
+  # Parse command-line arguments.
+  while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --gh-org)
+      GH_ORG="$2"
+      shift
+      ;;
+    --gh-repo)
+      GH_REPO="$2"
+      shift
+      ;;
+    --oci-org)
+      OCI_ORG="$2"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+
+  shift
+  done
+}
+
+function init() {
+  mkdir -p $bin_path
+  mkdir -p $krew_path
+  mkdir -p $homebrew_path
+  mkdir -p $operator_bundle_path
+  parse_args "$@"
+}
+
+function generate_full_bin_path() {
+  local GOOS=$1
+  local GOARCH=$2
+
+  if [ "$GOOS" == "windows" ]; then
+    ext=".exe"
+  else
+    ext=""
+  fi
+
+  echo ${bin_path}/noobaa-$(get_noobaa_version 1)-${GOOS}-${GOARCH}${ext}
+}
+
+function build_cli() {
+  local GOOS=$1
+  local GOARCH=$2
+
+  if [ "$GOOS" == "windows" ]; then
+    ext=".exe"
+  else
+    ext=""
+  fi
+
+  GOOS=$GOOS GOARCH=$GOARCH go build -o $(generate_full_bin_path $GOOS $GOARCH) main.go
+}
+
+function build_cli_for_all() {
+  build_cli linux amd64
+  build_cli linux arm64
+  build_cli darwin amd64
+  build_cli darwin arm64
+}
+
+function build_oci() {
+  local tag_prefix=$1
+  local os=linux
+  local arch=amd64
+
+  docker build --platform $os/$arch --build-arg NOOBAA_BIN_PATH=$(generate_full_bin_path $os $arch) -t $tag_prefix/noobaa-operator:$(get_noobaa_version) -f build/Dockerfile .
+}
+
+function generate_krew_manifest() {
+  cat <<EOF > $krew_path/noobaa.yaml
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: noobaa
+spec:
+  version: $(get_noobaa_version 1)
+  homepage: https://github.com/$GH_ORG/$GH_REPO
+  shortDescription: Manage the NooBaa operator and its resources
+  description: |
+    This plugin packages the entire NooBaa (aka Multi Cloud Gateway) CLI hence allows 
+    you to manage the NooBaa operator and its resources.
+
+    # Install the operator
+    kubectl noobaa install -n <namespace>
+
+    # Get the status of the operator
+    kubectl noobaa status -n <namespace>
+
+    It can also be used to create, delete, and manage NooBaa resources.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+      uri: https://github.com/$GH_ORG/$GH_REPO/releases/download/$(get_noobaa_version 1)/noobaa-$(get_noobaa_version 1)-linux-amd64.tar.gz
+      sha256: $(sha256sum $(generate_full_bin_path linux amd64) | cut -d ' ' -f 1)
+      bin: noobaa-operator
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+      uri: https://github.com/$GH_ORG/$GH_REPO/releases/download/$(get_noobaa_version 1)/noobaa-$(get_noobaa_version 1)-darwin-amd64.tar.gz
+      sha256: $(sha256sum $(generate_full_bin_path darwin amd64) | cut -d ' ' -f 1)
+      bin: noobaa-operator
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+      uri: https://github.com/$GH_ORG/$GH_REPO/releases/download/$(get_noobaa_version 1)/noobaa-$(get_noobaa_version 1)-darwin-arm64.tar.gz
+      sha256: $(sha256sum $(generate_full_bin_path darwin arm64) | cut -d ' ' -f 1)
+      bin: noobaa-operator
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+      uri: https://github.com/$GH_ORG/$GH_REPO/releases/download/$(get_noobaa_version 1)/noobaa-$(get_noobaa_version 1)-linux-arm64.tar.gz
+      sha256: $(sha256sum $(generate_full_bin_path linux arm64) | cut -d ' ' -f 1)
+      bin: noobaa-operator
+EOF
+}
+
+function generate_homebrew_formula() {
+  cat <<EOF > $homebrew_path/noobaa.rb
+class Noobaa < Formula
+  desc "CLI for managing NooBaa S3 service on Kubernetes/Openshift"
+  homepage "https://github.com/$GH_ORG/$GH_REPO"
+  url "https://github.com/$GH_ORG/$GH_REPO.git",
+      :tag      => "$(get_noobaa_version 1)",
+      :revision => "$(git rev-list -n 1 $(get_noobaa_version 1) || echo HEAD)"
+  head "https://github.com/$GH_ORG/$GH_REPO.git"
+
+  depends_on "go" => [:build, :test]
+
+  def install
+    ENV.deparallelize # avoid parallel make jobs
+    ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "on"
+    ENV["GOPROXY"] = "https://proxy.golang.org"
+
+    src = buildpath/"src/github.com/$GH_ORG/$GH_REPO"
+    src.install buildpath.children
+    src.cd do
+      system "go", "mod", "vendor"
+      system "go", "generate"
+      system "go", "build"
+      bin.install "noobaa-operator" => "noobaa"
+    end
+  end
+
+  test do
+    output = `#{bin}/noobaa version 2>&1`
+    pos = output.index "CLI version: $(get_noobaa_version)"
+    raise "Version check failed" if pos.nil?
+
+    puts "Success"
+  end
+end
+EOF
+}
+
+function generate_operator_bundle() {
+  make gen-olm
+  \cp -rf build/_output/olm/** $operator_bundle_path/
+}
+
+function main() {
+  check_deps "${dependencies[@]}"
+  build_cli_for_all
+  build_oci ${OCI_ORG:-noobaa}
+  generate_krew_manifest
+  generate_homebrew_formula
+  generate_operator_bundle
+}
+
+function usage() {
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  --help"
+  echo "  --dry-run - enable dry run (will not prevent artifacts generation but will prevent git commits and pushes)"
+  echo "  --gh-org <org> - set the github organization (default: noobaa)"
+  echo "  --gh-repo <repo> - set the github repository (default: noobaa-operator)"
+  echo "  --oci-org <org> - set the org name for the OCI image (default: noobaa)"
+}
+
+init "$@"
+
+if [ -f "$dir/builder-pre.sh" ]; then
+  DRY_RUN="$DRY_RUN" bash "$dir/builder-pre.sh"
+fi
+
+main "$@"
+
+if [ -f "$dir/builder-post.sh" ]; then
+  DRY_RUN="$DRY_RUN" bash "$dir/builder-post.sh"
+fi

--- a/build/tools/releaser-post.sh
+++ b/build/tools/releaser-post.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# This script will automate the file alteration, which involves
+# 1. Updating the version of the CLI in version/version.go
+# 2. Updating the version of noobaa core image in pkg/options.go => ContainerImageTag
+# 3. Run make gen
+# 4. Commit the changes with an automated commit message
+
+set -eux
+set -o pipefail
+
+export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
+
+dir=$(dirname "$0")
+
+# Source the utilities
+source $dir/utils.sh
+
+version=$(bump_semver_patch $(get_noobaa_version))
+DRY_RUN=${DRY_RUN:="false"}
+
+# Update version of the CLI in version/version.go
+function update_version() {
+  local version_file=version/version.go
+  # Replace the version line with the new version using perl because sed is not compatible with both mac and linux
+  # and awk solution is clumsy
+  finline_replace "Version = \".*\"" "Version = \"${version}\"" $version_file
+}
+
+# Update version of noobaa core image in pkg/options.go => ContainerImageTag
+function update_core_container_image_tag() {
+  local options_file=pkg/options/options.go
+  # Replace version line with new version using perl because sed is not compatible with both mac and linux
+  # and awk solution is clumsy
+  finline_replace ".*ContainerImageTag = \".*\"" "	ContainerImageTag = \"${version}\"" $options_file
+}
+
+# Run make gen
+function run_make_gen() {
+  make gen
+}
+
+# Commit the changes with automated commit message
+function commit_changes() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY_RUN is set to true: skipping commiting post release changes"
+    return
+  fi
+
+  git add .
+  git commit -m "Automated commit: Bump version to ${version}"
+  git push
+}
+
+# Main function
+function main() {
+  update_version
+  update_core_container_image_tag
+  run_make_gen
+  commit_changes
+}
+
+main "$@"

--- a/build/tools/releaser.sh
+++ b/build/tools/releaser.sh
@@ -1,0 +1,366 @@
+#!/bin/bash
+
+set -euox pipefail
+
+dir=$(dirname "$0")
+
+export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
+
+# Source the utilities
+source $dir/utils.sh
+
+dependencies=(docker sha256sum git gh yq)
+
+# Default values for the arguments.
+GH_ORG="noobaa"
+GH_REPO="noobaa-operator"
+OCI_ORG="noobaa"
+DRY_RUN="false"
+DRAFT="false"
+ONLY_GH="false"
+ONLY_OCI="false"
+ONLY_HOMEBREW="false"
+ONLY_OPERATOR_HUB="false"
+
+# Default values for the environment variables.
+ARTIFACTS_PATH=${ARTIFACTS_PATH:-$dir/artifacts}
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-}
+DOCKERHUB_TOKEN=${DOCKERHUB_TOKEN:-}
+QUAY_USERNAME=${QUAY_USERNAME:-}
+QUAY_TOKEN=${QUAY_TOKEN:-}
+HOMEBREW_CORE_REPO=${HOMEBREW_CORE_REPO:-}
+OPERATOR_HUB_REPO=${OPERATOR_HUB_REPO:-}
+
+function check_environment_variables() {
+  if [[ -z "${GITHUB_TOKEN}" ]]; then
+    echo "GITHUB_TOKEN environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${DOCKERHUB_USERNAME}" ]]; then
+    echo "DOCKERHUB_USERNAME environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${DOCKERHUB_TOKEN}" ]]; then
+    echo "DOCKERHUB_TOKEN environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${QUAY_USERNAME}" ]]; then
+    echo "QUAY_USERNAME environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${QUAY_TOKEN}" ]]; then
+    echo "QUAY_TOKEN environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${HOMEBREW_CORE_REPO}" ]]; then
+    echo "HOMEBREW_CORE_REPO environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${ARTIFACTS_PATH}" ]]; then
+    echo "ARTIFACTS_PATH environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${OPERATOR_HUB_REPO}" ]]; then
+    echo "OPERATOR_HUB_REPO environment variable is not set."
+    exit 1
+  fi
+}
+
+function parse_args() {
+  # Parse command-line arguments.
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --gh-org)
+      GH_ORG="$2"
+      shift
+      ;;
+    --gh-repo)
+      GH_REPO="$2"
+      shift
+      ;;
+    --oci-org)
+      OCI_ORG="$2"
+      shift
+      ;;
+    --only-gh)
+      ONLY_GH="true"
+      ;;
+    --only-oci)
+      ONLY_OCI="true"
+      ;;
+    --only-homebrew)
+      ONLY_HOMEBREW="true"
+      ;;
+    --only-operator-hub)
+      ONLY_OPERATOR_HUB="true"
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      ;;
+    --draft)
+      DRAFT="true"
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+    esac
+    shift
+  done
+}
+
+function prepare_release() {
+  local os="$1"
+  local arch="$2"
+  local version=$(get_noobaa_version 1)
+
+  # Create a temporary directory to store the release files.
+  local release_dir=$(mktemp -d)
+  echo "Created a temporary directory for the release: ${release_dir}"
+
+  cp "$ARTIFACTS_PATH/bin/noobaa-$version-$os-$arch" "$release_dir/noobaa-operator"
+  cp "LICENSE" "$release_dir/LICENSE"
+
+  # Create the release archive.
+  local release_archive="$ARTIFACTS_PATH/release/noobaa-operator-$version-$os-$arch.tar.gz"
+  tar -czf "$release_archive" -C "$release_dir" .
+  echo "Created the release archive: ${release_archive}"
+
+  # Create the release checksum.
+  local release_checksum="noobaa-operator-$version-$os-$arch.tar.gz.sha256"
+  (
+    cd $ARTIFACTS_PATH/release
+    sha256sum "noobaa-operator-$version-$os-$arch.tar.gz" >"$release_checksum"
+  )
+  echo "Created the release checksum: ${release_checksum}"
+
+  # Remove the temporary directory.
+  rm -rf "$release_dir"
+}
+
+function create_gh_release() {
+  # Generate all the release files.
+  prepare_release "linux" "amd64"
+  prepare_release "darwin" "amd64"
+  prepare_release "linux" "arm64"
+  prepare_release "darwin" "arm64"
+
+  # Create the release on GitHub using gh and github REST API
+  # https://cli.github.com/manual/gh_release_create
+  # https://docs.github.com/en/rest/reference/repos#create-a-release
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY_RUN is set, skipping Github release creation."
+    return
+  fi
+
+  # Create the release on GitHub.
+  echo "Creating the release on GitHub..."
+  gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    /repos/$GH_ORG/$GH_REPO/releases \
+    -f tag_name="$(get_noobaa_version 1)" \
+    -f name="$(get_noobaa_version 1)" \
+    -f body="Release $(get_noobaa_version 1)" \
+    -F draft="$DRAFT" \
+    -F generate_release_notes="true"
+
+  # Upload the release files to GitHub.
+  echo "Uploading the release files to GitHub..."
+  gh release upload "$(get_noobaa_version 1)" \
+    "$ARTIFACTS_PATH/release/noobaa-operator-$(get_noobaa_version 1)-linux-amd64.tar.gz" \
+    "$ARTIFACTS_PATH/release/noobaa-operator-$(get_noobaa_version 1)-linux-amd64.tar.gz.sha256" \
+    "$ARTIFACTS_PATH/release/noobaa-operator-$(get_noobaa_version 1)-darwin-amd64.tar.gz" \
+    "$ARTIFACTS_PATH/release/noobaa-operator-$(get_noobaa_version 1)-darwin-amd64.tar.gz.sha256" \
+    "$ARTIFACTS_PATH/release/noobaa-operator-$(get_noobaa_version 1)-linux-arm64.tar.gz" \
+    "$ARTIFACTS_PATH/release/noobaa-operator-$(get_noobaa_version 1)-linux-arm64.tar.gz.sha256" \
+    "$ARTIFACTS_PATH/release/noobaa-operator-$(get_noobaa_version 1)-darwin-arm64.tar.gz" \
+    "$ARTIFACTS_PATH/release/noobaa-operator-$(get_noobaa_version 1)-darwin-arm64.tar.gz.sha256"
+}
+
+function create_oci_release() {
+  # Release OCI images to docker and quay.io
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY_RUN is set, skipping OCI release creation."
+    return
+  fi
+
+  local quay_image="quay.io/$QUAY_USERNAME/noobaa-operator:$(get_noobaa_version)"
+  local docker_image="$DOCKERHUB_USERNAME/noobaa-operator:$(get_noobaa_version)"
+
+  echo "Tagging the images..."
+  docker tag "$OCI_ORG/noobaa-operator:$(get_noobaa_version)" $quay_image
+  docker tag "$OCI_ORG/noobaa-operator:$(get_noobaa_version)" $docker_image
+
+  echo "Logging in to docker.io..."
+  echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+
+  echo "Pushing the images to docker.io..."
+  docker push $docker_image
+
+  echo "Logging in to quay.io..."
+  echo "$QUAY_TOKEN" | docker login -u "$QUAY_USERNAME" --password-stdin quay.io
+
+  echo "Pushing the images to quay.io..."
+  docker push $quay_image
+}
+
+function create_krew() {
+  # Rely on the krew-release-bot to create the krew release
+  \cp "$ARTIFACTS_PATH/krew/noobaa.yaml" "./.krew.yaml"
+
+  return
+}
+
+function release_homebrew() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY_RUN is set, skipping homebrew release creation."
+    return
+  fi
+
+  local version=$(get_noobaa_version 1)
+
+  local homebrew_dir=$(mktemp -d)
+  echo "Created a temporary directory for homebrew-core: ${homebrew_dir}"
+
+  echo "Cloning homebrew-core..."
+  git clone https://$GITHUB_TOKEN@github.com/$HOMEBREW_CORE_REPO $homebrew_dir
+
+  echo "Updating the manifest..."
+  mkdir -p "$homebrew_dir/Formula"
+  cp "$ARTIFACTS_PATH/homebrew/noobaa.rb" "$homebrew_dir/Formula/noobaa.rb"
+
+  pushd $homebrew_dir
+
+  echo "Committing the changes..."
+  git add "Formula/noobaa.rb"
+  git commit -s -m "noobaa-operator $version"
+
+  echo "Pushing the changes..."
+  git push -u origin master
+
+  popd
+
+  echo "Cleaning up..."
+  rm -rf "$homebrew_dir"
+}
+
+function release_operatorhub() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY_RUN is set, skipping OLM release creation."
+    return
+  fi
+
+  local version=$(get_noobaa_version)
+
+  local operatorhub_dir=$(mktemp -d)
+  echo "Created a temporary directory for operatorhub.io: ${operatorhub_dir}"
+
+  echo "Cloning operatorhub.io..."
+  git clone https://$GITHUB_TOKEN@github.com/$OPERATOR_HUB_REPO $operatorhub_dir
+
+  pushd $operatorhub_dir
+
+  echo "Forking operatorhub.io..."
+  gh repo fork --remote
+  git remote set-url origin $(git remote get-url origin | sed -r "s/https:\/\/(.*)/https:\/\/$GITHUB_TOKEN\@\1/")
+
+  echo "Updating the manifest..."
+  git checkout -b "noobaa-operator-$version"
+
+  local last_version=$(cd operators/noobaa-operator && printf "%s\n" */ | sort -V | sed -e 's-/$--' | tail -n 1)
+  popd
+
+  mkdir -p "$operatorhub_dir/operators/noobaa-operator/"
+  # \cp is to bypass aliasing of cp to cp -i
+  \cp -rf $ARTIFACTS_PATH/operator-bundle/* "$operatorhub_dir/operators/noobaa-operator/"
+
+  pushd $operatorhub_dir
+
+  pushd "operators/noobaa-operator/"
+  # Update the ".spec.replaces" field in the CSV
+  yq -i ".spec.replaces = \"noobaa-operator.v$last_version\"" "$version/noobaa-operator.v$version.clusterserviceversion.yaml"
+  popd
+
+  echo "Committing the changes..."
+  git add "operators/noobaa-operator/"
+  git commit -s -m "noobaa-operator $version"
+
+  echo "Pushing the changes..."
+  git push -u origin "noobaa-operator-$version"
+
+  echo "Creating a pull request..."
+  gh pr create --title "noobaa-operator $version" --body "This is an automated PR for the release of Noobaa version: $version"
+
+  popd
+
+  echo "Cleaning up..."
+  rm -rf "$operatorhub_dir"
+}
+
+function usage() {
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  --help - Print this help message."
+  echo "  --oci-org <org> - The organization of the OCI images."
+  echo "  --gh-org <org> - The organization of the GitHub repository."
+  echo "  --gh-repo <repo> - The GitHub repository name."
+  echo "  --draft - Create the release as a draft."
+  echo "  --dry-run - Do not create the release."
+  echo "  --only-gh - Create the GitHub release only."
+  echo "  --only-oci - Create the OCI release only."
+  echo "  --only-homebrew - Create the homebrew release only."
+  echo "  --only-operator-hub - Create the operatorhub.io release only."
+}
+
+function init() {
+  check_environment_variables
+  mkdir -p "$ARTIFACTS_PATH/release"
+  parse_args "$@"
+}
+
+function main() {
+  check_deps "${dependencies[@]}"
+
+  # If none of --only-* flags are set, run all the release steps.
+  if [[ "$ONLY_GH" == "false" && "$ONLY_OCI" == "false" && "$ONLY_HOMEBREW" == "false" && "$ONLY_OPERATOR_HUB" == "false" ]]; then
+    create_gh_release
+    create_oci_release
+    create_krew
+    release_homebrew
+    release_operatorhub
+  fi
+
+  if [[ "$ONLY_GH" == "true" ]]; then
+    create_gh_release
+  fi
+
+  if [[ "$ONLY_OCI" == "true" ]]; then
+    create_oci_release
+  fi
+
+  if [[ "$ONLY_HOMEBREW" == "true" ]]; then
+    release_homebrew
+  fi
+
+  if [[ "$ONLY_OPERATOR_HUB" == "true" ]]; then
+    release_operatorhub
+  fi
+}
+
+init "$@"
+
+if [ -f "$dir/releaser-pre.sh" ]; then
+  bash "$dir/releaser-pre.sh"
+fi
+
+main "$@"
+
+if [ -f "$dir/releaser-post.sh" ]; then
+  bash "$dir/releaser-post.sh"
+fi

--- a/build/tools/utils.sh
+++ b/build/tools/utils.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
+
+function check_deps() {
+  local dependencies=("$@")
+  echo "Checking dependencies..."
+
+  for dep in ${dependencies[@]}; do
+    if ! command -v $dep &>/dev/null; then
+      echo "Please install $dep"
+      exit 1
+    fi
+  done
+
+  echo "All dependencies are installed"
+}
+
+function strip_prefix() {
+  local str="$1"
+  local prefix="$2"
+
+  echo ${str#"$prefix"}
+}
+
+function version_without_v() {
+  strip_prefix "$1" v
+}
+
+function version_with_v() {
+  local without_v=$(version_without_v "$1")
+
+  echo "v$without_v"
+}
+
+# get_noobaa_version returns the NooBaa version by reading the `cmd/version/main.go`
+#
+# The function can be called without any arguments in which case it will return
+# noobaa version without "v" prefixed to the version however if ANY second
+# argument is provided to the function then it will prefix "v" to the version.
+#
+# Example: get_noobaa_version # returns version without "v" prefix
+# Example: get_noobaa_version 1 # returns version with "v" prefix
+function get_noobaa_version() {
+  local version=$(go run cmd/version/main.go)
+  if [[ $# -gte 1 ]]; then
+    version_with_v "$version"
+  else
+    version_without_v "$version"
+  fi
+}
+
+# finline_replace takes 3 arguments. First is the regex for the line which
+# needs to be replaced, second is the regex for the line which needs to be
+# replace the previous line and third is the name of the file
+#
+# NOTE: Function relies on perl
+function finline_replace() {
+  perl -i -pe "s/$1/$2/" "$3"
+}
+
+# bump_semver_patch takes in a semver and bumps the patch version
+function bump_semver_patch() {
+  local version=$(version_without_v "$1")
+  version=$(echo ${version} | awk -F. -v OFS=. '{$NF = $NF+1 ; print}')
+  echo "$version"
+}


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
This PR attempts to provide a Github workflow which can be used to automate:
1. Updating `version/version.go`.
2. Updating `options.go`.
3. Update README.md.
4. Release of NooBaa CLI binaries for macos and linux platform (amd64 and arm64).
5. Release of NooBaa operator docker image to dockerhub and quay.
6. Release of NooBaa CLI homebrew formula.
7. Release of krew plugin (disabled in this PR, krew requires a manual first PR and then it can be enabled here).
8. Release of operator on Operator Hub

![image](https://user-images.githubusercontent.com/45818886/207248470-3fabb651-070f-48c2-bea3-69f82f2f575f.png)

Flow:
1. Workflow will first read the `version/version.go` to figure out which version is supposed to be built and released.
2. README.md is updated accordingly and push the changes to the base branch.
3. Build assets like: CLI binaries, Homebrew file, krew file, OCI images, OLM manifests.
4. Create release on Github.
5. Push the homebrew file to the given homebrew repositories.
6. Create a PR against the `OPERATOR_HUB_REPO` (== "k8s-operatorhub/community-operators") with the new version of `CSV`.
7. Save the .krew.yaml in the current tree to be utilized by the krew-release-bot.
8. Increment the patch version in `version/version.go` and `options.go`
9. Commit the changes and push to the base branch.

Caveats:
- The entire workflow assumes that the version in the `version/version.go` is correct. It does not have additional logic to ensure that. Whatever the version would be in that file, it will be released.
- Rollbacks are manual for now. That is, delete the releases, delete the tag, close the PR, revert the commits. Can be automated in the future though.
- Whenever a new version branch is created, we need to ensure that `version/version.go` reflects that. So when we move to `5.14` branch, `version/version.go` needs to be set to `Version = "5.14.0"`. This can be automated as well but not sure if its worth doing so.

The scripts/workflow will require a few secrets in place like:
1. `GHACTION_GH_PAT` - A github token which has write access to the repositories. This is needed because the workflow updates certain files and then runs `make gen` one last time and commit the changes to the branch. This is also required to create a new release and upload release assets.
11. `DOCKERHUB_USERNAME` - Username in dockerhub where the OCI image is supposed to be pushed.
12. `DOCKERHUB_TOKEN` - Dockerhub token is used to login to the registry and push the image.
13. `QUAY_USERNAME` - Username in quay where the OCI image is supposed to be pushed.
14. `QUAY_TOKEN` - Quay token is used to login to the registry and push the image.
15. `HOMEBREW_CORE_REPO` - This is the repository where we store our hombrew formulas (format: `org/repo`).
16. `OCI_ORG` - This is used internally hence this can be anything. It can be same as `DOCKERHUB_USERNAME` or `QUAY_USERNAME` or a random string.
