### PR TITLE
added --dev flag to the cli

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -110,6 +110,11 @@ var ImagePullSecret = ""
 // pod)
 var MiniEnv = false
 
+// DevEnv setting this option indicates to the operator that it is deployed on development environment
+// This info is used by the operator for environment based decisions (e.g. number of resources to request per
+// pod)
+var DevEnv = false
+
 // DisableLoadBalancerService is used for setting the service type to ClusterIP instead of LoadBalancer
 var DisableLoadBalancerService = false
 
@@ -208,6 +213,10 @@ func init() {
 	FlagSet.BoolVar(
 		&MiniEnv, "mini",
 		false, "Signal the operator that it is running in a low resource environment",
+	)
+	FlagSet.BoolVar(
+		&DevEnv, "dev",
+		false, "Set sufficient resources for dev env",
 	)
 	FlagSet.BoolVar(
 		&DisableLoadBalancerService, "disable-load-balancer",

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -213,6 +213,36 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 				Limits:   endpointResourceList,
 			}}
 	}
+	if options.DevEnv {
+		coreResourceList := corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(500), resource.Milli),
+			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(1), resource.Giga),
+		}
+		dbResourceList := corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(1000), resource.Milli),
+			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(2), resource.Giga),
+		}
+		endpointResourceList := corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(500), resource.Milli),
+			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(500), resource.Mega),
+		}
+		sys.Spec.CoreResources = &corev1.ResourceRequirements{
+			Requests: coreResourceList,
+			Limits:   coreResourceList,
+		}
+		sys.Spec.DBResources = &corev1.ResourceRequirements{
+			Requests: dbResourceList,
+			Limits:   dbResourceList,
+		}
+		sys.Spec.Endpoints = &nbv1.EndpointsSpec{
+			MinCount: 1,
+			MaxCount: 1,
+			Resources: &corev1.ResourceRequirements{
+				Requests: endpointResourceList,
+				Limits:   endpointResourceList,
+			}}
+	}
+
 	return sys
 }
 


### PR DESCRIPTION
### Explain the changes
1. added `--dev` flag to noobaa CLI
2. same as `--mini` but with higher resources requests tuned for a dev environment (mainly M1 macs)

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://github.com/noobaa/noobaa-operator/issues/1017

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
