### PR TITLE
Bug Fix #1040 | Add Namespace Option in Db-Dump (Not Only Default) In PG DB Only

### DIFF
--- a/pkg/dbdump/dbdump.go
+++ b/pkg/dbdump/dbdump.go
@@ -73,7 +73,7 @@ func CollectDBDump(kubeconfig string, destDir string) {
 func (c *Collector) generatePostgresDump(destDir string) error {
 	// In case of a postgres db, the dump is a single file so in this case we can
 	// redirect the output of the dump straight to a local file
-	cmd := exec.Command(c.kubeCommand, "exec", "-it", "pod/noobaa-db-pg-0", "--", "pg_dumpall")
+	cmd := exec.Command(c.kubeCommand, "exec", "-n", options.Namespace, "-it", "pod/noobaa-db-pg-0", "--", "pg_dumpall")
 	// handle custom path for kubeconfig file,
 	// see --kubeconfig cli options
 	if len(c.kubeconfig) > 0 {


### PR DESCRIPTION
### Explain the changes
1. Add namespace option in db-dump (not only default) in PG DB only.

### Issues: Fixed #1040 / Gap #1059
1. Today db-dump works well only with the default namespace.

### Testing Instructions:
1. Based on the instructions [here](https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76) - ‘Build images’.
2. Deploy Noobaa to a namespace that is different than the default (nb install -n test, for example).
3. Run: `nb diagnose --db-dump --dir=my-db-logs-test -n test`.
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._

#### Screenshots:
After running the command (no error):
![Screenshot 2023-02-22 at 12 51 32](https://user-images.githubusercontent.com/57721533/220599602-a4bf0ebd-4b2d-4a33-92c7-924384b4a7f8.png)

Viewing the file that was generated (size is above zero bytes):
![Screenshot 2023-02-22 at 12 51 50](https://user-images.githubusercontent.com/57721533/220599625-f2bf4e3d-18b8-4e14-a9e0-3ea54eb80fc2.png)


- [ ] Doc added/updated
- [ ] Tests added
