### PR TITLE
Adding ca-inject to the operator yaml as optional, and add it to rootCAs list

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -27,9 +27,19 @@ spec:
               audience: api
       - name: socket
         emptyDir: {}
+      - name: noobaa-ca-inject
+        configMap:
+          name: noobaa-ca-inject
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+          optional: true
       containers:
         - name: noobaa-operator
           image: NOOBAA_OPERATOR_IMAGE
+          volumeMounts:
+          - mountPath: /etc/pki/ca-trust/extracted/pem
+            name: noobaa-ca-inject
           resources:
             limits:
               cpu: "250m"

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5705,7 +5705,7 @@ spec:
   sourceNamespace: default
 `
 
-const Sha256_deploy_operator_yaml = "c1247e731010ceae30dbe32790fa64f99b03ed7902a84a1b3999c10f362e076f"
+const Sha256_deploy_operator_yaml = "439f5d9032805eeff3de6520c9baa1b178f1b044091c432f1196349ffb7f544e"
 
 const File_deploy_operator_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -5736,9 +5736,19 @@ spec:
               audience: api
       - name: socket
         emptyDir: {}
+      - name: noobaa-ca-inject
+        configMap:
+          name: noobaa-ca-inject
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+          optional: true
       containers:
         - name: noobaa-operator
           image: NOOBAA_OPERATOR_IMAGE
+          volumeMounts:
+          - mountPath: /etc/pki/ca-trust/extracted/pem
+            name: noobaa-ca-inject
           resources:
             limits:
               cpu: "250m"


### PR DESCRIPTION
### Explain the changes
1. As we are trying to create an RGW bucket using the operator, we are supposed to have the needed certificates in case RGW uses self-signed certificates. We handled it in core by mounting the OCP-injected CAs, but we didn't for the operator.
2. loading the mounted CA list from "/etc/pki/ca-trust/extracted/pem" happens only once when the operator pod is starting (issue with golang). So, if this mount will be changing in the background we will need to restart the pod in order for the new file to take effect. In order to avoid this restart, I added this file to our reconciled AddToRootCAs util. So we will just need to wait for the next system reconciliation instead of a pod restart.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2153199

### Testing Instructions:
1. Create a cluster with external Ceph (External mode)
2. Add the external cluster CA to you cluster: https://docs.openshift.com/container-platform/4.9/networking/configuring-a-custom-pki.html
3. see that noobaa CR is in Ready and not stuck in Configuring with this Error:
`RequestError: send request failed caused by: Put "https://<IP>:443/nb.1671009473760.apps.<cluster-url>": x509: certificate signed by unknown authority`

- [ ] Doc added/updated
- [ ] Tests added
