### PR TITLE
CI | Change Deprecating `set-output`

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -25,12 +25,12 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Prepare Suffix
         id: suffix
         if: ${{ github.event.inputs.tag != '' }}
-        run: echo ::set-output name=suffix::"-${{ github.event.inputs.tag }}"
+        run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
 
       - name: Prepare Tags
         id: prep
@@ -39,14 +39,14 @@ jobs:
           DOCKER_OPERATOR_BUNDLE_IMAGE=noobaa/noobaa-operator-bundle
           VERSION="${{ steps.date.outputs.date }}"
           echo "::warning ${VERSION}"
-          echo ::set-output name=version::${VERSION}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
           OPERATOR_TAGS="${DOCKER_OPERATOR_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
           OPERATOR_BUNDLE_TAGS="${DOCKER_OPERATOR_BUNDLE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
           OPERATOR_OCS_DEV_TAG="ocs-dev/noobaa-operator:${{ github.event.inputs.branch }}-latest"
           echo "::warning ${CORE_TAGS}"
-          echo ::set-output name=operatortags::${OPERATOR_TAGS}
-          echo ::set-output name=operatorbundletags::${OPERATOR_BUNDLE_TAGS}
-          echo ::set-output name=ocsdevlatest::${OPERATOR_OCS_DEV_TAG}
+          echo "operatortags=${OPERATOR_TAGS}" >> $GITHUB_OUTPUT
+          echo "operatorbundletags=${OPERATOR_BUNDLE_TAGS}" >> $GITHUB_OUTPUT
+          echo "ocsdevlatest=${OPERATOR_OCS_DEV_TAG}" >> $GITHUB_OUTPUT
 
       - name: Update Core Release
         id: update-release

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Prepare Tags
         id: prep
@@ -25,10 +25,10 @@ jobs:
           DOCKER_OPERATOR_IMAGE=noobaa/noobaa-operator
           VERSION="${{ steps.date.outputs.date }}"
           echo "::warning ${VERSION}"
-          echo ::set-output name=version::${VERSION}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
           OPERATOR_TAGS="${DOCKER_OPERATOR_IMAGE}:master-${VERSION}"          
           echo "::warning ${CORE_TAGS}"
-          echo ::set-output name=operatortags::${OPERATOR_TAGS}
+          echo "operatortags=${OPERATOR_TAGS}" >> $GITHUB_OUTPUT
 
       - name: Update Core Release
         id: update-release


### PR DESCRIPTION
### Explain the changes
1. Change deprecating set-output (instead we use `GITHUB_OUTPUT`), more information [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added
