### PR TITLE
Fix Bug #1043 | Noobaa Account Status of admin@noobaa.io

### DIFF
--- a/pkg/noobaaaccount/noobaaaccount.go
+++ b/pkg/noobaaaccount/noobaaaccount.go
@@ -355,11 +355,11 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	noobaaAccount.Namespace = options.Namespace
 	secret.Namespace = options.Namespace
 
-	if !util.KubeCheck(noobaaAccount) && (name != "admin@noobaa.io") {
+	if name == "admin@noobaa.io" {
+		secret.Name = "noobaa-admin"
+	} else if !util.KubeCheck(noobaaAccount) {
 		log.Fatalf(`❌ Could not get NooBaaAccount %q in namespace %q`,
 			noobaaAccount.Name, noobaaAccount.Namespace)
-	} else if name == "admin@noobaa.io" {
-		secret.Name = "noobaa-admin"
 	} else {
 		CheckPhase(noobaaAccount)
 


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. Fix Bug #1043 nb account status of admin@noobaa.io by change the order of conditions nb account status.

### Issues: Fixed #1043 
1. Show nb account status of [admin@noobaa.io](mailto:admin@noobaa.io) (without any error message).

### Testing Instructions:
1. Based on the instructions [here](https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76) - the steps of _‘Build images’_ and _‘Deploy noobaa’._
2. Run: `nb account status admin@noobaa.io `
_Note: `nb` is a alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._


![nb account status admin@noobaa  io after](https://user-images.githubusercontent.com/57721533/217786972-13578185-8687-40cd-9f56-a3d826fbab2b.png)

- [ ] Doc added/updated
- [ ] Tests added
