### PR TITLE
Master Root Key rotation for K8S secret backend

### DIFF
--- a/.github/workflows/run_kms_rotate_test.yml
+++ b/.github/workflows/run_kms_rotate_test.yml
@@ -1,0 +1,48 @@
+name: KMS Test - K8S Key Rotate
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  run-kms-key-rotate-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - name: Set environment variables
+        run: |
+          echo PATH=$PATH:$HOME/go/bin                                          >> $GITHUB_ENV
+          echo OPERATOR_IMAGE=localhost:5000/noobaa/noobaa-operator:integration >> $GITHUB_ENV
+
+      - name: Deploy Dependencies
+        run: |
+          set -x
+          bash .travis/install-5nodes-kind-cluster.sh
+          go get -v github.com/onsi/ginkgo/ginkgo
+          go install -v github.com/onsi/ginkgo/ginkgo
+          ginkgo version
+
+      - name: Build NooBaa
+        run: |
+          make cli
+          make image
+          docker tag noobaa/noobaa-operator:$(go run cmd/version/main.go) $OPERATOR_IMAGE
+          docker push $OPERATOR_IMAGE
+
+      - name: Install NooBaa CRD and Operator
+        run: |
+          echo "💬 Install NooBaa CRD"
+          ./build/_output/bin/noobaa-operator-local crd create
+
+          echo "💬 Create NooBaa operator deployment"
+          ./build/_output/bin/noobaa-operator-local operator --operator-image=$OPERATOR_IMAGE install
+
+      - name: Run KMS K8S Key Rotate Test
+        run: |
+          make test-kms-key-rotate

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,11 @@ test-kms-dev: vendor
 	@echo "✅ test-kms-dev"
 .PHONY: test-kms-dev
 
+test-kms-key-rotate: vendor
+	ginkgo -v pkg/util/kms/test/rotate
+	@echo "✅ test-kms-key-rotate"
+.PHONY: test-kms-key-rotate
+
 test-kms-tls-sa: vendor
 	ginkgo -v pkg/util/kms/test/tls-sa
 	@echo "✅ test-kms-tls-sa"

--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -1484,6 +1484,10 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      enableKeyRotation:
+                        type: boolean
+                      schedule:
+                        type: string
                       tokenSecretName:
                         type: string
                     type: object
@@ -1605,6 +1609,11 @@ spec:
                 - readyCount
                 - virtualHosts
                 type: object
+              lastKeyRotateTime:
+                description: LastKeyRotateTime is the time system ran an encryption
+                  key rotate
+                format: date-time
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this noobaa system. It corresponds to the CR generation, which

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/operator-framework/operator-lib v0.11.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/rook/rook v1.11.3
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1807,6 +1807,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOekn6B5G/+GMtks9UKbvRU/CMM/o=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -232,6 +232,10 @@ type SecuritySpec struct {
 
 // KeyManagementServiceSpec represent various details of the KMS server
 type KeyManagementServiceSpec struct {
+	// +optional
+	EnableKeyRotation bool `json:"enableKeyRotation,omitempty"`
+	// +optional
+	Schedule          string            `json:"schedule,omitempty"`
 	ConnectionDetails map[string]string `json:"connectionDetails,omitempty"`
 	TokenSecretName   string            `json:"tokenSecretName,omitempty"`
 }
@@ -305,6 +309,10 @@ type NooBaaStatus struct {
 	// Readme is a user readable string with explanations on the system
 	// +optional
 	Readme string `json:"readme,omitempty"`
+
+	// LastKeyRotateTime is the time system ran an encryption key rotate
+	// +optional
+	LastKeyRotateTime metav1.Time `json:"lastKeyRotateTime,omitempty"`
 }
 
 // SystemPhase is a string enum type for system phases
@@ -348,14 +356,23 @@ const (
 	// The root key was synchronized from external KMS
 	ConditionKMSSync corev1.ConditionStatus = "Sync"
 
+	// The root key was rotated
+	ConditionKMSKeyRotate corev1.ConditionStatus = "KeyRotate"
+
 	// Invalid external KMS definition
 	ConditionKMSInvalid corev1.ConditionStatus = "Invalid"
 
 	// Error reading secret from external KMS
 	ConditionKMSErrorRead corev1.ConditionStatus = "ErrorRead"
 
-	// Error writing initial root key to eternal KMS
+	// Error writing initial root key to external KMS
 	ConditionKMSErrorWrite corev1.ConditionStatus = "ErrorWrite"
+
+	// Error in data format, internal error
+	ConditionKMSErrorData corev1.ConditionStatus = "ErrorData"
+
+	// Error in data format, internal error
+	ConditionKMSErrorSecretReconcile corev1.ConditionStatus = "ErrorSecretReconcile"
 )
 
 // AccountsStatus is the status info of admin account

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -1213,6 +1213,7 @@ func (in *NooBaaStatus) DeepCopyInto(out *NooBaaStatus) {
 		*out = new(EndpointsStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	in.LastKeyRotateTime.DeepCopyInto(&out.LastKeyRotateTime)
 	return
 }
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1288,7 +1288,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "317f93d895ce9390304bef23f11f5f08dad040cefd6194f15bf99ebc50bdc31d"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "358ce59efe08f5cd594649cbd2bc49a1cbc4d9771328567d5c9ba897e7263083"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2776,6 +2776,10 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      enableKeyRotation:
+                        type: boolean
+                      schedule:
+                        type: string
                       tokenSecretName:
                         type: string
                     type: object
@@ -2897,6 +2901,11 @@ spec:
                 - readyCount
                 - virtualHosts
                 type: object
+              lastKeyRotateTime:
+                description: LastKeyRotateTime is the time system ran an encryption
+                  key rotate
+                format: date-time
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this noobaa system. It corresponds to the CR generation, which

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20230123"
+	ContainerImageTag = "master-20230426"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -89,6 +89,7 @@ type Reconciler struct {
 	SecretAdmin               *corev1.Secret
 	SecretEndpoints           *corev1.Secret
 	SecretRootMasterKey       string
+	SecretRootMasterMap       *corev1.Secret
 	AWSCloudCreds             *cloudcredsv1.CredentialsRequest
 	AWSSTSRoleSessionName     string
 	IsAWSSTSCluster           bool
@@ -154,6 +155,7 @@ func NewReconciler(
 		SecretOp:                  util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretAdmin:               util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretEndpoints:           util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
+		SecretRootMasterMap:       util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		AzureContainerCreds:       util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		GCPBucketCreds:            util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		AWSCloudCreds:             util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
@@ -197,6 +199,7 @@ func NewReconciler(
 	r.SecretOp.Namespace = r.Request.Namespace
 	r.SecretAdmin.Namespace = r.Request.Namespace
 	r.SecretEndpoints.Namespace = r.Request.Namespace
+	r.SecretRootMasterMap.Namespace = r.Request.Namespace
 	r.AzureContainerCreds.Namespace = r.Request.Namespace
 	r.GCPBucketCreds.Namespace = r.Request.Namespace
 	r.AWSCloudCreds.Namespace = r.Request.Namespace
@@ -237,6 +240,7 @@ func NewReconciler(
 	r.SecretOp.Name = r.Request.Name + "-operator"
 	r.SecretAdmin.Name = r.Request.Name + "-admin"
 	r.SecretEndpoints.Name = r.Request.Name + "-endpoints"
+	r.SecretRootMasterMap.Name = r.Request.Name + "-root-master-key-volume"
 	r.AWSCloudCreds.Name = r.Request.Name + "-aws-cloud-creds"
 	r.AWSCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-aws-cloud-creds-secret"
 	r.AzureContainerCreds.Name = r.Request.Name + "-azure-container-creds"
@@ -295,6 +299,7 @@ func NewReconciler(
 func (r *Reconciler) CheckAll() {
 
 	CheckSystem(r.NooBaa)
+	r.reportKMSConditionStatus()
 	util.KubeCheck(r.CoreApp)
 	util.KubeCheck(r.CoreAppConfig)
 	util.KubeCheck(r.ServiceMgmt)

--- a/pkg/util/kms/kms_ibm_kp.go
+++ b/pkg/util/kms/kms_ibm_kp.go
@@ -16,7 +16,7 @@ import (
 
 // IBM is a NooBaa root master key ibmKpSecretStorage driver
 type IBM struct {
-	UID string  // NooBaa system UID
+	UID string // NooBaa system UID
 }
 
 // NewIBM is IBM KP driver constructor
@@ -24,7 +24,7 @@ func NewIBM(
 	name string,
 	namespace string,
 	uid string,
-) (Driver) {
+) Driver {
 	return &IBM{uid}
 }
 
@@ -37,7 +37,7 @@ func (i *IBM) Config(config map[string]string, tokenSecretName, namespace string
 	}
 
 	// Cloud service IBM KP Instance ID should be passed from NooBaa CR
-	instanceID, instanceIDFound  := config[IbmInstanceIDKey]
+	instanceID, instanceIDFound := config[IbmInstanceIDKey]
 	if !instanceIDFound {
 		return nil, fmt.Errorf("❌ Unable to find IBM Key Protect instance ID in CR %v", IbmInstanceIDKey)
 	}
@@ -98,6 +98,12 @@ func (*IBM) SetContext() map[string]string {
 // DeleteContext returns context used for secret delete operation
 func (*IBM) DeleteContext() map[string]string {
 	return nil
+}
+
+// Version returns the current driver KMS version
+// either singlse string or map, i.e. rotating key
+func (*IBM) Version(kms *KMS) Version {
+	return &VersionSingleSecret{kms, nil}
 }
 
 // Register IBM KP driver with KMS layer

--- a/pkg/util/kms/kms_k8s.go
+++ b/pkg/util/kms/kms_k8s.go
@@ -6,8 +6,8 @@ import (
 
 // K8S is a Kubernetes driver
 type K8S struct {
-	name string  // NooBaa system name
-	ns   string  // NooBaa system namespace
+	name string // NooBaa system name
+	ns   string // NooBaa system namespace
 }
 
 // NewK8S is Kubernetes secret driver constructor
@@ -15,7 +15,7 @@ func NewK8S(
 	name string,
 	namespace string,
 	uid string,
-) (Driver) {
+) Driver {
 	return &K8S{name, namespace}
 }
 
@@ -23,7 +23,7 @@ func NewK8S(
 // Kubernetes secret driver for root master key
 //
 
-// Path returns the k8s secret name
+// Path returns the old format k8s secret name
 func (k *K8S) Path() string {
 	return k.name + "-root-master-key"
 }
@@ -35,7 +35,7 @@ func (*K8S) Name() string {
 
 func k8sContext(ns string) map[string]string {
 	return map[string]string{
-		k8s.SecretNamespace : ns,
+		k8s.SecretNamespace: ns,
 	}
 }
 
@@ -57,6 +57,11 @@ func (k *K8S) DeleteContext() map[string]string {
 // Config returns this driver secret config
 func (k *K8S) Config(map[string]string, string, string) (map[string]interface{}, error) {
 	return nil, nil
+}
+
+// Version returns the driver version
+func (k *K8S) Version(kms *KMS) Version {
+	return &VersionRotatingSecret{VersionBase{kms, nil}, k.name, k.ns}
 }
 
 // Register Kubernetes secret driver with KMS layer

--- a/pkg/util/kms/kms_kmip.go
+++ b/pkg/util/kms/kms_kmip.go
@@ -105,6 +105,12 @@ func (k *KMIP) DeleteContext() map[string]string {
 	return nil
 }
 
+// Version returns the current driver KMS version
+// either single string or map, i.e. rotating key
+func (k *KMIP) Version(kms *KMS) Version {
+	return &VersionSingleSecret{kms, nil}
+}
+
 // Register KMIP driver with KMS layer
 func init() {
 	if err := RegisterDriver(KMIPSecretStorageName, NewKMIP); err != nil {

--- a/pkg/util/kms/kms_vault.go
+++ b/pkg/util/kms/kms_vault.go
@@ -177,6 +177,12 @@ func writeCrtsToFile(secretName string, namespace string, secretValue []byte, en
 	return envVarValue, nil
 }
 
+// Version returns the current driver KMS version
+// either single string or map, i.e. rotating key
+func (*Vault) Version(kms *KMS) Version {
+	return &VersionSingleSecret{kms, nil}
+}
+
 // Register Vault driver with KMS layer
 func init() {
 	if err := RegisterDriver(vault.Name, NewVault); err != nil {

--- a/pkg/util/kms/kms_version.go
+++ b/pkg/util/kms/kms_version.go
@@ -1,0 +1,207 @@
+package kms
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/libopenstorage/secrets"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Version extracts version specific code
+// for two existing KMS models: single secret and
+// rotating secret, a.k.a. map
+// Those two flavors implement KMS SecretStorage interface
+type Version interface {
+	SecretStorage
+	Upgrade() error
+}
+
+// VersionBase contains the base fields
+// of both string and map models of the KMS
+type VersionBase struct {
+	k    *KMS        // Pointer to the parent KMS
+	data interface{} // Secret data stored in the KMS
+	//Could be either string or map
+}
+
+// VersionSingleSecret implements Version interface
+// for the single string KMS secret
+type VersionSingleSecret VersionBase
+
+// Reconcile sets the single string master root key
+// with the system reconciler
+func (v *VersionSingleSecret) Reconcile(r SecretReconciler) error {
+	return r.ReconcileSecretString(v.data.(string))
+}
+
+// Get implements SecretStorage interface for single string secret
+func (v *VersionSingleSecret) Get() error {
+	s, err := v.k.GetSecret(v.k.driver.Path(), v.k.driver.GetContext())
+	if err != nil {
+		// handle k8s get from non-existent secret
+		if strings.Contains(err.Error(), "not found") {
+			return secrets.ErrInvalidSecretId
+		}
+		return err
+	}
+
+	value, ok := s[v.k.driver.Name()]
+	if ok {
+		switch value.(type) {
+		case string:
+			v.data = s[v.k.driver.Name()].(string)
+			return nil
+		}
+	}
+	return secrets.ErrInvalidSecretId
+}
+
+// Set implements SecretStorage interface for single string secret
+func (v *VersionSingleSecret) Set(val string) error {
+	data := map[string]interface{}{
+		v.k.driver.Name(): val,
+	}
+
+	v.data = val
+	return v.k.PutSecret(v.k.driver.Path(), data, v.k.driver.SetContext())
+}
+
+// Delete implements SecretStorage interface for single string secret
+func (v *VersionSingleSecret) Delete() error {
+	return v.k.DeleteSecret(v.k.driver.Path(), v.k.driver.DeleteContext())
+}
+
+// Upgrade implements SecretStorage interface for single string secret
+func (v *VersionSingleSecret) Upgrade() error {
+	// NOOP
+	return nil
+}
+
+// VersionRotatingSecret implements SecretStorage interface
+// for the rotating root master key modeled as map
+type VersionRotatingSecret struct {
+	VersionBase
+	name string
+	ns   string
+}
+
+const (
+	// ActiveRootKey - pointer to the current key name
+	ActiveRootKey = "active_root_key"
+)
+
+// Reconcile sets the secret map, i.e. rotating master root key
+// with the system reconciler
+func (v *VersionRotatingSecret) Reconcile(r SecretReconciler) error {
+	return r.ReconcileSecretMap(v.data.(map[string]string))
+}
+
+// Get implements SecretStorage interface for the secret map, i.e. rotating master root key
+func (v *VersionRotatingSecret) Get() error {
+	s, err := v.k.GetSecret(v.backendSecretName(), v.k.driver.GetContext())
+	if err != nil {
+		// handle k8s get from non-existent secret
+		if strings.Contains(err.Error(), "not found") {
+			return secrets.ErrInvalidSecretId
+		}
+		return err
+	}
+
+	rc := map[string]string{}
+	for k, v := range s {
+		rc[k] = v.(string)
+	}
+
+	v.data = rc
+	return nil
+}
+
+// backendSecretName returns the rotating secret backend secret name
+func (v *VersionRotatingSecret) backendSecretName() string {
+	return v.name + "-root-master-key-backend"
+}
+
+// Set implements SecretStorage interface for the secret map, i.e. rotating master root key
+func (v *VersionRotatingSecret) Set(val string) error {
+	key := keyName()
+	var s map[string]string
+	if v.data == nil {
+		s = map[string]string{}
+	} else {
+		s = v.data.(map[string]string)
+	}
+	s[ActiveRootKey] = key
+	s[key] = val
+	v.data = s
+	return v.k.PutSecret(v.backendSecretName(), toInterfaceMap(s), v.k.driver.SetContext())
+}
+
+// deleteSingleStringSecret removes old format secret during upgrade
+func (v *VersionRotatingSecret) deleteSingleStringSecret() bool {
+	// Make sure single secret backend is deleted
+	v1BackendSecret := &corev1.Secret{}
+	v1BackendSecret.Name = v.k.driver.Path()
+	v1BackendSecret.Namespace = v.ns
+	return util.KubeDelete(v1BackendSecret)
+}
+
+// Delete implements SecretStorage interface for the secret map, i.e. rotating master root key
+func (v *VersionRotatingSecret) Delete() error {
+	// Delete rotating secret backend
+	backendSecret := &corev1.Secret{}
+	backendSecret.Name = v.backendSecretName()
+	backendSecret.Namespace = v.ns
+	if !util.KubeDelete(backendSecret) {
+		return fmt.Errorf("KMS Delete error for the rotating master root secret backend")
+
+	}
+
+	return nil
+}
+
+// Upgrade implements SecretStorage interface for the secret map, i.e. rotating master root key
+func (v *VersionRotatingSecret) Upgrade() error {
+	v1 := VersionSingleSecret{v.k, nil}
+	err := v1.Get()
+	if err != nil {
+		if err == secrets.ErrInvalidSecretId {
+			return nil // nothing to upgrade
+		}
+		return fmt.Errorf("KMS Upgrade Get error %w", err)
+	}
+
+	err = v.k.Set(v1.data.(string))
+	if err != nil {
+		return fmt.Errorf("KMS Upgrade Set error %w", err)
+	}
+
+	err = v.k.DeleteSecret(v.k.driver.Path(), v.k.driver.DeleteContext())
+	if err != nil {
+		return fmt.Errorf("KMS Upgrade Delete error %w", err)
+	}
+
+	// Make sure single secret backend is deleted
+	if !v.deleteSingleStringSecret() {
+		return fmt.Errorf("KMS Delete error for single secret")
+	}
+
+	return nil
+}
+
+// keyName generates a new timestamped key name,
+// for secret map, i.e. rotating master root key
+func keyName() string {
+	return fmt.Sprintf("key-%v", time.Now().UnixNano())
+}
+
+// toInterfaceMap converts map of string to string to map of string to interface
+func toInterfaceMap(s map[string]string) map[string]interface{} {
+	data := map[string]interface{}{}
+	for k, v := range s {
+		data[k] = v
+	}
+	return data
+}

--- a/pkg/util/kms/test/rotate/kms_rotate_suite_test.go
+++ b/pkg/util/kms/test/rotate/kms_rotate_suite_test.go
@@ -1,0 +1,29 @@
+package kmsrotatetest
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var logger *log.Logger
+
+// KMS - K8S Key Rotate deployment - integration test entry point
+func TestRotateKMS(t *testing.T) {
+	// this variable is defined in .github/workflows/run_kms_*_test.yml
+	// indication of running in integration test environment
+	_, ok := os.LookupEnv("OPERATOR_IMAGE")
+	if !ok {
+		t.Skip() // Not an integration test, skip
+	}
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "KMS (K8S Key Rotate) Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logger = log.New(GinkgoWriter, "INFO: ", log.Lshortfile)
+}, 60)

--- a/pkg/util/kms/test/rotate/kms_rotate_test.go
+++ b/pkg/util/kms/test/rotate/kms_rotate_test.go
@@ -1,0 +1,109 @@
+package kmsrotatetest
+
+import (
+	"github.com/libopenstorage/secrets"
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/system"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util/kms"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getMiniNooBaa() *nbv1.NooBaa {
+	options.MiniEnv = true
+	options.Namespace = corev1.NamespaceDefault
+	nb := system.LoadSystemDefaults()
+	return nb
+}
+
+func getSchedMiniNooBaa() *nbv1.NooBaa {
+	nb := getMiniNooBaa()
+	nb.Spec.Security.KeyManagementService.EnableKeyRotation = true
+	nb.Spec.Security.KeyManagementService.Schedule = "* * * * *" // every min
+	return nb
+}
+
+var _ = Describe("KMS - K8S Key Rotate", func() {
+	log := util.Logger()
+
+	Context("Verify Upgrade", func() {
+		noobaa := getMiniNooBaa()
+		cipherKeyB64 := util.RandomBase64(32)
+		log.Printf("💬 Generated cipher_key_b64=%v", cipherKeyB64)
+
+		Specify("Create old format K8S root master key secret", func() {
+			s := &corev1.Secret{}
+
+			s.Name = noobaa.Name + "-root-master-key"
+			s.Namespace = noobaa.Namespace
+			s.StringData = map[string]string{
+				"cipher_key_b64": cipherKeyB64,
+			}
+
+			Expect(util.KubeCreateFailExisting(s)).To(BeTrue())
+		})
+		Specify("Create default system", func() {
+			Expect(util.KubeCreateFailExisting(noobaa)).To(BeTrue())
+		})
+		Specify("Verify KMS condition Type", func() {
+			Expect(util.NooBaaCondition(noobaa, nbv1.ConditionTypeKMSType, secrets.TypeK8s)).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Sync", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSSync)).To(BeTrue())
+		})
+		Specify("Verify new format K8S root master key secret", func() {
+			volumeSecret := &corev1.Secret{}
+			volumeSecret.Name = noobaa.Name + "-root-master-key-volume"
+			volumeSecret.Namespace = noobaa.Namespace
+			Expect(util.KubeCheck(volumeSecret)).To(BeTrue())
+
+			activeRootKey, activeRootKeyOk := volumeSecret.StringData[kms.ActiveRootKey]
+			log.Printf("💬 Found activeRootKey=%v", activeRootKey)
+			Expect(activeRootKeyOk).To(BeTrue())
+			rootKeyValue, rootKeyValueOk := volumeSecret.StringData[activeRootKey]
+			log.Printf("💬 Found rootKeyValue=%v", rootKeyValue)
+			Expect(rootKeyValueOk).To(BeTrue())
+			Expect(rootKeyValue == cipherKeyB64).To(BeTrue())
+		})
+		Specify("Delete NooBaa", func() {
+			Expect(util.KubeDelete(noobaa)).To(BeTrue())
+		})
+	})
+
+	Context("Verify Rotate", func() {
+		noobaa := getSchedMiniNooBaa()
+
+		Specify("Create key rotate schedule system", func() {
+			Expect(util.KubeCreateFailExisting(noobaa)).To(BeTrue())
+		})
+		Specify("Verify KMS condition Type", func() {
+			Expect(util.NooBaaCondition(noobaa, nbv1.ConditionTypeKMSType, secrets.TypeK8s)).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Init", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSInit)).To(BeTrue())
+		})
+		Specify("Restart NooBaa operator", func() {
+			podList := &corev1.PodList{}
+			podSelector, _ := labels.Parse("noobaa-operator=deployment")
+			listOptions := client.ListOptions{Namespace: options.Namespace, LabelSelector: podSelector}
+
+			Expect(util.KubeList(podList, &listOptions)).To(BeTrue())
+			Expect(len(podList.Items)).To(BeEquivalentTo(1))
+			Expect(util.KubeDelete(&podList.Items[0])).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Sync", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSSync)).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Key Rotate", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSKeyRotate)).To(BeTrue())
+		})
+		Specify("Delete NooBaa", func() {
+			Expect(util.KubeDelete(noobaa)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
# KMS - Key Rotate

This is the interface for sharing keys between the NooBaa operator and the NooBaa core, endpoint pods for the Master Root Key rotation feature. [The Root key rotate - core side #7218](https://github.com/noobaa/noobaa-core/pull/7218)

## Sample rotating Master Root Key secret

The secret will contain a list of keys and the pointer to the current key.

```yaml
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: noobaa-root-master-key-volume
  namespace: default
data:
  active_root_key: a2V5LTE2Nzg4MjYyMzE1Mjk3ODk0Mzc=
  key-1678826231529789437: cTJ1SG5pbXJYeHViVTJTUVkwZmZ6eWVhMFNQSHAwLzNUMS9Wbi9vcGNPVT0=
```


## NooBaa core, endpoint pods view

The keys secret volume is mounted into the core, endpoint pods as a volume,
under `/etc/noobaa-server/root_keys` directory

### Pod shell view, 

```shell
bash-4.4$ cd /etc/noobaa-server/root_keys
bash-4.4$ ls -l
total 0
lrwxrwxrwx 1 root root 22 Mar 14 20:37 active_root_key -> ..data/active_root_key
lrwxrwxrwx 1 root root 30 Mar 14 20:37 key-1678826231529789437 -> ..data/key-1678826231529789437
bash-4.4$ for f in *; do echo "$f -> $(cat $f)"; done
active_root_key -> key-1678826231529789437
key-1678826231529789437 -> q2uHnimrXxubU2SQY0ffzyea0SPHp0/3T1/Vn/opcOU=

```