### PR TITLE
Replace ownership change init container with K8s FSGroup

### DIFF
--- a/deploy/internal/statefulset-db.yaml
+++ b/deploy/internal/statefulset-db.yaml
@@ -20,25 +20,6 @@ spec:
     spec:
       serviceAccountName: noobaa-db
       terminationGracePeriodSeconds: 60
-      initContainers:
-      #----------------#
-      # INIT CONTAINER #
-      #----------------#
-      - name: init
-        image: NOOBAA_CORE_IMAGE
-        command:
-        - /noobaa_init_files/noobaa_init.sh
-        - init_mongo
-        resources:
-          requests:
-            cpu: "500m"
-            memory: "500Mi"
-          limits:
-            cpu: "500m"
-            memory: "500Mi"
-        volumeMounts:
-        - name: db
-          mountPath: /mongo_data
       containers:
       #--------------------#
       # DATABASE CONTAINER #

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -23,21 +23,6 @@ spec:
       #-----------------#
       # INIT CONTAINERS #
       #-----------------#
-      - name: init
-        image: NOOBAA_CORE_IMAGE
-        command:
-        - /noobaa_init_files/noobaa_init.sh
-        - init_postgres
-        resources:
-          requests:
-            cpu: "500m"
-            memory: "500Mi"
-          limits:
-            cpu: "500m"
-            memory: "500Mi"
-        volumeMounts:
-        - name: db
-          mountPath: /var/lib/pgsql
       - name: initialize-database
         image: NOOBAA_DB_IMAGE
         env:
@@ -122,6 +107,8 @@ spec:
       securityContext: 
         runAsUser: 10001
         runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
   volumeClaimTemplates:
     - metadata:
         name: db

--- a/deploy/scc_db.yaml
+++ b/deploy/scc_db.yaml
@@ -14,7 +14,7 @@ allowedCapabilities:
 - SETUID
 - SETGID
 fsGroup:
-  type: MustRunAs
+  type: RunAsAny
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4239,7 +4239,7 @@ spec:
                   resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_db_yaml = "b6039d7ba3604deb54fdf6c48a7df758e1768e1af294ea21d0988cf30103c1c4"
+const Sha256_deploy_internal_statefulset_db_yaml = "25924f84967caebdeb5d61c2181f0ba04da92306fed7e44834dbcc7480b8d48a"
 
 const File_deploy_internal_statefulset_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4263,25 +4263,6 @@ spec:
     spec:
       serviceAccountName: noobaa-db
       terminationGracePeriodSeconds: 60
-      initContainers:
-      #----------------#
-      # INIT CONTAINER #
-      #----------------#
-      - name: init
-        image: NOOBAA_CORE_IMAGE
-        command:
-        - /noobaa_init_files/noobaa_init.sh
-        - init_mongo
-        resources:
-          requests:
-            cpu: "500m"
-            memory: "500Mi"
-          limits:
-            cpu: "500m"
-            memory: "500Mi"
-        volumeMounts:
-        - name: db
-          mountPath: /mongo_data
       containers:
       #--------------------#
       # DATABASE CONTAINER #
@@ -4318,7 +4299,7 @@ spec:
           storage: 50Gi
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "98abe98cd3089424ef5a7dcebd973b1c307f879d434872029b58c0be392b2756"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "0accc047982dbd1b8c207c81ef2bb1ae8c61c312915d3c2d196799ca6f146816"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4345,21 +4326,6 @@ spec:
       #-----------------#
       # INIT CONTAINERS #
       #-----------------#
-      - name: init
-        image: NOOBAA_CORE_IMAGE
-        command:
-        - /noobaa_init_files/noobaa_init.sh
-        - init_postgres
-        resources:
-          requests:
-            cpu: "500m"
-            memory: "500Mi"
-          limits:
-            cpu: "500m"
-            memory: "500Mi"
-        volumeMounts:
-        - name: db
-          mountPath: /var/lib/pgsql
       - name: initialize-database
         image: NOOBAA_DB_IMAGE
         env:
@@ -4444,6 +4410,8 @@ spec:
       securityContext: 
         runAsUser: 10001
         runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
   volumeClaimTemplates:
     - metadata:
         name: db
@@ -5535,7 +5503,7 @@ rules:
       - bucketclasses
 `
 
-const Sha256_deploy_scc_db_yaml = "49d970f874b9f458e286badddd46d772bbf8270b4d28a7c02002f1eef4d226be"
+const Sha256_deploy_scc_db_yaml = "d91c727214d8879843da81ee8778bf6ad6d06af6bdea0a36ac494b5ccc706d7a"
 
 const File_deploy_scc_db_yaml = `apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -5553,7 +5521,7 @@ allowedCapabilities:
 - SETUID
 - SETGID
 fsGroup:
-  type: MustRunAs
+  type: RunAsAny
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
### Explain the changes

This PR attempts to replace FS ownership change init container with K8s FSGroup in an attempt to:
1. Fix https://github.com/noobaa/noobaa-core/issues/7030.

FSGroup unfortunately is not a silver bullet:
- Its usage helps us gets rid of init container but that just delegates the responsibility of changing permissions and setting owner to kubelet. In theory, this should be more performant because CRI doesn't have to spin up a container just so that we can do our permission adjustment rather kubelet does that automatically on the mounted volume.
- Kubelet will perform 2 actions on the mounted directory
    - Change the group of the owner to the `fsGroup` passed in pod spec. Kubelet does this simply by running `os.Lchown(file, -1, int(*fsGroup))` which is run as a `root` user. This should work most of the time HOWEVER in the issue linked above, it WILL fail because any operation performed by the root user will be executed as `nobody:nogroup` by NFS. This does NOT causes any issues however because kubelet just logs the error instead of erroring out. This works out in our favor in THIS case.
    - Change the directory permissions to `0660 | os.ModeSetgid | 0110` which ensures that we get `drwxdrwx--` permission on the mounted directory which is good enough for us because we run group ID `0` while `os.ModeSetgid` set the first octal to `4` implying that directories and files created within this directory will inherit the group ownership. This suffers the same problem in NFS (root_squash) mounts but because kubelet will not error out, it should work just fine.
 
So this does NOT exactly fixes out problems with NFS mounts but makes sure that our DB pod doesn't ends up in CLBO because of permission issues but will crash if our second init container fails to do its thing (which it will if NFS mount does not provide enough permissions - which I think are available in the above issue's environment)

Reference: [Kubernetes FSGroup Source Code](https://github.com/kubernetes/kubernetes/blob/ad18954259eae3db51bac2274ed4ca7304b923c4/pkg/volume/volume_linux.go#L43)

#### Tests Performed
1. Deploy and run in fresh Minikube Cluster.
2. Deploy and run in fresh OpenShift Cluster (AWS gp2 storageclass).
3. Deploy and run in fresh OpenShift Cluster (AWS NFS mount with `drwxdrwxdrwx` mount permissions and `root_squash` enabled).

### Issues: Fixed #xxx / Gap #xxx
Fixes https://github.com/noobaa/noobaa-core/issues/7030.

### Testing Instructions:
Passing pre-existing CLI tests should be good enough indication as only deployment has changed.
