### PR TITLE
CI | Update Admission Tests Workflow

### DIFF
--- a/.github/workflows/run_admission_test.yml
+++ b/.github/workflows/run_admission_test.yml
@@ -17,7 +17,7 @@ jobs:
           # Freeze the version of core
           # to avoid a failed run due to code changes in the core repo.
           # Need to update the commit once in a while
-          ref: 293fefb9e755fa0d6bf1cc8b31f74259a0001730
+          ref: c97e4ddd2e5fcc110a3242c224eeea97d228c6eb
 
       - name: Checkout noobaa-operator
         uses: actions/checkout@v3
@@ -75,11 +75,12 @@ jobs:
           --endpoint-resources='{ "limits": {"cpu": "100m","memory": "1G"}, "requests": {"cpu": "100m","memory": "1G"}}' \
           --noobaa-image='noobaa-core:admission-test' -n test
           ./build/_output/bin/noobaa-operator status -n test
-          # we added the sleep since the test pool is in phase ready and condition available
-          # but the test pool storage is not ready yet, see issue:
-          # https://github.com/noobaa/noobaa-operator/issues/1007
-          sleep 3m
-          kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=3m -n test
+
+      - name: Wait for phase Ready in the backingstore pod
+        run: |
+          cd ./noobaa-operator
+          ./.travis/number_of_pods_in_system.sh --namespace test --pods 5
+          kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=5m -n test
 
       - name: Run Admission test
         run: |
@@ -94,8 +95,6 @@ jobs:
           cd ./noobaa-operator
           kubectl get events --sort-by='.metadata.creationTimestamp' -A > logs_kubectl_events.txt
           ./build/_output/bin/noobaa-operator diagnose --db-dump --dir=admission-tests-logs -n test
-          # We have a problem with the db-dump on namespaces which are not default
-          # https://github.com/noobaa/noobaa-operator/issues/1040
           mv logs_kubectl_events.txt ./admission-tests-logs
 
       - name: Save logs

--- a/.travis/number_of_pods_in_system.sh
+++ b/.travis/number_of_pods_in_system.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# This script checks the number of pods in a given namespace.
+# It waits until we have the minimum number of pods to start working on the system.
+CURRENT_PODS_NUMBER=0
+THESHOLD_PODS_NUMBER=5
+NAMESPACE=default
+NUMBER_OF_ITERATIONS=15 # arbitrary number
+
+while true; do
+    case "${1}" in
+        --pods) THESHOLD_PODS_NUMBER=${2}
+                       shift 2 ;;
+        --namespace)  NAMESPACE=${2}
+                        shift 2 ;;
+    esac
+    if [ -z ${1} ]; then
+      break
+    fi
+done
+
+echo "Check status of noobaa pods:"
+echo "Namespace: ${NAMESPACE}"
+echo "Number of pods to start using the system is ${THESHOLD_PODS_NUMBER}"
+
+i=1
+while [ "$i" -le ${NUMBER_OF_ITERATIONS} ];
+do
+    PODS_NUMBER=$(kubectl get pods -n ${NAMESPACE} --no-headers | wc -l)
+    echo ${PODS_NUMBER}
+    echo -ne "\033[1A\033[2K\033[1A" # move the cursor up 1 line and clear the line
+    if [ ${PODS_NUMBER} -ge ${THESHOLD_PODS_NUMBER} ]; then
+        echo "All needed pods were created!"
+        break
+    fi
+
+    echo "waiting for noobaa pods ${PODS_NUMBER}/${THESHOLD_PODS_NUMBER}..."
+    sleep 1
+done


### PR DESCRIPTION
### Explain the changes
1. Remove the comments about open issues that were closed (#1040 and #1007).
2. Add script to wait until we have the backingstore pod (in k8s we cannot wait for a resource that doesn't exist, more information [here](https://github.com/kubernetes/kubernetes/issues/83242)).
3. Update core repo to the latest commit.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none, will be tested in the workflow.

- [ ] Doc added/updated
- [ ] Tests added
