### PR TITLE
bumped go version to 1.20

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Get Current Date
         id: date

--- a/.github/workflows/run_admission_test.yml
+++ b/.github/workflows/run_admission_test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go on runner
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v2 # Could not change to version 3, see issue:
         # https://github.com/noobaa/noobaa-operator/issues/1031
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Deploy Dependencies
         id: deploy
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Deploy Dependencies
         id: deploy
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Deploy Dependencies
         id: deploy

--- a/.github/workflows/run_cosi_test.yaml
+++ b/.github/workflows/run_cosi_test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go on runner
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/run_hac_test.yml
+++ b/.github/workflows/run_hac_test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/run_kms_dev_test.yml
+++ b/.github/workflows/run_kms_dev_test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/run_kms_ibm_kp_test.yml
+++ b/.github/workflows/run_kms_ibm_kp_test.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/run_kms_kmip_test.yml
+++ b/.github/workflows/run_kms_kmip_test.yml
@@ -13,14 +13,14 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |
           echo PATH=$PATH:$HOME/go/bin                                          >> $GITHUB_ENV
           echo OPERATOR_IMAGE=localhost:5000/noobaa/noobaa-operator:integration >> $GITHUB_ENV
           echo PYKMIP_IMAGE=localhost:5000/noobaa/pykmip:integration >> $GITHUB_ENV
-      
+
       - name: Deploy Dependencies
         run: |
           set -x
@@ -28,7 +28,7 @@ jobs:
           go get -v github.com/onsi/ginkgo/ginkgo
           go install -v github.com/onsi/ginkgo/ginkgo
           ginkgo version
-          
+
       - name: Build NooBaa
         run: |
           make cli

--- a/.github/workflows/run_kms_rotate_test.yml
+++ b/.github/workflows/run_kms_rotate_test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/run_kms_tls_sa_test.yml
+++ b/.github/workflows/run_kms_tls_sa_test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/run_kms_tls_token_test.yml
+++ b/.github/workflows/run_kms_tls_token_test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Get Current Date
         id: date

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ gen-olm: $(OPERATOR_SDK) gen
 
 gen-odf-package: cli
 	rm -rf $(MANIFESTS)
-	MANIFESTS="$(MANIFESTS)" CSV_NAME="$(csv-name)" SKIP_RANGE="$(skip-range)" REPLACES="$(replaces)" CORE_IMAGE="$(core-image)" DB_IMAGE="$(db-image)" OPERATOR_IMAGE="$(operator-image)" OBC_CRD="$(obc-crd)" build/gen-odf-package.sh
+	MANIFESTS="$(MANIFESTS)" CSV_NAME="$(csv-name)" SKIP_RANGE="$(skip-range)" REPLACES="$(replaces)" CORE_IMAGE="$(core-image)" DB_IMAGE="$(db-image)" OPERATOR_IMAGE="$(operator-image)" OPERATOR_IMAGE="$(operator-image)" OBC_CRD="$(obc-crd)" build/gen-odf-package.sh
 	@echo "✅ gen-odf-package"
 .PHONY: gen-odf-package
 

--- a/build/gen-odf-package.sh
+++ b/build/gen-odf-package.sh
@@ -15,6 +15,7 @@ fi
 --noobaa-image ${CORE_IMAGE} \
 --db-image ${DB_IMAGE} \
 --operator-image ${OPERATOR_IMAGE} \
+--operator-image ${OPERATOR_IMAGE} \
 --obc-crd=${OBC_CRD} 
 
 temp_csv=$(mktemp)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/noobaa/noobaa-operator/v5
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/storage v1.30.1

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -65,10 +65,10 @@ func Cmd() *cobra.Command {
 
 	util.InitLogger(logrus.DebugLevel)
 
-	rand.Seed(time.Now().UTC().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 
 	logo := ASCIILogo1
-	if rand.Intn(2) == 0 { // 50% chance
+	if r.Intn(2) == 0 { // 50% chance
 		logo = ASCIILogo2
 	}
 


### PR DESCRIPTION
### Explain the changes
1. bumped go version in go mod to `1.20`
2. ran `go mod tidy -go=1.20`
3. changed workflows to use go `1.20`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
