### PR TITLE
Adding quantity quota alerts

### DIFF
--- a/deploy/internal/prometheus-rules.yaml
+++ b/deploy/internal/prometheus-rules.yaml
@@ -136,6 +136,30 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: NooBaaBucketReachingQuantityQuotaState
+      annotations:
+        description: A NooBaa bucket {{ $labels.bucket_name }} is using its quantity of quota
+          - {{ printf "%0.0f" $value }}%
+        message: A NooBaa Bucket Is In Reaching Quantity Quota State
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        NooBaa_bucket_quantity_quota{bucket_name=~".*"} > 80
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NooBaaBucketExceedingQuantityQuotaState
+      annotations:
+        description: A NooBaa bucket {{ $labels.bucket_name }} is exceeding its quantity of quota
+          - {{ printf "%0.0f" $value }}%
+        message: A NooBaa Bucket Is In Exceeding Quantity Quota State
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        NooBaa_bucket_quantity_quota{bucket_name=~".*"} >= 100
+      for: 5m
+      labels:
+        severity: warning
     - alert: NooBaaBucketLowCapacityState
       annotations:
         description: A NooBaa bucket {{ $labels.bucket_name }} is using {{ printf

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3726,7 +3726,7 @@ spec:
         claimName: noobaa-pv-claim
 `
 
-const Sha256_deploy_internal_prometheus_rules_yaml = "9fc9d30ce1f9ca180867255b363943b672689bb98139d6dcb12b63a95529ae0f"
+const Sha256_deploy_internal_prometheus_rules_yaml = "ecddaefe2a2ebcf0b4af80329eb15d393e52005c516878c25b40ba9d01dd425a"
 
 const File_deploy_internal_prometheus_rules_yaml = `apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -3863,6 +3863,30 @@ spec:
         storage_type: NooBaa
       expr: |
         NooBaa_bucket_size_quota{bucket_name=~".*"} >= 100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NooBaaBucketReachingQuantityQuotaState
+      annotations:
+        description: A NooBaa bucket {{ $labels.bucket_name }} is using its quantity of quota
+          - {{ printf "%0.0f" $value }}%
+        message: A NooBaa Bucket Is In Reaching Quantity Quota State
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        NooBaa_bucket_quantity_quota{bucket_name=~".*"} > 80
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NooBaaBucketExceedingQuantityQuotaState
+      annotations:
+        description: A NooBaa bucket {{ $labels.bucket_name }} is exceeding its quantity of quota
+          - {{ printf "%0.0f" $value }}%
+        message: A NooBaa Bucket Is In Exceeding Quantity Quota State
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        NooBaa_bucket_quantity_quota{bucket_name=~".*"} >= 100
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
`NooBaaBucketExceedingSizeQuotaState` and `NooBaaBucketReachingQuantityQuotaState` are missing in the deployment and the result which the alerts are not getting triggered. Adding the above alerts to this patch.

Ref Patch: https://github.com/noobaa/noobaa-mixins/pull/23

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2154250