### PR TITLE
Noobaa CR valiation Fix

### DIFF
--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -136,7 +136,8 @@ func (r *Reconciler) CheckSystemCR() error {
 		return util.NewPersistentError("Invalid, DefaultBackingStoreSpec was deprecated", fmt.Sprintf(`%s`, err))
 	}
 
-	if r.NooBaa.Spec.Autoscaler.AutoscalerType != nbv1.AutoscalerTypeHPAV1 &&
+	if (r.NooBaa.Spec.Autoscaler.AutoscalerType == nbv1.AutoscalerTypeKeda ||
+		r.NooBaa.Spec.Autoscaler.AutoscalerType == nbv1.AutoscalerTypeHPAV2) &&
 		r.NooBaa.Spec.Autoscaler.PrometheusNamespace == "" {
 		return util.NewPersistentError("InvalidEndpointsAutoscalerConfiguration",
 			fmt.Sprintf("Autoscaler %s missing prometheusNamespace property ", r.NooBaa.Spec.Autoscaler.AutoscalerType))

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -114,7 +114,11 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 	if err := r.UpgradeSplitDB(); err != nil {
 		return err
 	}
-
+	// Add AutoscalerType HPAV1 to Noobaa CR if AutoscalerType is empty
+	if r.NooBaa.Spec.Autoscaler.AutoscalerType == "" {
+		r.NooBaa.Spec.Autoscaler.AutoscalerType = nbv1.AutoscalerTypeHPAV1
+		util.KubeUpdate(r.NooBaa)
+	}
 	// create the mongo db only if mongo db url is not given.
 	if r.NooBaa.Spec.MongoDbURL == "" {
 		if err := r.UpgradeSplitDB(); err != nil {

--- a/pkg/validations/noobaa_validation.go
+++ b/pkg/validations/noobaa_validation.go
@@ -66,7 +66,8 @@ func validateCIDR(cidr string) error {
 }
 
 func validateNoobaaAutoscalerConfig(nb nbv1.NooBaa) error {
-	if nb.Spec.Autoscaler.AutoscalerType != nbv1.AutoscalerTypeHPAV1 &&
+	if (nb.Spec.Autoscaler.AutoscalerType == nbv1.AutoscalerTypeKeda ||
+		nb.Spec.Autoscaler.AutoscalerType == nbv1.AutoscalerTypeHPAV2) &&
 		nb.Spec.Autoscaler.PrometheusNamespace == "" {
 		return util.ValidationError{
 			Msg: fmt.Sprintf("Autoscaler %s missing prometheusNamespace property", nb.Spec.Autoscaler.AutoscalerType),


### PR DESCRIPTION
### Explain the changes
1. update condition which validates noobaa CR for autoscaler and adds default AutoscalerType to noobaa CR if no type is mentioned (#1023 )

### Issues: Fixed #xxx / Gap #xxx
1.  If noobaa AutoscalerType is empty noobaa installation is in an error state

### Testing Instructions:
1. Install noobaa in a cluster after installing Prometheus
2. check for the newly created HPA1 autoscaler

- [ ] Doc added/updated
- [ ] Tests added
