### PR TITLE
Refactoring | re-use of code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,3 +255,8 @@ test-util: vendor
 	ginkgo -v pkg/util
 	@echo "✅ test-util"
 .PHONY: test-util
+
+test-validations: 
+	ginkgo -v pkg/validations
+	@echo "✅ test-validations"
+.PHONY: test-validations

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2122,3 +2122,13 @@ func FilterSlice[V any](slice []V, f func(V) bool) []V {
 	}
 	return r
 }
+
+// IsTestEnv checks for TEST_ENV env var existance and equality
+// to true and returns true or false accordingly
+func IsTestEnv() bool {
+	testEnv, ok := os.LookupEnv("TEST_ENV")
+	if ok && testEnv == "true" {
+		return true
+	}
+	return false
+}

--- a/pkg/validations/bucketclass_validation.go
+++ b/pkg/validations/bucketclass_validation.go
@@ -67,24 +67,94 @@ func ValidateTiersNumber(tiers []nbv1.Tier) error {
 }
 
 // GetBucketclassNamespaceStoreArray returns an array of namespacestores of the provided bc
-func GetBucketclassNamespaceStoreArray(bc *nbv1.BucketClass) []string {
+func GetBucketclassNamespaceStoreArray(namespacePolicy *nbv1.NamespacePolicy) []string {
+	log := util.Logger()
+	log.Infof("creating namespace store array %+v from namespace policy", namespacePolicy)
 	var namespaceStoresArr []string
 
-	switch bc.Spec.NamespacePolicy.Type {
+	switch namespacePolicy.Type {
 	case nbv1.NSBucketClassTypeCache:
-		namespaceStoresArr = append(namespaceStoresArr, bc.Spec.NamespacePolicy.Cache.HubResource)
+		namespaceStoresArr = append(namespaceStoresArr, namespacePolicy.Cache.HubResource)
 	case nbv1.NSBucketClassTypeMulti:
-		if bc.Spec.NamespacePolicy.Multi.WriteResource == "" {
-			namespaceStoresArr = bc.Spec.NamespacePolicy.Multi.ReadResources
+		if namespacePolicy.Multi.WriteResource == "" {
+			namespaceStoresArr = namespacePolicy.Multi.ReadResources
 		} else {
-			namespaceStoresArr = append(bc.Spec.NamespacePolicy.Multi.ReadResources,
-				bc.Spec.NamespacePolicy.Multi.WriteResource)
+			namespaceStoresArr = append(namespacePolicy.Multi.ReadResources, namespacePolicy.Multi.WriteResource)
 		}
 	case nbv1.NSBucketClassTypeSingle:
-		namespaceStoresArr = append(namespaceStoresArr, bc.Spec.NamespacePolicy.Single.Resource)
+		namespaceStoresArr = append(namespaceStoresArr, namespacePolicy.Single.Resource)
+	}
+	log.Infof("created namespace store array successfully %+v", namespaceStoresArr)
+	return namespaceStoresArr
+}
+
+// ValidatePlacementPolicy validates backingstore existance and readiness
+func ValidatePlacementPolicy(placementPolicy *nbv1.PlacementPolicy, namespace string) error {
+	log := util.Logger()
+	log.Infof("validating placement policy %+v", placementPolicy)
+	if placementPolicy == nil {
+		return nil
 	}
 
-	return namespaceStoresArr
+	for i := range placementPolicy.Tiers {
+		tier := &placementPolicy.Tiers[i]
+		for _, backingStoreName := range tier.BackingStores {
+			backStore := &nbv1.BackingStore{
+				TypeMeta: metav1.TypeMeta{Kind: "BackingStore"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      backingStoreName,
+					Namespace: namespace,
+				},
+			}
+			if !util.KubeCheck(backStore) {
+				return util.NewPersistentError("MissingBackingStore",
+					fmt.Sprintf("NooBaa BackingStore %q not found or deleted", backingStoreName))
+			}
+			if backStore.Status.Phase == nbv1.BackingStorePhaseRejected {
+				return util.NewPersistentError("RejectedBackingStore",
+					fmt.Sprintf("NooBaa BackingStore %q is in rejected phase", backingStoreName))
+			}
+			if backStore.Status.Phase != nbv1.BackingStorePhaseReady {
+				return fmt.Errorf("NooBaa BackingStore %q is not yet ready", backingStoreName)
+			}
+		}
+	}
+	log.Infof("validated placement policy successfully %+v", placementPolicy)
+	return nil
+}
+
+// ValidateNamespacePolicy validates namespacestores existance and readiness
+func ValidateNamespacePolicy(namespacePolicy *nbv1.NamespacePolicy, namespace string) error {
+	log := util.Logger()
+	log.Infof("validating namespace policy %+v", namespacePolicy)
+	if namespacePolicy == nil {
+		return nil
+	}
+
+	namespaceStoresArr := GetBucketclassNamespaceStoreArray(namespacePolicy)
+	// check that namespace stores exists and their phase it ready
+	for _, name := range namespaceStoresArr {
+		nsStore := &nbv1.NamespaceStore{
+			TypeMeta: metav1.TypeMeta{Kind: "NamespaceStore"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+		if !util.KubeCheck(nsStore) {
+			return util.NewPersistentError("MissingNamespaceStore",
+				fmt.Sprintf("NooBaa NamespaceStore %q not found or deleted", name))
+		}
+		if nsStore.Status.Phase == nbv1.NamespaceStorePhaseRejected {
+			return util.NewPersistentError("RejectedNamespaceStore",
+				fmt.Sprintf("NooBaa NamespaceStore %q is in rejected phase", name))
+		}
+		if nsStore.Status.Phase != nbv1.NamespaceStorePhaseReady {
+			return fmt.Errorf("NooBaa NamespaceStore %q is not yet ready", name)
+		}
+	}
+	log.Infof("validated namespace policy successfully %+v", namespacePolicy)
+	return nil
 }
 
 // ValidateNSFSSingleBC validates that bucketclass configured to NS of type NSFS it will only be of type Single.
@@ -92,7 +162,7 @@ func ValidateNSFSSingleBC(bc *nbv1.BucketClass) error {
 	if bc.Spec.NamespacePolicy.Type == nbv1.NSBucketClassTypeSingle {
 		return nil
 	}
-	namespaceStoresArr := GetBucketclassNamespaceStoreArray(bc)
+	namespaceStoresArr := GetBucketclassNamespaceStoreArray(bc.Spec.NamespacePolicy)
 	for _, name := range namespaceStoresArr {
 		nsStore := &nbv1.NamespaceStore{
 			TypeMeta: metav1.TypeMeta{Kind: "NamespaceStore"},

--- a/pkg/validations/common_bucket_validation_integ_test.go
+++ b/pkg/validations/common_bucket_validation_integ_test.go
@@ -1,0 +1,77 @@
+package validations
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	firstBucket  = "first.bucket"
+	secondBucket = "second.bucket"
+)
+
+var _ = Describe("Replication Validation tests", func() {
+
+	It("validate valid replication policy", func() {
+		validReplicationPolicy := getValidReplicationPolicy()
+		err := ValidateReplicationPolicy(secondBucket, validReplicationPolicy, false)
+		Expect(err).To(BeNil())
+	})
+
+	It("validate invalid replication policy - should fail", func() {
+		invalidReplicationPolicy := getInvalidReplicationPolicy()
+		err := ValidateReplicationPolicy(firstBucket, invalidReplicationPolicy, false)
+		expectedErrMsg := fmt.Sprintf("Provisioner Failed to validate replication of bucket \"%s\" with error: INVALID_SCHEMA_PARAMS SERVER bucket_api#/methods/validate_replication", firstBucket)
+		Expect(err.Error()).To(Equal(expectedErrMsg))
+	})
+
+	It("validate invalid replication policy json - should fail", func() {
+		invalidReplicationPolicyJSON := getInvalidReplicationPolicyJSON()
+		err := ValidateReplicationPolicy(firstBucket, invalidReplicationPolicyJSON, false)
+		expectedErrMsg := "Failed to parse replication json {[] <nil>}: unexpected end of JSON input"
+		Expect(err.Error()).To(Equal(expectedErrMsg))
+	})
+
+	It("validate empty replication policy valid", func() {
+		emptyReplicationPolicy := getEmptyReplicationPolicy()
+		err := ValidateReplicationPolicy(firstBucket, emptyReplicationPolicy, false)
+		Expect(err).To(BeNil())
+	})
+
+	It("validate empty replication rules array on create bucket - should fail", func() {
+		emptyRulesArrReplicationPolicy := getEmptyRulesArrReplicationPolicy()
+		err := ValidateReplicationPolicy(firstBucket, emptyRulesArrReplicationPolicy, false)
+		expectedErrMsg := fmt.Sprintf("replication rules array of bucket \"%s\" is empty {[] <nil>}", firstBucket)
+		Expect(err.Error()).To(Equal(expectedErrMsg))
+	})
+
+	It("validate empty replication rules array on create bucket", func() {
+		emptyRulesArrReplicationPolicy := getEmptyRulesArrReplicationPolicy()
+		err := ValidateReplicationPolicy(firstBucket, emptyRulesArrReplicationPolicy, true)
+		Expect(err).To(BeNil())
+
+	})
+})
+
+func getValidReplicationPolicy() string {
+	return `{"rules":[{"rule_id":"rule-1","destination_bucket":"first.bucket","filter":{"prefix":"a"}}]}`
+}
+
+func getInvalidReplicationPolicy() string {
+	return `{"rules":[{"destination_bucket":"second.bucket","filter":{"prefix":"a"}}]}`
+}
+
+func getInvalidReplicationPolicyJSON() string {
+	// missing } at the end of the string
+	return `{"rules":[{"destination_bucket":"second.bucket","filter":{"prefix":"a"}}]`
+}
+
+func getEmptyRulesArrReplicationPolicy() string {
+	return `{"rules":[]}`
+}
+
+func getEmptyReplicationPolicy() string {
+	return ``
+}

--- a/pkg/validations/common_bucket_validations.go
+++ b/pkg/validations/common_bucket_validations.go
@@ -1,0 +1,63 @@
+package validations
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
+	"github.com/noobaa/noobaa-operator/v5/pkg/system"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+)
+
+// ValidateReplicationPolicy validates and replication params and returns the replication policy object
+func ValidateReplicationPolicy(bucketName string, replicationPolicy string, update bool) error {
+	log := util.Logger()
+	if replicationPolicy == "" {
+		return nil
+	}
+
+	var replicationRules nb.ReplicationPolicy
+	err := json.Unmarshal([]byte(replicationPolicy), &replicationRules)
+	if err != nil {
+		return fmt.Errorf("Failed to parse replication json %q: %v", replicationRules, err)
+	}
+	log.Infof("ValidateReplicationPolicy: newReplication %+v", replicationRules)
+
+	if len(replicationRules.Rules) == 0 {
+		if update {
+			return nil
+		}
+		return fmt.Errorf("replication rules array of bucket %q is empty %q", bucketName, replicationRules)
+	}
+
+	replicationParams := &nb.BucketReplicationParams{
+		Name:              bucketName,
+		ReplicationPolicy: replicationRules,
+	}
+
+	log.Infof("ValidateReplicationPolicy: validating replication: replicationParams: %+v", replicationParams)
+	IsExternalRPCConnection := false
+	if util.IsTestEnv() {
+		IsExternalRPCConnection = true
+	}
+	sysClient, err := system.Connect(IsExternalRPCConnection)
+	if err != nil {
+		return fmt.Errorf("Provisioner Failed to validate replication of bucket %q with error: %v", bucketName, err)
+	}
+
+	err = sysClient.NBClient.ValidateReplicationAPI(*replicationParams)
+	if err != nil {
+		rpcErr, isRPCErr := err.(*nb.RPCError)
+		if isRPCErr {
+			if rpcErr.RPCCode == "INVALID_REPLICATION_POLICY" {
+				return fmt.Errorf("Bucket replication configuration is invalid")
+			}
+			if rpcErr.RPCCode == "INVALID_LOG_REPLICATION_INFO" {
+				return fmt.Errorf("Bucket log replication info configuration is invalid")
+			}
+		}
+		return fmt.Errorf("Provisioner Failed to validate replication of bucket %q with error: %v", bucketName, err)
+	}
+	log.Infof("ValidateReplicationPolicy: validated replication successfully")
+	return nil
+}

--- a/pkg/validations/validations_suite_test.go
+++ b/pkg/validations/validations_suite_test.go
@@ -1,0 +1,48 @@
+package validations_test
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+var clientset *kubernetes.Clientset
+var logger *log.Logger
+
+func TestValidations(t *testing.T) {
+	// TODO: add to an existing workflow a run of this test suite
+	// this variable will be defined in .github/workflows/run_some_test.yml
+	// indication of running in integration test environment
+	_, ok := os.LookupEnv("OPERATOR_IMAGE")
+	if !ok {
+		t.Skip() // Not an integration test, skip
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validation Suite")
+}
+
+func connectToK8s() (*kubernetes.Clientset, error) {
+	clientset, err := kubernetes.NewForConfig(util.KubeConfig())
+	if err != nil {
+		logger.Printf("failed to create K8s clientset")
+		return nil, err
+	}
+
+	return clientset, nil
+}
+
+var _ = BeforeSuite(func() {
+	By("Connecting to K8S cluster")
+	logger = log.New(GinkgoWriter, "INFO: ", log.Lshortfile)
+
+	var err error
+	clientset, err = connectToK8s()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(clientset).ToNot(BeNil())
+}, 60)


### PR DESCRIPTION
### Explain the changes
1. Merged same code existed in different contexts:
    a. merged usage of Namespace bucket info structure creation existing in bucketclass reconciler and in obc provisioner code.
   b. Moved validations of namespace policy/placement policy to bucket_class validations class
   c. moved replication validation to a new class called common_bucket_validations.go
   d. moved replication validation from prepare replication params to validateOBC() and validateOB() functions to get it validated as soon as possible before creating the bucket in NooBaa.

these changes are all needed as they will be re-used again in COSI PR https://github.com/noobaa/noobaa-operator/pull/1132

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
