### PR TITLE
CI | Exclude 'docs' Directory From GitHub Workflows 

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,12 @@
 name: golangci-lint
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   golangci:

--- a/.github/workflows/run_admission_test.yml
+++ b/.github/workflows/run_admission_test.yml
@@ -1,5 +1,12 @@
 name: Admission Webhook Tests
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   run-admission-test:

--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -1,5 +1,12 @@
 name: Run Operator Unit Tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/run_hac_test.yml
+++ b/.github/workflows/run_hac_test.yml
@@ -1,5 +1,12 @@
 name: HAC on KIND cluster Test
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   run-hac-test:

--- a/.github/workflows/run_kms_dev_test.yml
+++ b/.github/workflows/run_kms_dev_test.yml
@@ -1,5 +1,12 @@
 name: KMS Test - DEV Vault, Token Auth
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   run-kms-dev-test:

--- a/.github/workflows/run_kms_ibm_kp_test.yml
+++ b/.github/workflows/run_kms_ibm_kp_test.yml
@@ -1,5 +1,12 @@
 name: KMS Test - IBM KP
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   run-kms-ibm-kp-test:

--- a/.github/workflows/run_kms_kmip_test.yml
+++ b/.github/workflows/run_kms_kmip_test.yml
@@ -1,5 +1,12 @@
 name: KMS Test - KMIP
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   run-kms-kmip-test:

--- a/.github/workflows/run_kms_tls_sa_test.yml
+++ b/.github/workflows/run_kms_tls_sa_test.yml
@@ -1,7 +1,12 @@
 name: KMS Test - TLS Vault, K8S ServiceAccount Auth
-
-# Run on each new PR and each new push to existing PR
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   run-kms-tls-sa-test:

--- a/.github/workflows/run_kms_tls_token_test.yml
+++ b/.github/workflows/run_kms_tls_token_test.yml
@@ -1,7 +1,12 @@
 name: KMS Test - TLS Vault, Token Auth
-
-# Run on each new PR and each new push to existing PR
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   run-kms-tls-token-test:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,12 @@
 name: Testing flows
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   auto-update:


### PR DESCRIPTION
### Explain the changes
1. Add `workflow_dispatch` option where we didn't have it.
2. Exclude `doc` directory from the CI (for more information you can see [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths)).

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added
