### PR TITLE
[backport to 5.13] remove printing inside rpc_ws to avoid race condition

### DIFF
--- a/pkg/nb/rpc_ws.go
+++ b/pkg/nb/rpc_ws.go
@@ -134,7 +134,6 @@ func (c *RPCConnWS) ConnectUnderLock() error {
 func (c *RPCConnWS) ping() error {
 	ctx, cancel := context.WithTimeout(context.Background(), pongTimeout)
 	defer cancel()
-	logrus.Infof("RPC: Ping (%p) %+v", c, c)
 	return c.WS.Ping(ctx)
 }
 


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>
(cherry picked from commit 945cced82a00c30a40804629d96b50a6e36f09d4)

### Explain the changes
1. [backport to 5.13] remove printing inside rpc_ws to avoid race condition


