### PR TITLE
add security context to NooBaa operator pod

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,6 +14,10 @@ spec:
         noobaa-operator: deployment
     spec:
       serviceAccountName: noobaa
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       volumes:
       - name: oidc-token
         projected:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5090,7 +5090,7 @@ spec:
   sourceNamespace: default
 `
 
-const Sha256_deploy_operator_yaml = "2870838f688bf1691d85c64dc5e302eb6575996427c7cfdb7143f322ff0dbd18"
+const Sha256_deploy_operator_yaml = "7c4a0b3f43fcf06a10db4dfc4fa3a4f4e1a26be35cb890e64007405ec7129dec"
 
 const File_deploy_operator_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -5108,6 +5108,10 @@ spec:
         noobaa-operator: deployment
     spec:
       serviceAccountName: noobaa
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       volumes:
       - name: oidc-token
         projected:


### PR DESCRIPTION
### Explain the changes
This PR adds security context to NooBaa operator pod as per the requirements of the IBM VA report.

<img width="815" alt="image" src="https://user-images.githubusercontent.com/45818886/224629334-7120bd83-3a41-4832-99a5-51bd7d6a4471.png">
<img width="307" alt="image" src="https://user-images.githubusercontent.com/45818886/224629396-e126a4f1-b65a-4186-85ff-48f9cf543818.png">

### Issue / BZ
https://bugzilla.redhat.com/show_bug.cgi?id=2167308