### PR TITLE
use a specific tag for smallstep/step-ca in kmip test - update

### DIFF
--- a/.travis/install-kmip-kms-noobaa.sh
+++ b/.travis/install-kmip-kms-noobaa.sh
@@ -4,7 +4,7 @@ set -o errexit
 container=$(docker run -d \
     -e "DOCKER_STEPCA_INIT_NAME=The Authority" \
     -e "DOCKER_STEPCA_INIT_DNS_NAMES=localhost,$(hostname -f)" \
-    smallstep/step-ca:0.23.0)
+    smallstep/step-ca:0.22.1)
 echo "💬 Generate certificates in container $container"
 while [ "$(docker inspect -f {{.State.Running}} $container)" != "true" ]; do
     echo "💬 Wait for container $container to start running, state running $(docker inspect -f {{.State.Running}} $container)"


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. Change the specific tag for [smallstep/step-ca](https://hub.docker.com/r/smallstep/step-ca/tags?page=1) in kmip test.

### Issues: Gap
1. Our `Run KMS KMIP` test is failing in the last two days (see [here](https://github.com/noobaa/noobaa-operator/actions/workflows/run_kms_kmip_test.yml)). [The last change was updating the version](https://github.com/noobaa/noobaa-operator/pull/1018), this PR is updating the chosen version.

### Testing Instructions:
1. If the builtin check `Run KMS KMIP` will succeed. 

- [ ] Doc added/updated
- [ ] Tests added
