### PR TITLE
[backport to 5.10] Prompting more readable error when we get CONNECTED_BUCKET_DELETING

### DIFF
--- a/pkg/validations/backingstore_validations.go
+++ b/pkg/validations/backingstore_validations.go
@@ -263,6 +263,10 @@ func ValidateBackingstoreDeletion(bs nbv1.BackingStore, systemInfo nb.SystemInfo
 		if pool.Name == bs.Name {
 			if pool.Undeletable == "IS_BACKINGSTORE" || pool.Undeletable == "BEING_DELETED" {
 				return nil
+			} else if pool.Undeletable == "CONNECTED_BUCKET_DELETING" {
+				return util.ValidationError{
+					Msg: fmt.Sprintf("cannot complete because objects in Backingstore %q are still being deleted, Please try later", pool.Name),
+				}
 			}
 			return util.ValidationError{
 				Msg: fmt.Sprintf("cannot complete because pool %q in %q state", pool.Name, pool.Undeletable),


### PR DESCRIPTION
Prompting more readable error when we get CONNECTED_BUCKET_DELETING

### Explain the changes
1. Backporting PR https://github.com/noobaa/noobaa-operator/pull/1005 

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2176363

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
