### PR TITLE
Fix kmip test

### DIFF
--- a/pkg/util/kms/test/kmip/pykmip/Dockerfile
+++ b/pkg/util/kms/test/kmip/pykmip/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.9-slim
-RUN pip install --no-cache-dir pykmip
+RUN pip install --no-cache-dir sqlalchemy==1.4.45
+RUN pip install --no-cache-dir pykmip==0.10.0
 WORKDIR /work
 COPY start.sh         start.sh
 COPY server.conf      server.conf


### PR DESCRIPTION
Default pip installed pykmip-server generates the following error:
```
sqlalchemy.exc.InvalidRequestError: Implicitly combining column managed_objects.uid with column crypto_objects.uid under attribute 'unique_identifier'.  Please configure one or more attributes for these same-named columns explicitly.
```
See https://github.com/OpenKMIP/PyKMIP/issues/687 for this workaround

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>
