### PR TITLE
ignore ReadSystemInfo persistent error in deletion

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -436,7 +436,7 @@ func (r *Reconciler) ReconcilePhaseCreating() error {
 // Handles NooBaa core side of the store deletion
 func (r *Reconciler) finalizeCore() error {
 
-	if err := r.ReadSystemInfo(); err != nil {
+	if err := r.ReadSystemInfo(); err != nil && !util.IsPersistentError(err) {
 		return err
 	}
 

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -345,7 +345,7 @@ func (r *Reconciler) ReconcileDeletion(systemFound bool) error {
 	}
 
 	if systemFound {
-		if err := r.ReadSystemInfo(); err != nil {
+		if err := r.ReadSystemInfo(); err != nil && !util.IsPersistentError(err) {
 			return err
 		}
 
@@ -803,7 +803,7 @@ func (r *Reconciler) ReconcileNamespaceStore() error {
 	return nil
 }
 
-//getAuthMethod get auth method based on s3 signature
+// getAuthMethod get auth method based on s3 signature
 func getAuthMethod(signature nbv1.S3SignatureVersion, nsStoreName string) nb.CloudAuthMethod {
 
 	if signature == nbv1.S3SignatureVersionV4 {


### PR DESCRIPTION
### Explain the changes
1. this issue is caused by ReadSystemInfo failing on deletion. this should not cause the deletion to fail. added a check to continue deleting if the error is persistent 

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-operator/issues/1035 

### Testing Instructions:
1. testing instructions in issue

- [ ] Doc added/updated
- [ ] Tests added
