### PR TITLE
build: use proper operator-sdk on ARM64

### DIFF
--- a/build/install-operator-sdk.sh
+++ b/build/install-operator-sdk.sh
@@ -21,13 +21,27 @@ then
 fi
 
 PLATFORM="$(uname)"
-ARCHITECTURE="x86_64"
+ARCH=$(uname -m)
+ARCH_TAG=""
+if [[ "$ARCH" == "x86_64" ]]; then
+    ARCH_TAG="x86_64"
+elif [[ "$ARCH" == "aarch64" ]]; then
+    # NOTE: newer version of operator-sdk use 'arm64' tag
+    ARCH_TAG="aarch64"
+elif [[ "$ARCH" == "arm64" && "${PLATFORM}" == "Darwin" ]]; then
+    # Current in-use operator-sdk version does not support arm64 for MacOS
+    ARCH_TAG="x86_64"    
+else
+    echo "unsupported: $ARCH on ${PLATFORM}"
+    exit 1
+fi
+
 if [ "${PLATFORM}" == "Darwin" ] 
 then 
-    SDK_RELEASE="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-${ARCHITECTURE}-apple-darwin"
+    SDK_RELEASE="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-${ARCH_TAG}-apple-darwin"
 else 
     # Assuming that if not darwin then running on linux
-    SDK_RELEASE="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-${ARCHITECTURE}-linux-gnu"
+    SDK_RELEASE="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-${ARCH_TAG}-linux-gnu"
 fi
 
 echo "installing version ${OPERATOR_SDK_VERSION}"


### PR DESCRIPTION
Align operator-sdk download URL with instructions from https://sdk.operatorframework.io/docs/installation/

Build tested on AWS/Graviton machine (arm64).

Signed-off-by: Shachar Sharon <ssharon@redhat.com>

### Explain the changes
1. Use proper ARCH tag when using operator-sdk (do not asume hard-coded x86_64)

### Issues: Fixed #xxx / Gap #xxx
1. Build noobaa-operator image on arm64 machine (AWS Graviton)

### Testing Instructions:
1. AWS aarch64 vm

- [ ] Doc added/updated
- [ ] Tests added
