### PR TITLE
use a specific tag for smallstep/step-ca in kmip test

### DIFF
--- a/.travis/install-kmip-kms-noobaa.sh
+++ b/.travis/install-kmip-kms-noobaa.sh
@@ -4,7 +4,7 @@ set -o errexit
 container=$(docker run -d \
     -e "DOCKER_STEPCA_INIT_NAME=The Authority" \
     -e "DOCKER_STEPCA_INIT_DNS_NAMES=localhost,$(hostname -f)" \
-    smallstep/step-ca)
+    smallstep/step-ca:0.23.0)
 echo "💬 Generate certificates in container $container"
 while [ "$(docker inspect -f {{.State.Running}} $container)" != "true" ]; do
     echo "💬 Wait for container $container to start running, state running $(docker inspect -f {{.State.Running}} $container)"


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. Fix failure in KMIP KMS test - using a specific tag for `smallstep/step-ca` instead of latest that failed to deploy

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
