### PR TITLE
changes to all GitHub workflows - timeout, checkout v3, concurrency, general cleanup

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,15 +1,18 @@
 name: golangci-lint
-
 on: [push, pull_request]
 
 jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.50

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -13,12 +13,13 @@ on:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   releaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Set branch
         run: echo "BRANCH=${{ github.event.inputs.base_branch }}" >> $GITHUB_ENV

--- a/.github/workflows/run_admission_test.yml
+++ b/.github/workflows/run_admission_test.yml
@@ -6,10 +6,14 @@ on: [push, pull_request]
 jobs:
   run-admission-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 

--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -1,8 +1,8 @@
 name: Run Operator Unit Tests
-
-# Run on each new PR and each new push to existing PR
 on: [push, pull_request]
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
   GO111MODULE: "on"
@@ -12,10 +12,12 @@ env:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v2 # Could not change to version 3, see issue:
+        # https://github.com/noobaa/noobaa-operator/issues/1031
         with:
           go-version: "1.18"
 
@@ -44,6 +46,7 @@ jobs:
 
   run-cli-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -72,6 +75,7 @@ jobs:
 
   run-core-config-map-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/run_hac_test.yml
+++ b/.github/workflows/run_hac_test.yml
@@ -1,15 +1,17 @@
 name: HAC on KIND cluster Test
-
-# Run on each new PR and each new push to existing PR
 on: [push, pull_request]
 
 jobs:
   run-hac-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 

--- a/.github/workflows/run_kms_dev_test.yml
+++ b/.github/workflows/run_kms_dev_test.yml
@@ -1,15 +1,17 @@
 name: KMS Test - DEV Vault, Token Auth
-
-# Run on each new PR and each new push to existing PR
 on: [push, pull_request]
 
 jobs:
   run-kms-dev-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 

--- a/.github/workflows/run_kms_ibm_kp_test.yml
+++ b/.github/workflows/run_kms_ibm_kp_test.yml
@@ -1,6 +1,4 @@
 name: KMS Test - IBM KP
-
-# Run on each new PR and each new push to existing PR
 on: [push, pull_request]
 
 jobs:
@@ -9,10 +7,14 @@ jobs:
       IBM_KP_SERVICE_INSTANCE_ID: ${{ secrets.IBM_INSTANCE_ID }}
       IBM_KP_SERVICE_API_KEY: ${{ secrets.IBM_SERVICE_API_KEY }}
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 

--- a/.github/workflows/run_kms_kmip_test.yml
+++ b/.github/workflows/run_kms_kmip_test.yml
@@ -1,15 +1,17 @@
 name: KMS Test - KMIP
-
-# Run on each new PR and each new push to existing PR
 on: [push, pull_request]
 
 jobs:
   run-kms-kmip-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 

--- a/.github/workflows/run_kms_tls_sa_test.yml
+++ b/.github/workflows/run_kms_tls_sa_test.yml
@@ -6,10 +6,14 @@ on: [push, pull_request]
 jobs:
   run-kms-tls-sa-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 

--- a/.github/workflows/run_kms_tls_token_test.yml
+++ b/.github/workflows/run_kms_tls_token_test.yml
@@ -6,10 +6,14 @@ on: [push, pull_request]
 jobs:
   run-kms-tls-token-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,17 +1,17 @@
 name: Testing flows
-
-# Run the Weekly on Monday 8:15 AM UTC
 on: [push, pull_request]
-  #schedule:
-  #  - cron: "15 8 * * 1"
 
 jobs:
   auto-update:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
According to _CI next steps_ meeting:
1. Change default timeouts for our tests to 1.5h (90 minutes).
2. Change all checkout to v3 (v2 is using node version 12).
3. Use GH Concurrency to cancel the previous run.

General cleanup (was not in the meeting): 
1. Update [golangci-lint-action](https://github.com/marketplace/actions/run-golangci-lint) to the latest version.
2. Update [setup-go](https://github.com/marketplace/actions/setup-go-environment) to the latest version - except for one case in `run_ci` file (see [this issue](https://github.com/noobaa/noobaa-operator/issues/1031) for more details).
3. Remove extra newlines.
4. Remove comments that explain the code itself.


### Issues: Gap
The main gap is that the default timeout of jobs is 6 hours and it is a waste of computing resources since all of our jobs run in a sixth of the time.  Another waste of computing resources is when we use successive pushes, and we would like to reduce it.

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added