### PR TITLE
Endpoints  topology-spread-constraints added

### DIFF
--- a/doc/noobaa-crd.md
+++ b/doc/noobaa-crd.md
@@ -240,6 +240,22 @@ spec:
   dbConf: |+
     max_connections = 1000
 ```
+## Pod Topology Spread Constraints for Noobaa endpoint
+
+Noobaa operator will add the Topology Spread Constraints to Noobaa endpoint deployment to make sure endpoint pods are evenly spread across nodes. Cluster based on Kubernetes 1.25 and previous versions missing `nodeTaintsPolicy` in `topologySpreadConstraints` and pods are not evenly spread between nodes for these clusters. Noobaa operator checks for the Kubernates version and adds `topologySpreadConstraints` only if the Kubernates version is 1.26+. Operator also skips `topologySpreadConstraints` if this is already set on the deployment, or the CR annotation `noobaa.io/skip_topology_spread_constraints` is set to true.
+
+```yaml
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        noobaa-s3: noobaa
+    nodeTaintsPolicy: Honor
+
+```
+Users can make changes to `topologySpreadConstraints` configuration after the operator creates it and the changes will not override it. But once user remove the custome `topologySpreadConstraints` default value is resotored. 
 
 ## Notes
 1. `dbConf` field will have no effect if `dbType` is not "postgres".

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -478,6 +478,9 @@ const (
 
 	// DeleteOBCConfirmation represents the validation to destry obc
 	DeleteOBCConfirmation CleanupConfirmationProperty = "yes-really-destroy-obc"
+
+	// SkipTopologyConstraints is Annotation name for disabling default topology Constraints
+	SkipTopologyConstraints = "noobaa.io/skip_topology_spread_constraints"
 )
 
 // DBTypes is a string enum type for specify the types of DB that are supported.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,6 +26,7 @@ import (
 	"time"
 	"unicode"
 
+	semver "github.com/coreos/go-semver/semver"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	obv1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	nbapis "github.com/noobaa/noobaa-operator/v5/pkg/apis"
@@ -53,6 +54,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -183,6 +185,22 @@ func KubeConfig() *rest.Config {
 		}
 	}
 	return lazyConfig
+}
+
+// GetKubeVersion will fetch the kubernates minor version
+func GetKubeVersion() (*semver.Version, error) {
+	var err error
+	var discClient *discovery.DiscoveryClient
+	var kubeVersionInfo *version.Info
+	if discClient, err = discovery.NewDiscoveryClientForConfig(KubeConfig()); err != nil {
+		return nil, err
+	}
+	if kubeVersionInfo, err = discClient.ServerVersion(); err != nil {
+		return nil, err
+	}
+	kubeVersion := fmt.Sprintf("%s.%s.0", kubeVersionInfo.Major, kubeVersionInfo.Minor)
+	version, err := semver.NewVersion(kubeVersion)
+	return version, err
 }
 
 // MapperProvider creates RESTMapper


### PR DESCRIPTION
### Explain the changes
1. a new [topology-spread-constraints/](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) is added for noobaa endpoint pod to make sure the endpoint pod spread across multiple nodes with a skew difference of 1.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/MCGI-116

### Testing Instructions:
1. increase the number of endpoint pods either through HPA or manually through  `noobaa-endpoint` Deployment. Each pod should be spread in different nodes with a maximum skew difference of 1. One point to remember is `whenUnsatisfiable` is configured as `ScheduleAnyway` so if there is any CPU/Memory constraint in nodes that node will be skipped and the pod added to another node without considering topology-spread-constraints.

- [ ] Doc added/updated
- [ ] Tests added
