### PR TITLE
[backport to 5.11] Prompting more readable error when we get CONNECTED_BUCKET_DELETING

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,18 +1,21 @@
 name: golangci-lint
-
 on: [push, pull_request]
 
 jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.48.0
+          version: v1.50
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.
@@ -22,6 +25,6 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --disable-all -E varcheck,structcheck,typecheck,errcheck,gosimple,unused,deadcode,ineffassign,staticcheck --timeout=4m
+          args: --disable-all --print-issued-lines -E varcheck,structcheck,typecheck,errcheck,gosimple,unused,deadcode,ineffassign,staticcheck --timeout=4m
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/pkg/validations/backingstore_validations.go
+++ b/pkg/validations/backingstore_validations.go
@@ -263,6 +263,10 @@ func ValidateBackingstoreDeletion(bs nbv1.BackingStore, systemInfo nb.SystemInfo
 		if pool.Name == bs.Name {
 			if pool.Undeletable == "IS_BACKINGSTORE" || pool.Undeletable == "BEING_DELETED" {
 				return nil
+			} else if pool.Undeletable == "CONNECTED_BUCKET_DELETING" {
+				return util.ValidationError{
+					Msg: fmt.Sprintf("cannot complete because objects in Backingstore %q are still being deleted, Please try later", pool.Name),
+				}
 			}
 			return util.ValidationError{
 				Msg: fmt.Sprintf("cannot complete because pool %q in %q state", pool.Name, pool.Undeletable),


### PR DESCRIPTION
Prompting more readable error when we get CONNECTED_BUCKET_DELETING

### Explain the changes
1. Fix for https://bugzilla.redhat.com/show_bug.cgi?id=2144823 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
