### PR TITLE
Fix DB SCC reconcile

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -855,7 +855,9 @@ func (r *Reconciler) ReconcileRootSecret() error {
 
 func (r *Reconciler) reconcileRbac(scc, sa, role, binding string) error {
 	SCC := util.KubeObject(scc).(*secv1.SecurityContextConstraints)
-	util.KubeCreateOptional(SCC)
+	if ok := util.KubeApply(SCC); ok {
+		r.Logger.Infof("ReconcileRbac: SCC %q", SCC.Name)
+	}
 
 	SA := util.KubeObject(sa).(*corev1.ServiceAccount)
 	SA.Namespace = options.Namespace

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -243,6 +243,7 @@ func KubeApply(obj client.Object) bool {
 	clone := obj.DeepCopyObject().(client.Object)
 	err := klient.Get(ctx, objKey, clone)
 	if err == nil {
+		obj.SetResourceVersion(clone.GetResourceVersion())
 		err = klient.Update(ctx, obj)
 		if err == nil {
 			log.Printf("✅ Updated: %s %q\n", gvk.Kind, objKey.Name)


### PR DESCRIPTION
### Explain the changes
`noobaa-db` SCC was updated recently. This update is not getting reflected in system upgrades because NooBaa operator does not update the SCC if it already exists. This PR simply forces the operator to apply the intended SCC to the cluster repeatedly in order to keep it in sync.

### Testing Instructions:
1. Install NooBaa in an openshift cluster (IMPORTANT). NooBaa Operator version must be older than 16th April 2023.
2. Wait for NooBaa to be healthy.
3. Update NooBaa operator image to the one built off this PR.
4. Old DB pod MUST terminate and a new pod should come up. Failure to do so is an issue.

- [ ] Doc added/updated
- [ ] Tests added
