### PR TITLE
Bug Fix #1007 | Default backing store avoid phase Ready with mode INITIALIZING

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -212,14 +212,18 @@ func (r *Reconciler) completeReconcile(err error) (reconcile.Result, error) {
 		mode := r.BackingStore.Status.Mode.ModeCode
 		phaseInfo, exist := bsModeInfoMap[mode]
 
-		if exist && phaseInfo.Phase != r.BackingStore.Status.Phase {
-			phaseName := fmt.Sprintf("BackingStorePhase%s", phaseInfo.Phase)
-			desc := fmt.Sprintf("Backing store mode: %s", mode)
-			r.SetPhase(phaseInfo.Phase, desc, phaseName)
-			if r.Recorder != nil {
-				r.Recorder.Eventf(r.BackingStore, phaseInfo.Severity, phaseName, desc)
+		if exist {
+			if phaseInfo.Phase != r.BackingStore.Status.Phase {
+				phaseName := fmt.Sprintf("BackingStorePhase%s", phaseInfo.Phase)
+				desc := fmt.Sprintf("Backing store mode: %s", mode)
+				r.SetPhase(phaseInfo.Phase, desc, phaseName)
+				if r.Recorder != nil {
+					r.Recorder.Eventf(r.BackingStore, phaseInfo.Severity, phaseName, desc)
+				}
 			}
 		} else {
+			// We will get here in case we do not have a mapping inside bsModeInfoMap
+			// The default phase that was chosen was phase ready
 			r.SetPhase(
 				nbv1.BackingStorePhaseReady,
 				"BackingStorePhaseReady",


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. Using the default backing store (type: pv-pool) we found that the phase is `Ready` and the mode is `INITIALIZING`.

### Issues: Fixed #1007 
1. Inside the issue you can find the details of the investigation.

### Testing Instructions:
In default backing store (type: pv-pool):
1. Based on the instructions [here](https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76) - the steps of _‘Build images’_ and _‘Deploy noobaa’._
2. `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=3m`
3. Right after getting `backingstore.noobaa.io/noobaa-default-backing-store condition met` Run:
 `  kubectl edit backingstore/noobaa-default-backing-store`
5. Check at the end of the file that the phase is `Ready` and the mode is `OPTIMAL`.

- [ ] Doc added/updated
- [ ] Tests added
