### PR TITLE
Bug Fix 1089 | `account-name` And `account-key` Should Not Appear When Creating azure-blob Namespacestore or Backingstore

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -594,8 +594,8 @@ func RunCreateAzureBlob(cmd *cobra.Command, args []string) {
 		mandatoryProperties := []string{"AccountName", "AccountKey"}
 
 		if secretName == "" {
-			accountName := util.GetFlagStringOrPrompt(cmd, "account-name")
-			accountKey := util.GetFlagStringOrPrompt(cmd, "account-key")
+			accountName := util.GetFlagStringOrPromptPassword(cmd, "account-name")
+			accountKey := util.GetFlagStringOrPromptPassword(cmd, "account-key")
 			secret.StringData["AccountName"] = accountName
 			secret.StringData["AccountKey"] = accountKey
 		} else {

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -619,8 +619,8 @@ func RunCreateAzureBlob(cmd *cobra.Command, args []string) {
 		mandatoryProperties := []string{"AccountName", "AccountKey"}
 
 		if secretName == "" {
-			accountName := util.GetFlagStringOrPrompt(cmd, "account-name")
-			accountKey := util.GetFlagStringOrPrompt(cmd, "account-key")
+			accountName := util.GetFlagStringOrPromptPassword(cmd, "account-name")
+			accountKey := util.GetFlagStringOrPromptPassword(cmd, "account-key")
 			secret.StringData["AccountName"] = accountName
 			secret.StringData["AccountKey"] = accountKey
 		} else {


### PR DESCRIPTION
### Explain the changes
1. Change Azure fields (account name and account key) to `GetFlagStringOrPromptPassword`.

### Issues: Fixed #1089
1. The characters in fields account-name and account-key would not appear (same as in aws-s3) after this fix.

### Testing Instructions:
1. Deploy Noobaa On Minikube (Instructions are in draft [here](https://github.com/noobaa/noobaa-core/pull/7261) until the will be moved to the operator repo).
2. it happens in namespacestore and backingstore:
* Namespacestore - Run: `nb namespacestore create azure-blob <name>`, for example: `nb namespacestore create azure-blob shira-azure`
* Backingstore - Run: `nb backingstore create azure-blob <name>`, for example: `nb backingstore create azure-blob shira-bs-azure`

- [ ] Doc added/updated
- [ ] Tests added
