### PR TITLE
fixing issue - setting externalDNS without port

### DIFF
--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -101,7 +101,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 	if route.Spec.Host != "" {
 		status.ExternalDNS = append(
 			status.ExternalDNS,
-			fmt.Sprintf("%s://%s", proto, route.Spec.Host),
+			fmt.Sprintf("%s://%s:%d", proto, route.Spec.Host, servicePort.Port),
 		)
 	}
 


### PR DESCRIPTION
### Explain the changes
1. Adding the port to the ExternalDNS list as we do to all the other lists: InternalIP and InternalDNS
2. Later in the code in phase4_configuring we are going over this list and trying to remove the port 
https://github.com/jackyalbo/noobaa-operator/blob/cee21fef5f8723df29d6bce6198d38671b0d45c7/pkg/system/phase4_configuring.go#L344-L351
3. this fails as we didn't use to have a port - and we are ignoring this kind of issue so the list doesn't have the ExternalDNS just the Internal - so not propogated to the endpoint and it can't split this virtual host when he gets request url with the external virtual host form. like: obc-bucket-92ab874d-3bce-4c26-b086-XXXX.s3-openshift-storage.apps.xxxx.lab.upshift.rdu2.redhat.com
bucket =  obc-bucket-92ab874d-3bce-4c26-b086-XXXX
externalDNS =  s3-openshift-storage.apps.xxxx.lab.upshift.rdu2.redhat.com

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2183092

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
