### PR TITLE
fix obc updates

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2036,3 +2036,12 @@ func MapAlternateKeysValue(stringData map[string]string, key string) string {
 
 	return stringData[key]
 }
+
+// CloneMap creates a shallow clone of the given map
+func CloneMap[K comparable, V any](src map[K]V) map[K]V {
+	dst := make(map[K]V)
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}


### PR DESCRIPTION
### Explain the changes
This PR attempts to fix broken OBC updates in NooBaa operator which happened due to https://github.com/kube-object-storage/lib-bucket-provisioner/pull/224.

### Testing Instructions:
1. Deploy NooBaa.
2. Create an OBC with no `additionalConfig.replicationPolicy`.
3. Update the OBC `additionalConfig.replicationPolicy` to add a replication policy.
4. Run `kubectl exec -n noobaa noobaa-db-pg-0 -- psql -d nbcore -c "SELECT * FROM replicationconfigs"` and verify that the updated replication config is reflected here.

- [ ] Doc added/updated
- [ ] Tests added
