### PR TITLE
Noobaa bucket quota alerts are not working

### DIFF
--- a/deploy/internal/prometheus-rules.yaml
+++ b/deploy/internal/prometheus-rules.yaml
@@ -112,27 +112,27 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: NooBaaBucketReachingQuotaState
+    - alert: NooBaaBucketReachingSizeQuotaState
       annotations:
         description: A NooBaa bucket {{ $labels.bucket_name }} is using {{ printf
           "%0.0f" $value }}% of its quota
-        message: A NooBaa Bucket Is In Reaching Quota State
+        message: A NooBaa Bucket Is In Reaching Size Quota State
         severity_level: warning
         storage_type: NooBaa
       expr: |
-        NooBaa_bucket_quota{bucket_name=~".*"} > 80
+        NooBaa_bucket_size_quota{bucket_name=~".*"} > 80
       for: 5m
       labels:
         severity: warning
-    - alert: NooBaaBucketExceedingQuotaState
+    - alert: NooBaaBucketExceedingSizeQuotaState
       annotations:
-        description: A NooBaa bucket {{ $labels.bucket_name }} is exceeding its quota
+        description: A NooBaa bucket {{ $labels.bucket_name }} is exceeding its size quota
           - {{ printf "%0.0f" $value }}% used
-        message: A NooBaa Bucket Is In Exceeding Quota State
+        message: A NooBaa Bucket Is In Exceeding Size Quota State
         severity_level: warning
         storage_type: NooBaa
       expr: |
-        NooBaa_bucket_quota{bucket_name=~".*"} >= 100
+        NooBaa_bucket_size_quota{bucket_name=~".*"} >= 100
       for: 5m
       labels:
         severity: warning

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3499,7 +3499,7 @@ spec:
         claimName: noobaa-pv-claim
 `
 
-const Sha256_deploy_internal_prometheus_rules_yaml = "cb2ad373486d32ee49226251ebe7f07ff0f189c4efe9cfaa6e2d8b23f606a6d6"
+const Sha256_deploy_internal_prometheus_rules_yaml = "9fc9d30ce1f9ca180867255b363943b672689bb98139d6dcb12b63a95529ae0f"
 
 const File_deploy_internal_prometheus_rules_yaml = `apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -3615,27 +3615,27 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: NooBaaBucketReachingQuotaState
+    - alert: NooBaaBucketReachingSizeQuotaState
       annotations:
         description: A NooBaa bucket {{ $labels.bucket_name }} is using {{ printf
           "%0.0f" $value }}% of its quota
-        message: A NooBaa Bucket Is In Reaching Quota State
+        message: A NooBaa Bucket Is In Reaching Size Quota State
         severity_level: warning
         storage_type: NooBaa
       expr: |
-        NooBaa_bucket_quota{bucket_name=~".*"} > 80
+        NooBaa_bucket_size_quota{bucket_name=~".*"} > 80
       for: 5m
       labels:
         severity: warning
-    - alert: NooBaaBucketExceedingQuotaState
+    - alert: NooBaaBucketExceedingSizeQuotaState
       annotations:
-        description: A NooBaa bucket {{ $labels.bucket_name }} is exceeding its quota
+        description: A NooBaa bucket {{ $labels.bucket_name }} is exceeding its size quota
           - {{ printf "%0.0f" $value }}% used
-        message: A NooBaa Bucket Is In Exceeding Quota State
+        message: A NooBaa Bucket Is In Exceeding Size Quota State
         severity_level: warning
         storage_type: NooBaa
       expr: |
-        NooBaa_bucket_quota{bucket_name=~".*"} >= 100
+        NooBaa_bucket_size_quota{bucket_name=~".*"} >= 100
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
### Explain the changes
Prometheus-rules.yaml should be updated according to https://github.com/noobaa/noobaa-mixins/pull/23

The tag "Noobaa_bucket_quota" has been changed to
"Noobaa_bucket_size_quota" in noobaa-mixins and reflecting the same into noobaa-operator in this PR

### Fixes
* https://bugzilla.redhat.com/show_bug.cgi?id=2154250

### Testing Instructions:
Steps to Reproduce:
1. Create bucket in NooBaa and set capacity quota to 2 GB (RPC call {'name': '<bucket-name>', 'quota': 
{'unit': 'GIGABYTE', 'size': 2}}).
2. Upload 5 files with size 500MB into the bucket.
3. Check alerts in ODF Monitoring.

OR

This patch can be tested with the following TC https://github.com/red-hat-storage/ocs-ci/blob/b28dfcd0e3f7fcf624d6590dd40255821058fbf7/tests/manage/monitoring/prometheus/test_noobaa.py#L21

- [ ] Doc added/updated
- [ ] Tests added
