### PR TITLE
CI | Undo Exclude Doc Directory from CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,12 +1,5 @@
 name: golangci-lint
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   golangci:

--- a/.github/workflows/run_admission_test.yml
+++ b/.github/workflows/run_admission_test.yml
@@ -1,12 +1,5 @@
 name: Admission Webhook Tests
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-admission-test:

--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -1,12 +1,5 @@
 name: Run Operator Unit Tests
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/run_hac_test.yml
+++ b/.github/workflows/run_hac_test.yml
@@ -1,12 +1,5 @@
 name: HAC on KIND cluster Test
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-hac-test:

--- a/.github/workflows/run_kms_dev_test.yml
+++ b/.github/workflows/run_kms_dev_test.yml
@@ -1,12 +1,5 @@
 name: KMS Test - DEV Vault, Token Auth
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-kms-dev-test:

--- a/.github/workflows/run_kms_ibm_kp_test.yml
+++ b/.github/workflows/run_kms_ibm_kp_test.yml
@@ -1,12 +1,5 @@
 name: KMS Test - IBM KP
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-kms-ibm-kp-test:

--- a/.github/workflows/run_kms_kmip_test.yml
+++ b/.github/workflows/run_kms_kmip_test.yml
@@ -1,12 +1,5 @@
 name: KMS Test - KMIP
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-kms-kmip-test:

--- a/.github/workflows/run_kms_tls_sa_test.yml
+++ b/.github/workflows/run_kms_tls_sa_test.yml
@@ -1,12 +1,5 @@
 name: KMS Test - TLS Vault, K8S ServiceAccount Auth
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-kms-tls-sa-test:

--- a/.github/workflows/run_kms_tls_token_test.yml
+++ b/.github/workflows/run_kms_tls_token_test.yml
@@ -1,12 +1,5 @@
 name: KMS Test - TLS Vault, Token Auth
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-kms-tls-token-test:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,12 +1,5 @@
 name: Testing flows
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   auto-update:


### PR DESCRIPTION
### Explain the changes
1. Undo exclude doc directory from CI. After this change all workflows will run on every change (even if it is only documentation).
This was added in #1093, but it doesn't work well with required tests. We decided not to use the workaround to solve it (as described [here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks)). 

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added
