### PR TITLE
update noobaa endpoint replication

### DIFF
--- a/deploy/internal/hpa-keda-scaled-object.yaml
+++ b/deploy/internal/hpa-keda-scaled-object.yaml
@@ -1,7 +1,6 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: noobaa-endpoint
   labels:
     deploymentName: noobaa-endpoint
     origin: keda
@@ -12,6 +11,8 @@ spec:
   pollingInterval: 30
   scaleTargetRef:
     name: noobaa-endpoint
+    apiVersion: apps/v1
+    kind: Deployment
   triggers:
     - authenticationRef: 
         name: keda-prom-creds

--- a/deploy/internal/hpav2-autoscaling.yaml
+++ b/deploy/internal/hpav2-autoscaling.yaml
@@ -3,7 +3,6 @@ apiVersion: autoscaling/v2
 metadata:
   labels:
     app: noobaa
-  name: hpav2-noobaa-endpoint
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3708,12 +3708,11 @@ spec:
         runAsGroup: 0
 `
 
-const Sha256_deploy_internal_hpa_keda_scaled_object_yaml = "16cf6a7587f44acaad171e3541f044fe3af1568a0ea60e28e4e37b3eb81e0238"
+const Sha256_deploy_internal_hpa_keda_scaled_object_yaml = "35a812a748636c240124b6688bffd6cc4b3c9535a24574c97fd5a46d4bf9cf99"
 
 const File_deploy_internal_hpa_keda_scaled_object_yaml = `apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: noobaa-endpoint
   labels:
     deploymentName: noobaa-endpoint
     origin: keda
@@ -3724,6 +3723,8 @@ spec:
   pollingInterval: 30
   scaleTargetRef:
     name: noobaa-endpoint
+    apiVersion: apps/v1
+    kind: Deployment
   triggers:
     - authenticationRef: 
         name: keda-prom-creds
@@ -3777,14 +3778,13 @@ spec:
   versionPriority: 100
 `
 
-const Sha256_deploy_internal_hpav2_autoscaling_yaml = "a0b4c55d02b8314d8c6c7858ae18a6c43861d38bbaa2d8d0b7d641b1d9d45b8c"
+const Sha256_deploy_internal_hpav2_autoscaling_yaml = "f9b77a7b7e9175a2930ee95214033858440a3d2f97de3838c104b8ece78d6b47"
 
 const File_deploy_internal_hpav2_autoscaling_yaml = `kind: HorizontalPodAutoscaler
 apiVersion: autoscaling/v2
 metadata:
   labels:
     app: noobaa
-  name: hpav2-noobaa-endpoint
 spec:
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
### Explain the changes
1.  update noobaa endpoint pod with respect to noobaa CR spec. 

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2217904

### Testing Instructions:

1. install Prometheus(only if Promethue missing) and noobaa in cluster 
eg: ``` helm install prometheus  prometheus-community/kube-prometheus-stack -n monitoring ```
nb install --operator-image='{image}' --noobaa-image='{image}' -n {namespace} --autoscaler-type hpav2 --prometheus-namespace {namespace}
2. update noobaa CR with autoscalerType and prometheusNamespace
``` autoscaler: ```
    ``` autoscalerType: hpav2 ```
     ``` prometheusNamespace: monitoring ```
    
3.update noobaa endpoint min and max count from noobaa CR and check the noobaa endpoint scale up/down.


- [ ] Doc added/updated
- [ ] Tests added
