### PR TITLE
Bug Fix #1135 BZ 2214288 | Remove Printing inside `rpc_WS` to Avoid Race Condition

### DIFF
--- a/pkg/nb/rpc_ws.go
+++ b/pkg/nb/rpc_ws.go
@@ -134,7 +134,6 @@ func (c *RPCConnWS) ConnectUnderLock() error {
 func (c *RPCConnWS) ping() error {
 	ctx, cancel := context.WithTimeout(context.Background(), pongTimeout)
 	defer cancel()
-	logrus.Infof("RPC: Ping (%p) %+v", c, c)
 	return c.WS.Ping(ctx)
 }
 


### PR DESCRIPTION
### Explain the changes
1.  Remove printing inside `rpc_ws.go` to avoid a race condition (anyway, there was a plan to refactor and remove it in #811 ).

#### Some details about the investigation:
- `PendingRequests` is a map inside `RPCConnWS`.
- 2 goroutines are relevant in this scope: goroutine `SendPings()` and goroutine `ReadMessages()` which inside it we have `HandleResponse()`.
- When we call `HandleResponse()` we lock the part of the code which deletes an element from a map - but a concurrent goroutine might at this time call `ping` and inside it print `RPCConnW` which contains the map.
- We can have a concurrent write (inside `HandleResponse` we delete) and iterate over the map (inside `ping` read the map).
- In order to help with the investigation we added before the deep-print (`%+v` of the struct `RPCConnW`) a printing of each property separately. When we had an operator crash the error message changed to `fatal error: concurrent map iteration and map write`.

### Issues: Fixed #1135  , [BZ 2214288](https://bugzilla.redhat.com/show_bug.cgi?id=2214288)
1. Both issues are about the restarts of the operator pod, same stack trace.

### Testing Instructions:
1. Deploy Noobaa On Minikube (Instructions are in draft #1097).
3. See if there are any restarts in the operator pod when running `kubectl get pods`.

- [ ] Doc added/updated
- [ ] Tests added
