### PR TITLE
Fix Bug BZ 2149872, 1066 | Add Toleration And Affinity to Backingstore Pod after Editing Noobaa CR

### DIFF
--- a/pkg/controller/backingstore/backingstore_controller.go
+++ b/pkg/controller/backingstore/backingstore_controller.go
@@ -89,6 +89,19 @@ func Add(mgr manager.Manager) error {
 		return err
 	}
 
+	// Setting another handler to watch events on noobaa system that are not necessarily owned by the backingstore.
+	// For example: modify toleration in Noobaa CR should pass to the backingstores.
+	noobaaHandler := handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+		return backingstore.MapNoobaaToBackingStores(types.NamespacedName{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+		})
+	})
+	err = c.Watch(&source.Kind{Type: &nbv1.NooBaa{}}, noobaaHandler, logEventsPredicate)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -104,7 +104,7 @@ func (p *Provisioner) Provision(bucketOptions *obAPI.BucketOptions) (*nbv1.Objec
 
 	if r.SysClient.NooBaa.DeletionTimestamp != nil {
 		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
-		if util.Contains(nbv1.GracefulFinalizer, finalizersArray) {
+		if util.Contains(finalizersArray, nbv1.GracefulFinalizer) {
 			msg := "NooBaa is in deleting state, new requests will be ignored"
 			log.Errorf(msg)
 			return nil, obErrors.NewBucketExistsError(msg)
@@ -143,7 +143,7 @@ func (p *Provisioner) Grant(bucketOptions *obAPI.BucketOptions) (*nbv1.ObjectBuc
 
 	if r.SysClient.NooBaa.DeletionTimestamp != nil {
 		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
-		if util.Contains(nbv1.GracefulFinalizer, finalizersArray) {
+		if util.Contains(finalizersArray, nbv1.GracefulFinalizer) {
 			msg := "NooBaa is in deleting state, new requests will be ignored"
 			log.Errorf(msg)
 			return nil, obErrors.NewBucketExistsError(msg)
@@ -700,7 +700,7 @@ func (r *BucketRequest) putBucketTagging() error {
 	taggingArray := []*s3.Tag{}
 	for key, value := range r.OBC.Labels {
 		// no need to put tagging of these labels
-		if !util.Contains(key, []string{"app", "noobaa-domain", "bucket-provisioner"}) {
+		if !util.Contains([]string{"app", "noobaa-domain", "bucket-provisioner"}, key) {
 			keyPointer := key
 			valuePointer := value
 			taggingArray = append(taggingArray, &s3.Tag{Key: &keyPointer, Value: &valuePointer})

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -296,12 +296,8 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 		podSpec.ImagePullSecrets =
 			[]corev1.LocalObjectReference{*r.NooBaa.Spec.ImagePullSecret}
 	}
-	if r.NooBaa.Spec.Tolerations != nil {
-		podSpec.Tolerations = r.NooBaa.Spec.Tolerations
-	}
-	if r.NooBaa.Spec.Affinity != nil {
-		podSpec.Affinity = r.NooBaa.Spec.Affinity
-	}
+	podSpec.Tolerations = r.NooBaa.Spec.Tolerations
+	podSpec.Affinity = r.NooBaa.Spec.Affinity
 
 	if NooBaaDB.UID == "" {
 		for i := range NooBaaDB.Spec.VolumeClaimTemplates {
@@ -491,12 +487,8 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 		podSpec.ImagePullSecrets =
 			[]corev1.LocalObjectReference{*r.NooBaa.Spec.ImagePullSecret}
 	}
-	if r.NooBaa.Spec.Tolerations != nil {
-		podSpec.Tolerations = r.NooBaa.Spec.Tolerations
-	}
-	if r.NooBaa.Spec.Affinity != nil {
-		podSpec.Affinity = r.NooBaa.Spec.Affinity
-	}
+	podSpec.Tolerations = r.NooBaa.Spec.Tolerations
+	podSpec.Affinity = r.NooBaa.Spec.Affinity
 
 	if r.CoreApp.UID == "" {
 		// generate info event for the first creation of noobaa

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -257,12 +257,8 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 
 	endpointsSpec := r.NooBaa.Spec.Endpoints
 	podSpec := &r.DeploymentEndpoint.Spec.Template.Spec
-	if r.NooBaa.Spec.Tolerations != nil {
-		podSpec.Tolerations = r.NooBaa.Spec.Tolerations
-	}
-	if r.NooBaa.Spec.Affinity != nil {
-		podSpec.Affinity = r.NooBaa.Spec.Affinity
-	}
+	podSpec.Tolerations = r.NooBaa.Spec.Tolerations
+	podSpec.Affinity = r.NooBaa.Spec.Affinity
 	if r.NooBaa.Spec.ImagePullSecret == nil {
 		podSpec.ImagePullSecrets =
 			[]corev1.LocalObjectReference{}

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -293,7 +293,7 @@ func RunDelete(cmd *cobra.Command, args []string) {
 	util.KubeList(objectBuckets, &client.ListOptions{LabelSelector: obcSelector})
 	finalizersArray := sys.GetFinalizers()
 
-	if util.Contains(nbv1.GracefulFinalizer, finalizersArray) {
+	if util.Contains(finalizersArray, nbv1.GracefulFinalizer) {
 
 		confirm := sys.Spec.CleanupPolicy.Confirmation
 		if !cleanupData && len(objectBuckets.Items) != 0 && confirm != nbv1.DeleteOBCConfirmation {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -628,7 +628,7 @@ func RemoveFinalizer(obj metav1.Object, finalizer string) bool {
 
 // AddFinalizer adds the finalizer to the object if it doesn't contains it already
 func AddFinalizer(obj metav1.Object, finalizer string) bool {
-	if !Contains(finalizer, obj.GetFinalizers()) {
+	if !Contains(obj.GetFinalizers(), finalizer) {
 		finalizers := append(obj.GetFinalizers(), finalizer)
 		obj.SetFinalizers(finalizers)
 		return true
@@ -1322,14 +1322,29 @@ func WriteYamlFile(name string, obj runtime.Object, moreObjects ...runtime.Objec
 	return nil
 }
 
-// Contains checks if string array arr contains string s
-func Contains(s string, arr []string) bool {
-	for _, b := range arr {
-		b = strings.TrimSpace(b)
-		if b == s {
+// Contains is a generic function
+// that receives a slice and an element from comparable type (sould be from the same type)
+// and returns true if the slice contains the element, otherwise false
+func Contains[T comparable](arr []T, item T) bool {
+	return ContainsAny(
+		arr,
+		item,
+		func(a, b T) bool {
+			return a == b
+		},
+	)
+}
+
+// ContainsAny is a generic function
+// that receives a slice, an element and a function to compare
+// and returns true if the function executed on the item and the slice return true
+func ContainsAny[T any](arr []T, item T, eq func(T, T) bool) bool {
+	for _, element := range arr {
+		if eq(element, item) {
 			return true
 		}
 	}
+
 	return false
 }
 


### PR DESCRIPTION
### Explain the changes
1.  Add toleration and affinity to backingstore pod after editing noobaa CR by adding it as a part of `needUpdate`.
2. Edit the controller of backingstore and add a watch explicitly on changes in noobaa CR.
3. Create a generic function `contains` (will be discussed).
4. Change the condition of toleration and affinity (to be set even if it is `nil`).

### Issues: Fixed [BZ 2149872](https://bugzilla.redhat.com/show_bug.cgi?id=2149872), #1066
1. Title:  Toleration not added to the noobaa-default-backing-store pod after editing storagecluster CR and subs with toleration (to the original BZ about **tolerations** we also added issue #1066 about **affinities**).
2. Before we implemented the change (on adding a change - affinity or toleration): the pods core, db, and endpoint were be terminated and then running, but the operator and backinstore pods were not. 
For the operator it is clear, this is what starts the system, changes in Noobaa CR does not pass to it. 
In the backing store pod, it is a bug.
3. We also solved when the tolerations or affinities were deleted the pods core, db, endpoint and backingstore were not terminated.

### Testing Instructions:
#### Toleration (add a new one):
Requisitions: Have noobaa system running.
Test on minikube - only tolerations (without taint, in minikube we have only one node).
1. Change Noobaa CR and add Toleration to it:  `kubectl edit noobaa noobaa`.
2. Paste this inside :
```
tolerations:
  - effect: NoSchedule
     key: xyz
     operator: Equal
     value: "true"
```
It looks like this (after paste):
![Screenshot 2023-02-15 at 12 33 02](https://user-images.githubusercontent.com/57721533/220886328-eb0d0890-cfb2-413d-8618-f7d6c20a36a3.png)
3. See the changes of the pods:  `kubectl get pods -w`.
would expect to see the pods core, db, endpoint and backingstore terminated. 

#### Affinity (add a new one):
Test on minikube
1. Add affinity on the node: `kubectl label nodes minikube name=app-shira` (I chose `name=app-shira` as a new label).
2. If you want to check that your label was added: `kubectl describe nodes minikube`.
3. Change Noobaa CR and add Affinity to it:  `kubectl edit noobaa noobaa`.
4. Paste this inside :
```
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: name
            operator: In
            values:
            - app-shira
```
It looks like this (after paste):
<img width="441" alt="Screenshot 2023-02-28 at 12 49 07" src="https://user-images.githubusercontent.com/57721533/221832634-e6426109-1323-4607-b918-40eec8ba2039.png">
5. See the changes of the pods:  `kubectl get pods -w`.
would expect to see the pods core, db, endpoint and backingstore terminated. 
- [ ] Doc added/updated
- [ ] Tests added
