### PR TITLE
Adding support for Namespace GoogleCloudStorage

### DIFF
--- a/deploy/crds/noobaa.io_namespacestores_crd.yaml
+++ b/deploy/crds/noobaa.io_namespacestores_crd.yaml
@@ -101,6 +101,31 @@ spec:
                 - secret
                 - targetBlobContainer
                 type: object
+              googleCloudStorage:
+                description: GoogleCloudStorage specifies a namespace store of type
+                  google-cloud-storage
+                properties:
+                  secret:
+                    description: Secret refers to a secret that provides the credentials
+                      The secret should define GoogleServiceAccountPrivateKeyJson
+                      containing the entire json string as provided by Google.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  targetBucket:
+                    description: TargetBucket is the name of the target S3 bucket
+                    type: string
+                required:
+                - secret
+                - targetBucket
+                type: object
               ibmCos:
                 description: IBMCos specifies a namespace store of type ibm-cos
                 properties:

--- a/doc/namespace-store-crd.md
+++ b/doc/namespace-store-crd.md
@@ -5,7 +5,7 @@ NamespaceStore CRD represents an underlying storage to be used as read or write 
 namespace buckets.
 These storage targets are used to store plain data.
 Namespace-Store are referred to by name when defining [BucketClass](bucket-class-crd.md).
-Multiple types of Namespace-Store are currently supported: aws-s3, s3-compatible, ibm-cos, azure-blob.
+Multiple types of Namespace-Store are currently supported: aws-s3, s3-compatible, ibm-cos, google-cloud-storage, azure-blob.
 
 # Definitions
 
@@ -92,6 +92,31 @@ spec:
     signatureVersion: v2
     targetBucket: BUCKET
   type: ibm-cos
+```
+
+#### GOOGLE-CLOUD-STORAGE type
+
+Create a cloud resource within the NooBaa brain and use Google Cloud Storage API for reading or writing data in any Google Cloud Storage API compatible endpoint.
+```shell
+noobaa -n noobaa namespacestore create google-cloud-storage ns --private-key-json-file key.json --target-bucket BUCKET
+```
+```yaml
+apiVersion: noobaa.io/v1alpha1
+kind: NamespaceStore
+metadata:
+  finalizers:
+  - noobaa.io/finalizer
+  labels:
+    app: noobaa
+  name: bs
+  namespace: noobaa
+spec:
+  googleCloudStorage:
+    secret:
+      name: namespace-store-google-cloud-storage-bs
+      namespace: noobaa
+    targetBucket: BUCKET
+  type: google-cloud-storage
 ```
 
 #### AZURE-BLOB type

--- a/pkg/admission/validate_namespacestore.go
+++ b/pkg/admission/validate_namespacestore.go
@@ -87,7 +87,7 @@ func (nsv *ResourceValidator) ValidateUpdateNS() {
 	}
 
 	switch ns.Spec.Type {
-	case nbv1.NSStoreTypeAWSS3, nbv1.NSStoreTypeS3Compatible, nbv1.NSStoreTypeIBMCos, nbv1.NSStoreTypeAzureBlob:
+	case nbv1.NSStoreTypeAWSS3, nbv1.NSStoreTypeS3Compatible, nbv1.NSStoreTypeIBMCos, nbv1.NSStoreTypeAzureBlob, nbv1.NSStoreTypeGoogleCloudStorage:
 		if err := validations.ValidateTargetNSBucketChange(*ns, *oldNS); err != nil && util.IsValidationError(err) {
 			nsv.SetValidationResult(false, err.Error())
 			return

--- a/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
+++ b/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
@@ -80,6 +80,10 @@ type NamespaceStoreSpec struct {
 	// +optional
 	AzureBlob *AzureBlobSpec `json:"azureBlob,omitempty"`
 
+	// GoogleCloudStorage specifies a namespace store of type google-cloud-storage
+	// +optional
+	GoogleCloudStorage *GoogleCloudStorageSpec `json:"googleCloudStorage,omitempty"`
+
 	// NSFS specifies a namespace store of type nsfs
 	// +optional
 	NSFS *NSFSSpec `json:"nsfs,omitempty"`
@@ -159,6 +163,9 @@ const (
 
 	// NSStoreTypeAzureBlob is used to connect to Azure Blob
 	NSStoreTypeAzureBlob NSType = "azure-blob"
+
+	// NSStoreTypeGoogleCloudStorage is used to connect to Google Cloud Storage
+	NSStoreTypeGoogleCloudStorage NSType = "google-cloud-storage"
 
 	// NSStoreTypeNSFS is used to connect to a file system
 	NSStoreTypeNSFS NSType = "nsfs"

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -813,6 +813,11 @@ func (in *NamespaceStoreSpec) DeepCopyInto(out *NamespaceStoreSpec) {
 		*out = new(AzureBlobSpec)
 		**out = **in
 	}
+	if in.GoogleCloudStorage != nil {
+		in, out := &in.GoogleCloudStorage, &out.GoogleCloudStorage
+		*out = new(GoogleCloudStorageSpec)
+		**out = **in
+	}
 	if in.NSFS != nil {
 		in, out := &in.NSFS, &out.NSFS
 		*out = new(NSFSSpec)

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -729,7 +729,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_namespacestores_crd_yaml = "94617b9c3967ae0d8515f6196e9a6571242e74ebca91eedba56b57e8ac460551"
+const Sha256_deploy_crds_noobaa_io_namespacestores_crd_yaml = "091c20d3b5d3f245a83def2dccc11ae255a08ddd703b3915e9ecb890d01042ec"
 
 const File_deploy_crds_noobaa_io_namespacestores_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -833,6 +833,31 @@ spec:
                 required:
                 - secret
                 - targetBlobContainer
+                type: object
+              googleCloudStorage:
+                description: GoogleCloudStorage specifies a namespace store of type
+                  google-cloud-storage
+                properties:
+                  secret:
+                    description: Secret refers to a secret that provides the credentials
+                      The secret should define GoogleServiceAccountPrivateKeyJson
+                      containing the entire json string as provided by Google.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  targetBucket:
+                    description: TargetBucket is the name of the target S3 bucket
+                    type: string
+                required:
+                - secret
+                - targetBucket
                 type: object
               ibmCos:
                 description: IBMCos specifies a namespace store of type ibm-cos

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -117,7 +117,7 @@ var (
 		"aws-s3":               {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},         // backingstores and namespacestores
 		"s3-compatible":        {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},         // backingstores and namespacestores
 		"ibm-cos":              {"IBM_COS_ACCESS_KEY_ID", "IBM_COS_SECRET_ACCESS_KEY"}, // backingstores and namespacestores
-		"google-cloud-storage": {"GoogleServiceAccountPrivateKeyJson"},                 // backingstores
+		"google-cloud-storage": {"GoogleServiceAccountPrivateKeyJson"},                 // backingstores and namespacestores
 		"azure-blob":           {"AccountName", "AccountKey"},                          // backingstores and namespacestores
 		"pv-pool":              {},                                                     // backingstores
 		"nsfs":                 {},                                                     // namespacestores
@@ -1732,6 +1732,8 @@ func GetNamespaceStoreSecretByType(ns *nbv1.NamespaceStore) (*corev1.SecretRefer
 		secretRef = ns.Spec.IBMCos.Secret
 	case nbv1.NSStoreTypeAzureBlob:
 		secretRef = ns.Spec.AzureBlob.Secret
+	case nbv1.NSStoreTypeGoogleCloudStorage:
+		secretRef = ns.Spec.GoogleCloudStorage.Secret
 	case nbv1.NSStoreTypeNSFS:
 		return nil, nil
 	default:
@@ -1768,6 +1770,9 @@ func SetNamespaceStoreSecretRef(ns *nbv1.NamespaceStore, ref *corev1.SecretRefer
 	case nbv1.NSStoreTypeAzureBlob:
 		ns.Spec.AzureBlob.Secret = *ref
 		return nil
+	case nbv1.NSStoreTypeGoogleCloudStorage:
+		ns.Spec.GoogleCloudStorage.Secret = *ref
+		return nil
 	case nbv1.NSStoreTypeNSFS:
 		return nil
 	default:
@@ -1786,6 +1791,8 @@ func GetNamespaceStoreTargetBucket(ns *nbv1.NamespaceStore) (string, error) {
 		return ns.Spec.IBMCos.TargetBucket, nil
 	case nbv1.NSStoreTypeAzureBlob:
 		return ns.Spec.AzureBlob.TargetBlobContainer, nil
+	case nbv1.NSStoreTypeGoogleCloudStorage:
+		return ns.Spec.GoogleCloudStorage.TargetBucket, nil
 	case nbv1.NSStoreTypeNSFS:
 		return "", nil
 	default:

--- a/pkg/validations/namespacestore_validations.go
+++ b/pkg/validations/namespacestore_validations.go
@@ -42,6 +42,9 @@ func ValidateNamespaceStore(nsStore *nbv1.NamespaceStore) error {
 	case nbv1.NSStoreTypeAzureBlob:
 		return nil
 
+	case nbv1.NSStoreTypeGoogleCloudStorage:
+		return nil
+
 	default:
 		return util.ValidationError{
 			Msg: "Invalid Namespacestore type, please provide a valid Namespacestore type",
@@ -206,6 +209,12 @@ func ValidateNSEmptySecretName(ns nbv1.NamespaceStore) error {
 				Msg: "Failed creating the namespacestore, please provide secret name",
 			}
 		}
+	case nbv1.NSStoreTypeGoogleCloudStorage:
+		if len(ns.Spec.GoogleCloudStorage.Secret.Name) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the namespacestore, please provide secret name",
+			}
+		}
 	case nbv1.NSStoreTypeNSFS:
 		break
 	default:
@@ -243,6 +252,12 @@ func ValidateNSEmptyTargetBucket(ns nbv1.NamespaceStore) error {
 				Msg: "Failed creating the namespacestore, please provide target bucket",
 			}
 		}
+	case nbv1.NSStoreTypeGoogleCloudStorage:
+		if len(ns.Spec.GoogleCloudStorage.TargetBucket) == 0 {
+			return util.ValidationError{
+				Msg: "Failed creating the namespacestore, please provide target bucket",
+			}
+		}
 	case nbv1.NSStoreTypeNSFS:
 		break
 	default:
@@ -276,6 +291,12 @@ func ValidateTargetNSBucketChange(ns nbv1.NamespaceStore, oldNs nbv1.NamespaceSt
 		}
 	case nbv1.NSStoreTypeAzureBlob:
 		if oldNs.Spec.AzureBlob.TargetBlobContainer != ns.Spec.AzureBlob.TargetBlobContainer {
+			return util.ValidationError{
+				Msg: "Changing a NamespaceStore target bucket is unsupported",
+			}
+		}
+	case nbv1.NSStoreTypeGoogleCloudStorage:
+		if oldNs.Spec.GoogleCloudStorage.TargetBucket != ns.Spec.GoogleCloudStorage.TargetBucket {
 			return util.ValidationError{
 				Msg: "Changing a NamespaceStore target bucket is unsupported",
 			}


### PR DESCRIPTION
### Explain the changes

1. Adding support for Namespace GoogleCloudStorage
2. Adding CLI for creating NS GoogleCloudStorage
3. Adding validation for Namespacestore GoogleCloudStorage
4. Updating the Namespacestore crd documentation

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### GAP: 
We need to add tests once the core side will have Namespace GoogleCloudStorage, Currently running throw this flow will fail miserably 🙂 

- [x] Doc added/updated

