### PR TITLE
[backport to 5.10] add security context to NooBaa operator pod

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,6 +14,10 @@ spec:
         noobaa-operator: deployment
     spec:
       serviceAccountName: noobaa
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       volumes:
       - name: oidc-token
         projected:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4916,7 +4916,7 @@ spec:
   sourceNamespace: default
 `
 
-const Sha256_deploy_operator_yaml = "2870838f688bf1691d85c64dc5e302eb6575996427c7cfdb7143f322ff0dbd18"
+const Sha256_deploy_operator_yaml = "7c4a0b3f43fcf06a10db4dfc4fa3a4f4e1a26be35cb890e64007405ec7129dec"
 
 const File_deploy_operator_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4934,6 +4934,10 @@ spec:
         noobaa-operator: deployment
     spec:
       serviceAccountName: noobaa
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       volumes:
       - name: oidc-token
         projected:


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>
(cherry picked from commit 2628d3cbff25774b59a5f7895d8db020d082d34b)

### Explain the changes
1. backport of https://github.com/noobaa/noobaa-operator/pull/1069

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
