### PR TITLE
Add the characters EXAMPLE as a prefix in secrets examples

### DIFF
--- a/doc/install-on-minikube-on-ubuntu.md
+++ b/doc/install-on-minikube-on-ubuntu.md
@@ -214,7 +214,7 @@ PodPorts    : [https://172.17.0.5:6443]
 #------------------#
 
 AWS_ACCESS_KEY_ID     : ku2pBEPGqsTvGd47qfL9
-AWS_SECRET_ACCESS_KEY : KQTQOIK1BGZcYYPqaYw8RFfpt0RmsVsyfdn/BR4J
+AWS_SECRET_ACCESS_KEY : EXAMPLEKQTQOIK1BGZcYYPqaYw8RFfpt0RmsVsyfdn/BR4J
 
 #------------------#
 #- Backing Stores -#

--- a/doc/obc-provisioner.md
+++ b/doc/obc-provisioner.md
@@ -120,7 +120,7 @@ Secret:
 apiVersion: v1
 data:
   AWS_ACCESS_KEY_ID: UU1odkFSWjNiMWplTmx2UnZpcHU=
-  AWS_SECRET_ACCESS_KEY: eTdFdlkva1FSQVEzWElWWXB3L2ZYdVBZdG8wSDBxaVlBSUpraW1iTA==
+  AWS_SECRET_ACCESS_KEY: EXAMPLEeTdFdlkva1FSQVEzWElWWXB3L2ZYdVBZdG8wSDBxaVlBSUpraW1iTA==
 kind: Secret
 metadata:
   creationTimestamp: "2020-01-14T08:05:31Z"


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. Add the characters EXAMPLE as a prefix in secrets examples for lines the infoSec found in its alerts that were false-positive alerts in files with ".md" extension.

### Issues: Gap
1. When I worked on the GH Action on a copy of noobaa-operator repository I got false-positive alerts from infoSec.
2. One of the ways to turn it off is to add EXAMPLE as a prefix in secrets, which is the simplest way, suggested by @bplaxco.

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added
