### PR TITLE
for ODF - only support install mode AllNamespaces

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -304,6 +304,26 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 					Value:    "true",
 				},
 			}
+
+			csv.Spec.InstallModes = []operv1.InstallMode{
+				{
+					Type:      operv1.InstallModeTypeOwnNamespace,
+					Supported: false,
+				},
+				{
+					Type:      operv1.InstallModeTypeSingleNamespace,
+					Supported: false,
+				},
+				{
+					Type:      operv1.InstallModeTypeMultiNamespace,
+					Supported: false,
+				},
+				{
+					Type:      operv1.InstallModeTypeAllNamespaces,
+					Supported: true,
+				},
+			}
+
 		}
 
 		if csvParams.Replaces != "" {


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. when generating CSV for ODF, set `true` only for install mode `AllNamespaces`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
