### PR TITLE
[Backport to 5.12] Prompting more readable error when we get CONNECTED_BUCKET_DELETING

### DIFF
--- a/pkg/validations/backingstore_validations.go
+++ b/pkg/validations/backingstore_validations.go
@@ -263,6 +263,10 @@ func ValidateBackingstoreDeletion(bs nbv1.BackingStore, systemInfo nb.SystemInfo
 		if pool.Name == bs.Name {
 			if pool.Undeletable == "IS_BACKINGSTORE" || pool.Undeletable == "BEING_DELETED" {
 				return nil
+			} else if pool.Undeletable == "CONNECTED_BUCKET_DELETING" {
+				return util.ValidationError{
+					Msg: fmt.Sprintf("cannot complete because objects in Backingstore %q are still being deleted, Please try later", pool.Name),
+				}
 			}
 			return util.ValidationError{
 				Msg: fmt.Sprintf("cannot complete because pool %q in %q state", pool.Name, pool.Undeletable),


### PR DESCRIPTION
### Explain the changes
Prompting more readable error when we get CONNECTED_BUCKET_DELETING

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit fa46462481c800dfafe374e343741982b107f3ec)

