### PR TITLE
Admission Tests Changes - Integration and Workflow

### DIFF
--- a/.github/workflows/run_admission_test.yml
+++ b/.github/workflows/run_admission_test.yml
@@ -1,7 +1,5 @@
 name: Admission Webhook Tests
-
-# Run on each new PR and each new push to existing PR
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-admission-test:
@@ -11,9 +9,24 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: checkout
+      - name: Checkout noobaa-core
         uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        with:
+          repository: 'noobaa/noobaa-core'
+          path: "noobaa-core"
+          # Freeze the version of core
+          # to avoid a failed run due to code changes in the core repo.
+          # Need to update the commit once in a while
+          ref: 293fefb9e755fa0d6bf1cc8b31f74259a0001730
+
+      - name: Checkout noobaa-operator
+        uses: actions/checkout@v3
+        with:
+          repository: 'noobaa/noobaa-operator'
+          path: "noobaa-operator"
+
+      - name: Setup Go on runner
+        uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 
@@ -22,30 +35,78 @@ jobs:
           echo PATH=$PATH:$HOME/go/bin                           >> $GITHUB_ENV
           echo OPERATOR_IMAGE=noobaa/noobaa-operator:integration >> $GITHUB_ENV
           echo CHANGE_MINIKUBE_NONE_USER=true                    >> $GITHUB_ENV
- 
-      - name: Deploy Dependencies
+
+      - name: Deploy dependencies
         run: |
           set -x
+          cd ./noobaa-operator
           sudo bash .travis/install-minikube.sh
           go get -v github.com/onsi/ginkgo/ginkgo
           go install -v github.com/onsi/ginkgo/ginkgo
           ginkgo version
 
-      - name: Update Kubectl Context
+      - name: Change settings for k8s and minikube
         run: |
           sudo mv /root/.kube /root/.minikube $HOME
           sudo chown -R $USER $HOME/.kube $HOME/.minikube
           sed "s/root/home\/$USER/g" $HOME/.kube/config > tmp; mv tmp $HOME/.kube/config
 
-      - name: Build NooBaa
+      - name: Build noobaa image
         run: |
+          cd ./noobaa-core
+          make noobaa NOOBAA_TAG=noobaa-core:admission-test
+
+      - name: Build operator image
+        run: |
+          set -x
+          cd ./noobaa-operator
           make cli
           make image
           sudo docker tag noobaa/noobaa-operator:$(go run cmd/version/main.go) $OPERATOR_IMAGE
 
-      - name: Install NooBaa
+      - name: Install noobaa system
         run: |
-          ./build/_output/bin/noobaa-operator -n test --mini --admission --operator-image=$OPERATOR_IMAGE install
+          cd ./noobaa-operator
+          ./build/_output/bin/noobaa-operator crd create -n test
+          ./build/_output/bin/noobaa-operator operator install --operator-image=$OPERATOR_IMAGE --admission -n test
+          ./build/_output/bin/noobaa-operator system create \
+          --db-resources='{ "limits": {"cpu": "100m","memory": "1G"}, "requests": {"cpu": "100m","memory": "1G"}}' \
+          --core-resources='{ "limits": {"cpu": "100m","memory": "1G"}, "requests": {"cpu": "100m","memory": "1G"}}' \
+          --endpoint-resources='{ "limits": {"cpu": "100m","memory": "1G"}, "requests": {"cpu": "100m","memory": "1G"}}' \
+          --noobaa-image='noobaa-core:admission-test' -n test
+          ./build/_output/bin/noobaa-operator status -n test
+          # we added the sleep since the test pool is in phase ready and condition available
+          # but the test pool storage is not ready yet, see issue:
+          # https://github.com/noobaa/noobaa-operator/issues/1007
+          sleep 3m
+          kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=3m -n test
 
       - name: Run Admission test
-        run: make test-admission
+        run: |
+          set -x
+          cd ./noobaa-operator
+          make test-admission
+
+      - name: Collect logs
+        if: ${{ failure() }}
+        run: |
+          set -x
+          cd ./noobaa-operator
+          kubectl get events --sort-by='.metadata.creationTimestamp' -A > logs_kubectl_events.txt
+          ./build/_output/bin/noobaa-operator diagnose --db-dump --dir=admission-tests-logs -n test
+          # We have a problem with the db-dump on namespaces which are not default
+          # https://github.com/noobaa/noobaa-operator/issues/1040
+          mv logs_kubectl_events.txt ./admission-tests-logs
+
+      - name: Save logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: admission-tests-logs
+          path: noobaa-operator/admission-tests-logs
+
+      # Uncomment this step in case where you want to connect to the VM of this workflow using SSH.
+      # Pay attention that this workflow was configured with a timeout, and you might change it for this step.
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3

--- a/pkg/admission/test/integ/admission_integ_test.go
+++ b/pkg/admission/test/integ/admission_integ_test.go
@@ -2,6 +2,7 @@ package admissionintegtests
 
 import (
 	"context"
+	"fmt"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/backingstore"
@@ -9,8 +10,10 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bundle"
 	"github.com/noobaa/noobaa-operator/v5/pkg/namespacestore"
+	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/operator"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -256,6 +259,19 @@ var _ = Describe("Admission server integration tests", func() {
 					Namespace: namespace,
 				},
 			}
+			// Set the default resource explicitly to be noobaa-default-backing-store
+			// of the account that run these tests (admin@noobaa.io) before starting the first delete operation test.
+			// We use an RPC call update_account_s3_access
+			// https://github.com/noobaa/noobaa-operator/issues/1045
+			nbClient := system.GetNBClient()
+			err := nbClient.UpdateAccountS3Access(nb.UpdateAccountS3AccessParams{
+				Email:           "admin@noobaa.io",
+				S3Access:        true,
+				DefaultResource: &defaultBs.Name,
+			})
+			if err != nil {
+				fmt.Printf("setting the default resource created an error %s\n", err)
+			}
 
 			// try to delete noobaa-default-backing-store and failing because it has data buckets
 			result, err = KubeDelete(defaultBs)
@@ -263,12 +279,13 @@ var _ = Describe("Admission server integration tests", func() {
 			Ω(err).Should(HaveOccurred())
 			Expect(err.Error()).To(Equal("admission webhook \"admissionwebhook.noobaa.io\" denied the request: cannot complete because pool \"noobaa-default-backing-store\" in \"IN_USE\" state"))
 		})
-		It("Should Allow", func() {
+		It("Should Allow backingstore deletion", func() {
 			// delete "bs-name" backingstore
 			result, err = KubeDelete(testBackingstore)
 			Expect(result).To(BeTrue())
 			Ω(err).ShouldNot(HaveOccurred())
-
+		})
+		It("Should Allow namespacestore deletion", func() {
 			// delete "ns-name" namespacestore
 			result, err = KubeDelete(testNamespacestore)
 			Expect(result).To(BeTrue())


### PR DESCRIPTION
### Explain the changes
Changes in the admission tests (integration tests):
1. Separate the last delete test (It, Should Allow) into 2 tests (bs = backingstore, ns = namespacestore).
2. Set the default resource explicitly before starting the first delete operation test.

Changes in the admission test workflow:
1. Clone core repo and build it.
2. Install nb with max resources to pass the tests.
3. Collect logs and upload artifacts.

### Issues: Gap
1. I could not add this fix (#1033) because a test in the integration test didn't pass due to a change in the timing.

### Testing Instructions:
1. none, it is checked in the workflow.

- [ ] Doc added/updated
- [ ] Tests added
