### PR TITLE
COSI | CLI | bucketclass & bucketclaim support

### DIFF
--- a/deploy/cosi/bucket_class.yaml
+++ b/deploy/cosi/bucket_class.yaml
@@ -3,7 +3,7 @@ kind: BucketClass
 metadata:
   name: my-cosi-bucket-class
 driverName: noobaa.objectstorage.k8s.io
-DeletionPolicy: delete
+deletionPolicy: delete
 parameters:
   placementPolicy: '{"tiers":[{"backingStores":["noobaa-default-backing-store"]}]}'
   replicationPolicy: '"{\"rules\":[{\"rule_id\":\"rule-1\",\"destination_bucket\":\"first.bucket\",\"filter\":{\"prefix\":\"a\"}}]}"'

--- a/deploy/cosi/cosi_bucket.yaml
+++ b/deploy/cosi/cosi_bucket.yaml
@@ -1,0 +1,15 @@
+apiVersion:  objectstorage.k8s.io/v1alpha1
+kind:         Bucket
+metadata:
+  name: my-cosi-bucket-class-xxx
+spec:
+  protocols:
+      - S3
+  bucketClaim:
+    name:             my-cosi-bucket-claim
+    namespace:        my-app
+  bucketClassName:    my-cosi-bucket-class
+  deletionPolicy:     delete
+  driverName:         noobaa.objectstorage.k8s.io
+  parameters: {}
+

--- a/doc/cosi-provisioner.md
+++ b/doc/cosi-provisioner.md
@@ -103,6 +103,10 @@ parameters:
   placementPolicy: '{"tiers":[{"backingStores":["noobaa-default-backing-store"]}]}'
 ```
 
+The equivalent noobaa cli command - 
+noobaa cosi bucketclass create placement-bucketclass my-cosi-bucket-class --backingstores noobaa-default-backing-store
+
+
 &nbsp;
 Example of namespace bucketclass:
 
@@ -116,6 +120,9 @@ DeletionPolicy: delete
 parameters:
   namespacePolicy: '{"type": "Single", "single": { "resource": "nsr-name"}}'
 ```
+
+The equivalent noobaa cli command - 
+noobaa cosi bucketclass create namespace-bucketclass single my-cosi-ns-bucket-class --resource nsr-name
 
 &nbsp;
 Example of namespace bucketclass with a replication policy:
@@ -131,6 +138,12 @@ parameters:
   placementPolicy: '{"tiers":[{"backingStores":["noobaa-default-backing-store"]}]}'
   replicationPolicy: '"{\"rules\":[{\"rule_id\":\"rule-1\",\"destination_bucket\":\"first.bucket\",\"filter\":{\"prefix\":\"a\"}}]}"'
 ```
+
+The equivalent noobaa cli command - 
+/path/to/json-file.json is the path to a JSON file which defines the replication policy
+```shell
+noobaa cosi bucketclass create placement-bucketclass my-cosi-ns-bucket-class --backingstores noobaa-default-backing-store
+--replication-policy=/path/to/json-file.json
 
 ## COSI Bucket Claim
 
@@ -153,6 +166,9 @@ spec:
   protocols:
     - "S3"
 ```
+
+The equivalent noobaa cli command - 
+noobaa cosi bucketclaim create my-cosi-bucket-claim --bucketclass my-cosi-bucket-class
 
 ## COSI BucketAccessClass
 

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	k8s.io/kubectl v0.25.4
 	k8s.io/utils v0.0.0-20230202215443-34013725500c
 	nhooyr.io/websocket v1.8.7
+	sigs.k8s.io/container-object-storage-interface-api v0.1.0
 	sigs.k8s.io/container-object-storage-interface-provisioner-sidecar v0.1.0
 	sigs.k8s.io/container-object-storage-interface-spec v0.1.0
 	sigs.k8s.io/controller-runtime v0.14.4

--- a/go.sum
+++ b/go.sum
@@ -747,8 +747,8 @@ github.com/go-openapi/spec v0.19.8/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHK
 github.com/go-openapi/spec v0.19.15/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
 github.com/go-openapi/spec v0.20.0/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
 github.com/go-openapi/spec v0.20.1/go.mod h1:93x7oh+d+FQsmsieroS4cmR3u0p/ywH649a3qwC9OsQ=
-github.com/go-openapi/spec v0.20.3 h1:uH9RQ6vdyPSs2pSy9fL8QPspDF2AMIMPtmK5coSSjtQ=
 github.com/go-openapi/spec v0.20.3/go.mod h1:gG4F8wdEDN+YPBMVnzE85Rbhf+Th2DTvA9nFPQ5AYEg=
+github.com/go-openapi/spec v0.20.6 h1:ich1RQ3WDbfoeTqTAb+5EIxNmpKVJZWBNah9RAT0jIQ=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+ZPMF/cC8nDY=
@@ -3034,6 +3034,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
+sigs.k8s.io/container-object-storage-interface-api v0.1.0 h1:8tB6JFQhbQIC1hwGQ+q4+tmSSNfjKemb7bFI6C0CK/4=
+sigs.k8s.io/container-object-storage-interface-api v0.1.0/go.mod h1:YiB+i/UGkzqgODDhRG3u7jkbWkQcoUeLEJ7hwOT/2Qk=
 sigs.k8s.io/container-object-storage-interface-provisioner-sidecar v0.1.0 h1:S5Qh/VAd745a2vMyZfK6qLiWJxvGpbUOddBtEVX1nU4=
 sigs.k8s.io/container-object-storage-interface-provisioner-sidecar v0.1.0/go.mod h1:JhfV605PePyAvL4F8wTjJ9ZiSAaGkrMmpn0liMPftJ4=
 sigs.k8s.io/container-object-storage-interface-spec v0.1.0 h1:WHeei3OywFyebPwBkVUuuV1SuGjG6Qm4BBmnfFTVa1Y=

--- a/pkg/apis/noobaa/v1alpha1/cosi_types.go
+++ b/pkg/apis/noobaa/v1alpha1/cosi_types.go
@@ -1,0 +1,45 @@
+package v1alpha1
+
+import (
+	cosiapi "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage"
+	cosiv1 "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage/v1alpha1"
+)
+
+// COSIBucketFinalizer is the name of the COSIBucket finalizer
+const COSIBucketFinalizer = cosiapi.GroupName + "/finalizer"
+
+// COSIBucketClaim is the API type for submitting bucket claims
+type COSIBucketClaim = cosiv1.BucketClaim
+
+// COSIBucketClaimList is a list of COSIBucketClaim
+type COSIBucketClaimList = cosiv1.BucketClaimList
+
+// COSIBucketClaimSpec defines the desired state of COSIBucketClaim
+type COSIBucketClaimSpec = cosiv1.BucketClaimSpec
+
+// COSIBucketClass is the API type for submitting bucket classes
+type COSIBucketClass = cosiv1.BucketClass
+
+// COSIBucketClassList is a list of COSIBucketClass
+type COSIBucketClassList = cosiv1.BucketClassList
+
+// COSIBucket is the API type for provisioners of buckets
+type COSIBucket = cosiv1.Bucket
+
+// COSIBucketList is a list of COSIBucket
+type COSIBucketList = cosiv1.BucketList
+
+// COSIBucketSpec defines the desired state of COSIBucket
+type COSIBucketSpec = cosiv1.BucketSpec
+
+// COSIProtocol is the API type for protocols of buckets
+type COSIProtocol = cosiv1.Protocol
+
+// COSIS3Protocol is a constant represents the s3 protocol of buckets
+const COSIS3Protocol = cosiv1.ProtocolS3
+
+// COSIDeletionPolicyRetain is a constant represents a retain deletion policy
+const COSIDeletionPolicyRetain = cosiv1.DeletionPolicyRetain
+
+// COSIDeletionPolicyDelete is  a constant represents a delete deletion policy
+const COSIDeletionPolicyDelete = cosiv1.DeletionPolicyDelete

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -242,17 +242,36 @@ spec:
     - "S3"
 `
 
-const Sha256_deploy_cosi_bucket_class_yaml = "70fde174ec4079506903cafe587d5b541823ac626ac367364581ca7f1789b39e"
+const Sha256_deploy_cosi_bucket_class_yaml = "df623fd1a41c71246a658ac4b7b13255578210dc4d2756aac60391bc69e489c9"
 
 const File_deploy_cosi_bucket_class_yaml = `apiVersion: objectstorage.k8s.io/v1alpha1
 kind: BucketClass
 metadata:
   name: my-cosi-bucket-class
 driverName: noobaa.objectstorage.k8s.io
-DeletionPolicy: delete
+deletionPolicy: delete
 parameters:
   placementPolicy: '{"tiers":[{"backingStores":["noobaa-default-backing-store"]}]}'
   replicationPolicy: '"{\"rules\":[{\"rule_id\":\"rule-1\",\"destination_bucket\":\"first.bucket\",\"filter\":{\"prefix\":\"a\"}}]}"'
+
+`
+
+const Sha256_deploy_cosi_cosi_bucket_yaml = "23af88f7164889958027390904c4b7d7a411593947e008dbf367f2c4be21f0ee"
+
+const File_deploy_cosi_cosi_bucket_yaml = `apiVersion:  objectstorage.k8s.io/v1alpha1
+kind:         Bucket
+metadata:
+  name: my-cosi-bucket-class-xxx
+spec:
+  protocols:
+      - S3
+  bucketClaim:
+    name:             my-cosi-bucket-claim
+    namespace:        my-app
+  bucketClassName:    my-cosi-bucket-class
+  deletionPolicy:     delete
+  driverName:         noobaa.objectstorage.k8s.io
+  parameters: {}
 
 `
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/backingstore"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bucket"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
+	"github.com/noobaa/noobaa-operator/v5/pkg/cosi"
 	"github.com/noobaa/noobaa-operator/v5/pkg/crd"
 	"github.com/noobaa/noobaa-operator/v5/pkg/diagnostics"
 	"github.com/noobaa/noobaa-operator/v5/pkg/install"
@@ -122,6 +123,7 @@ Load noobaa completion to bash:
 			bucketclass.Cmd(),
 			noobaaaccount.Cmd(),
 			obc.Cmd(),
+			cosi.Cmd(),
 			diagnostics.CmdDiagnoseDeprecated(),
 			diagnostics.CmdDbDumpDeprecated(),
 			diagnostics.Cmd(),

--- a/pkg/cosi/cosi.go
+++ b/pkg/cosi/cosi.go
@@ -1,0 +1,18 @@
+package cosi
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Cmd returns a CLI command
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cosi",
+		Short: "Manage cosi resources",
+	}
+	cmd.AddCommand(
+		CmdCOSIBucketClaim(),
+		CmdCOSIBucketClass(),
+	)
+	return cmd
+}

--- a/pkg/cosi/cosi_bucket_claim.go
+++ b/pkg/cosi/cosi_bucket_claim.go
@@ -1,0 +1,353 @@
+package cosi
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/bundle"
+	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/system"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// CmdCOSIBucketClaim returns a CLI command
+func CmdCOSIBucketClaim() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bucketclaim",
+		Short: "Manage cosi bucket claims",
+	}
+	cmd.AddCommand(
+		CmdCreateBucketClaim(),
+		CmdDeleteBucketClaim(),
+		CmdStatusBucketClaim(),
+		CmdListBucketClaim(),
+	)
+	return cmd
+}
+
+// CmdCreateBucketClaim returns a CLI command
+func CmdCreateBucketClaim() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <bucket-claim-name>",
+		Short: "Create an cosi bucket claim",
+		Run:   RunCreateBucketClaim,
+	}
+
+	cmd.Flags().String("app-namespace", "",
+		"Set the namespace of the application where the COSI bucket claim should be created")
+	cmd.Flags().String("bucketclass", "",
+		"Set bucket class to specify the bucket policy")
+	cmd.Flags().String("path", "",
+		"Set path to specify inner directory in namespace store target path - can be used only while specifing a namespace bucketclass")
+	return cmd
+}
+
+// CmdDeleteBucketClaim returns a CLI command
+func CmdDeleteBucketClaim() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <bucket-claim-name>",
+		Short: "Delete a COSI bucket claim",
+		Run:   RunDeleteBucketClaim,
+	}
+	cmd.Flags().String("app-namespace", "",
+		"Set the namespace of the application where the COSI bucket claim should be created")
+	return cmd
+}
+
+// CmdStatusBucketClaim returns a CLI command
+func CmdStatusBucketClaim() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <bucket-claim-name>",
+		Short: "Status of a COSI bucket claim",
+		Run:   RunStatusBucketClaim,
+	}
+	cmd.Flags().String("app-namespace", "",
+		"Set the namespace of the application where the COSI bucket claim should be created")
+	return cmd
+}
+
+// CmdListBucketClaim returns a CLI command
+func CmdListBucketClaim() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List COSI bucket claims",
+		Run:   RunListBucketClaim,
+		Args:  cobra.NoArgs,
+	}
+	return cmd
+}
+
+// RunCreateBucketClaim runs a CLI command
+func RunCreateBucketClaim(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+
+	if len(args) != 1 || args[0] == "" {
+		log.Fatalf(`Missing expected arguments: <bucket-claim-name> %s`, cmd.UsageString())
+	}
+	name := args[0]
+
+	bucketClassName := util.GetFlagStringOrPrompt(cmd, "bucketclass")
+	appNamespace, _ := cmd.Flags().GetString("app-namespace")
+	path, _ := cmd.Flags().GetString("path")
+
+	cosiBucketClaim := util.KubeObject(bundle.File_deploy_cosi_bucket_claim_yaml).(*nbv1.COSIBucketClaim)
+	cosiBucketClaim.Name = name
+	cosiBucketClaim.Namespace = options.Namespace
+	if appNamespace != "" {
+		cosiBucketClaim.Namespace = appNamespace
+	}
+	if path != "" {
+		cosiBucketClaim.Labels = map[string]string{"path": path}
+	}
+	cosiBucketClaim.Spec.Protocols = []nbv1.COSIProtocol{nbv1.COSIS3Protocol}
+
+	bucketClass := util.KubeObject(bundle.File_deploy_cosi_bucket_class_yaml).(*nbv1.COSIBucketClass)
+	bucketClass.Name = bucketClassName
+	if !util.KubeCheck(bucketClass) {
+		log.Fatalf(`❌ Could not get BucketClass %q in namespace %q`,
+			bucketClass.Name, bucketClass.Namespace)
+	}
+
+	cosiBucketClaim.Spec.BucketClassName = bucketClassName
+	bucketClassSpec, errMsg := CreateBucketClassSpecFromParameters(bucketClass.Parameters)
+	if errMsg != "" {
+		log.Fatalf(`❌ Could not create BucketClass spec out of bucketclass parameters %q %q`, bucketClass.Name, bucketClass.Parameters)
+	}
+	err := ValidateCOSIBucketClaim(cosiBucketClaim.Name, options.Namespace, *bucketClassSpec)
+	if err != nil {
+		log.Fatalf(`❌ Could not validate COSI bucket claim %q in namespace %q validation failed %q`, cosiBucketClaim.Name, cosiBucketClaim.Namespace, err)
+	}
+
+	if !util.KubeCreateFailExisting(cosiBucketClaim) {
+		log.Fatalf(`❌ Could not create COSI bucket claim %q in namespace %q (conflict)`, cosiBucketClaim.Name, cosiBucketClaim.Namespace)
+	}
+
+	log.Printf("")
+	util.PrintThisNoteWhenFinishedApplyingAndStartWaitLoop()
+	log.Printf("")
+	log.Printf("COSI bucket claim Wait Ready:")
+	if WaitReady(cosiBucketClaim) {
+		log.Printf("")
+		log.Printf("")
+		RunStatusBucketClaim(cmd, args)
+	}
+}
+
+// RunDeleteBucketClaim runs a CLI command
+func RunDeleteBucketClaim(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+
+	if len(args) != 1 || args[0] == "" {
+		log.Fatalf(`Missing expected arguments: <bucket-claim-name> %s`, cmd.UsageString())
+	}
+	appNamespace, _ := cmd.Flags().GetString("app-namespace")
+
+	cosiBucketClaim := util.KubeObject(bundle.File_deploy_cosi_bucket_claim_yaml).(*nbv1.COSIBucketClaim)
+	cosiBucketClaim.Name = args[0]
+	cosiBucketClaim.Namespace = options.Namespace
+	if appNamespace != "" {
+		cosiBucketClaim.Namespace = appNamespace
+	}
+
+	if !util.KubeDelete(cosiBucketClaim) {
+		log.Fatalf(`❌ Could not delete COSI bucket claim %q in namespace %q`,
+			cosiBucketClaim.Name, cosiBucketClaim.Namespace)
+	}
+}
+
+// RunStatusBucketClaim runs a CLI command
+func RunStatusBucketClaim(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+
+	if len(args) != 1 || args[0] == "" {
+		log.Fatalf(`Missing expected arguments: <bucket-claim-name> %s`, cmd.UsageString())
+	}
+
+	appNamespace, _ := cmd.Flags().GetString("app-namespace")
+
+	cosiBucketClaim := util.KubeObject(bundle.File_deploy_cosi_bucket_claim_yaml).(*nbv1.COSIBucketClaim)
+	cosiBucket := util.KubeObject(bundle.File_deploy_cosi_cosi_bucket_yaml).(*nbv1.COSIBucket)
+
+	cosiBucketClaim.Name = args[0]
+	cosiBucketClaim.Namespace = options.Namespace
+	if appNamespace != "" {
+		cosiBucketClaim.Namespace = appNamespace
+	}
+
+	if !util.KubeCheck(cosiBucketClaim) {
+		log.Fatalf(`❌ Could not find COSI bucket claim %q in namespace %q`, cosiBucketClaim.Name, cosiBucketClaim.Namespace)
+	}
+
+	cosiBucket.Name = cosiBucketClaim.Status.BucketName
+	if !util.KubeCheck(cosiBucket) {
+		log.Fatalf(`❌ Could not find COSI bucket %q`, cosiBucket.Name)
+	}
+
+	bucketClass := &nbv1.COSIBucketClass{
+		TypeMeta: metav1.TypeMeta{Kind: "BucketClass"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cosiBucketClaim.Spec.BucketClassName,
+			Namespace: options.Namespace,
+		},
+	}
+
+	if bucketClass.Name != "" {
+		if !util.KubeCheck(bucketClass) {
+			log.Errorf(`❌ Could not get BucketClass %q in namespace %q`,
+				bucketClass.Name, bucketClass.Namespace)
+		}
+	}
+
+	sysClient, err := system.Connect(true)
+	if err != nil {
+		util.Logger().Fatalf("❌ %s", err)
+	}
+	var b *nb.BucketInfo
+	if cosiBucketClaim.Status.BucketName != "" {
+		nbClient := sysClient.NBClient
+		bucket, err := nbClient.ReadBucketAPI(nb.ReadBucketParams{Name: cosiBucketClaim.Status.BucketName})
+		if err == nil {
+			b = &bucket
+		}
+	}
+
+	fmt.Printf("\n")
+	fmt.Printf("COSI BucketClaim info:\n")
+	fmt.Printf("  %-22s : %t\n", "Bucket Ready", cosiBucketClaim.Status.BucketReady)
+	fmt.Printf("  %-22s : kubectl get -n %s bucketclaim %s\n", "COSIBucketClaim", cosiBucketClaim.Namespace, cosiBucketClaim.Name)
+	fmt.Printf("  %-22s : kubectl get bucket %s\n", "COSIBucket", cosiBucket.Name)
+	fmt.Printf("  %-22s : kubectl get bucketclasses.objectstorage.k8s.io %s\n", "BucketClass", bucketClass.Name)
+	fmt.Printf("\n")
+
+	fmt.Printf("Shell commands:\n")
+	if b != nil {
+		fmt.Printf("Bucket status:\n")
+		fmt.Printf("  %-22s : %s\n", "Name", b.Name)
+		fmt.Printf("  %-22s : %s\n", "Type", b.BucketType)
+		fmt.Printf("  %-22s : %s\n", "Mode", b.Mode)
+		if b.PolicyModes != nil {
+			fmt.Printf("  %-22s : %s\n", "ResiliencyStatus", b.PolicyModes.ResiliencyStatus)
+			fmt.Printf("  %-22s : %s\n", "QuotaStatus", b.PolicyModes.QuotaStatus)
+		}
+		if b.Undeletable != "" {
+			fmt.Printf("  %-22s : %s\n", "Undeletable", b.Undeletable)
+		}
+		if b.NumObjects != nil {
+			fmt.Printf("  %-22s : %d\n", "Num Objects", b.NumObjects.Value)
+		}
+		if b.DataCapacity != nil {
+			fmt.Printf("  %-22s : %s\n", "Data Size", nb.BigIntToHumanBytes(b.DataCapacity.Size))
+			fmt.Printf("  %-22s : %s\n", "Data Size Reduced", nb.BigIntToHumanBytes(b.DataCapacity.SizeReduced))
+			fmt.Printf("  %-22s : %s\n", "Data Space Avail", nb.BigIntToHumanBytes(b.DataCapacity.AvailableSizeToUpload))
+			fmt.Printf("  %-22s : %s\n", "Num Objects Avail", b.DataCapacity.AvailableQuantityToUpload.ToString())
+		}
+		fmt.Printf("\n")
+	}
+}
+
+// RunListBucketClaim runs a CLI command
+func RunListBucketClaim(cmd *cobra.Command, args []string) {
+	list := &nbv1.COSIBucketClaimList{
+		TypeMeta: metav1.TypeMeta{Kind: "BucketClaim"},
+	}
+	if !util.KubeList(list) {
+		return
+	}
+	if len(list.Items) == 0 {
+		fmt.Printf("No COSI bucket claims found.\n")
+		return
+	}
+	table := (&util.PrintTable{}).AddRow(
+		"NAMESPACE",
+		"NAME",
+		"BUCKET-NAME",
+		"BUCKET-CLASS",
+		"BUCKET-READY",
+	)
+	for i := range list.Items {
+		cosiBucketClaim := &list.Items[i]
+		table.AddRow(
+			cosiBucketClaim.Namespace,
+			cosiBucketClaim.Name,
+			cosiBucketClaim.Status.BucketName,
+			cosiBucketClaim.Spec.BucketClassName,
+			fmt.Sprintf("%t", bool(cosiBucketClaim.Status.BucketReady)),
+		)
+	}
+	fmt.Print(table.String())
+}
+
+// WaitReady waits until the cosi bucket claim status bucket ready changes to true
+func WaitReady(cosiBucketClaim *nbv1.COSIBucketClaim) bool {
+	log := util.Logger()
+	klient := util.KubeClient()
+
+	intervalSec := time.Duration(3)
+	maxRetries := 60
+	retries := 0
+	err := wait.PollImmediateInfinite(intervalSec*time.Second, func() (bool, error) {
+		if retries == maxRetries {
+			return false, fmt.Errorf("COSI bucket claim is not ready after max retries - %q", maxRetries)
+		}
+		retries++
+		err := klient.Get(util.Context(), util.ObjectKey(cosiBucketClaim), cosiBucketClaim)
+		if err != nil {
+			log.Printf("⏳ Failed to get COSI bucket claim: %s", err)
+			return false, nil
+		}
+		CheckPhase(cosiBucketClaim)
+		if cosiBucketClaim.Status.BucketReady {
+			return true, nil
+		}
+		return false, nil
+	})
+	return (err == nil)
+}
+
+// CheckPhase prints the phase and reason for it
+func CheckPhase(cosiBucketClaim *nbv1.COSIBucketClaim) {
+	log := util.Logger()
+	if cosiBucketClaim.Status.BucketReady {
+		log.Printf("✅ COSI bucket claim %q Bucket is ready", cosiBucketClaim.Name)
+	} else {
+		log.Printf("⏳ COSI bucket claim %q is not yet ready", cosiBucketClaim.Name)
+	}
+}
+
+// CreateBucketClassSpecFromParameters converts Cosi bucket class additional Parameters to BucketClassSpec
+func CreateBucketClassSpecFromParameters(parameters map[string]string) (*nbv1.BucketClassSpec, string) {
+	log := util.Logger()
+	spec := &nbv1.BucketClassSpec{}
+	if parameters["placementPolicy"] != "" {
+		log.Infof("CreateBucketClassSpecFromParameters: placement policy - %+v %+v", parameters["placementPolicy"], &spec.PlacementPolicy)
+		if err := json.Unmarshal([]byte(parameters["placementPolicy"]), &spec.PlacementPolicy); err != nil {
+			return nil, fmt.Sprintf("failed to parse placement policy in COSI params %s", parameters["placementPolicy"])
+		}
+	}
+	if parameters["namespacePolicy"] != "" {
+		log.Infof("CreateBucketClassSpecFromParameters: namespace policy - %+v", parameters["namespacePolicy"])
+		if err := json.Unmarshal([]byte(parameters["namespacePolicy"]), &spec.NamespacePolicy); err != nil {
+			return nil, fmt.Sprintf("failed to parse namespace policy in COSI params %s", parameters["namespacePolicy"])
+		}
+	}
+	if parameters["replicationPolicy"] != "" {
+		log.Infof("CreateBucketClassSpecFromParameters: replication policy - %+v", parameters["replicationPolicy"])
+		if err := json.Unmarshal([]byte(parameters["replicationPolicy"]), &spec.ReplicationPolicy); err != nil {
+			return nil, fmt.Sprintf("failed to parse replication policy in COSI params %s", parameters["replicationPolicy"])
+		}
+	}
+	if parameters["quota"] != "" {
+		log.Infof("CreateBucketClassSpecFromParameters: quota - %+v", parameters["quota"])
+		if err := json.Unmarshal([]byte(parameters["quota"]), &spec.Quota); err != nil {
+			return nil, fmt.Sprintf("failed to parse quota policy in COSI params %s", parameters["quota"])
+		}
+	}
+	return spec, ""
+}

--- a/pkg/cosi/cosi_bucket_class.go
+++ b/pkg/cosi/cosi_bucket_class.go
@@ -1,0 +1,432 @@
+package cosi
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
+	"github.com/noobaa/noobaa-operator/v5/pkg/bundle"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CmdCOSIBucketClass returns a CLI command
+func CmdCOSIBucketClass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bucketclass",
+		Short: "Manage cosi bucket classes",
+	}
+	cmd.AddCommand(
+		CmdCreateBucketClass(),
+		CmdDeleteBucketClass(),
+		CmdStatusBucketClass(),
+		CmdListBucketClass(),
+	)
+	return cmd
+}
+
+// CmdCreateBucketClass returns a CLI command
+func CmdCreateBucketClass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an cosi bucket class",
+	}
+
+	cmd.AddCommand(
+		CmdCreateNamespaceBucketclass(),
+		CmdCreatePlacementBucketClass(),
+	)
+
+	return cmd
+}
+
+// CmdCreatePlacementBucketClass returns a CLI command
+func CmdCreatePlacementBucketClass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "placement-bucketclass <bucket-class-name>",
+		Short: "Create placement policy bucket class",
+		Run:   RunCreatePlacementBucketClass,
+	}
+
+	// placement policy flags
+	cmd.Flags().String("placement", "",
+		"Set first tier placement policy - Mirror | Spread | \"\" (empty defaults to single backing store)")
+	cmd.Flags().StringSlice("backingstores", nil,
+		"Set first tier backing stores (use commas or multiple flags)")
+	cmd.Flags().String("replication-policy", "",
+		"Set the json file name that contains the replication rules")
+	cmd.Flags().String("deletion-policy", "retain",
+		"Set the deletion policy, specify how COSI will handle deletion of buckets created on top of the created bucketclass "+
+			"- delete | retain - the default deletion policy is retain")
+	cmd.Flags().String("max-objects", "",
+		"Set quota max objects quantity config to requested bucket")
+	cmd.Flags().String("max-size", "",
+		"Set quota max size config to requested bucket")
+
+	return cmd
+}
+
+// CmdCreateNamespaceBucketclass returns a CLI command
+func CmdCreateNamespaceBucketclass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "namespace-bucketclass <bucket-class-name>",
+		Short: "Create namespace policy bucket class",
+	}
+
+	cmd.AddCommand(
+		CmdCreateSingleNamespaceBucketclass(),
+		CmdCreateMultiNamespaceBucketclass(),
+		CmdCreateCacheNamespaceBucketclass(),
+	)
+
+	return cmd
+}
+
+// CmdCreateSingleNamespaceBucketclass returns a CLI command
+func CmdCreateSingleNamespaceBucketclass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "single <bucket-class-name>",
+		Short: "Create namespace bucket class of type Single",
+		Run:   RunCreateSingleNamespaceBucketClass,
+	}
+
+	// single namespace policy
+	cmd.Flags().String("resource", "",
+		"Set the namespace read and write resource")
+	cmd.Flags().String("replication-policy", "",
+		"Set the json file name that contains replication rules")
+	cmd.Flags().String("deletion-policy", "retain",
+		"Set the deletion policy, specify how COSI will handle deletion of buckets created on top of the created bucketclass "+
+			"- delete | retain - the default deletion policy is retain")
+	return cmd
+}
+
+// CmdCreateMultiNamespaceBucketclass returns a CLI command
+func CmdCreateMultiNamespaceBucketclass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "multi <bucket-class-name>",
+		Short: "Create namespace bucket class of type Multi",
+		Run:   RunCreateMultiNamespaceBucketClass,
+	}
+
+	// multi namespace policy
+	cmd.Flags().String("write-resource", "",
+		"Set the namespace write resource")
+	cmd.Flags().StringSlice("read-resources", nil,
+		"Set the namespace read resources")
+	cmd.Flags().String("replication-policy", "",
+		"Set the json file name that contains replication rules")
+	cmd.Flags().String("deletion-policy", "retain",
+		"Set the deletion policy, specify how COSI will handle deletion of buckets created on top of the created bucketclass "+
+			"- delete | retain - the default deletion policy is retain")
+
+	return cmd
+}
+
+// CmdCreateCacheNamespaceBucketclass returns a CLI command
+func CmdCreateCacheNamespaceBucketclass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache <bucket-class-name>",
+		Short: "Create namespace bucket class of type Cache",
+		Run:   RunCreateCacheNamespaceBucketClass,
+	}
+
+	// cache namespace policy
+	cmd.Flags().String("hub-resource", "",
+		"Set the namespace read and write resource")
+	cmd.Flags().Uint32("ttl", 0,
+		"Set the namespace cache ttl")
+
+	// placement policy flags
+	cmd.Flags().String("placement", "",
+		"Set first tier placement policy - Mirror | Spread | \"\" (empty defaults to single backing store)")
+	cmd.Flags().StringSlice("backingstores", nil,
+		"Set first tier backing stores (use commas or multiple flags)")
+	cmd.Flags().String("replication-policy", "",
+		"Set the json file name that contains replication rules")
+	cmd.Flags().String("deletion-policy", "retain",
+		"Set the deletion policy, specify how COSI will handle deletion of buckets created on top of the created bucketclass "+
+			"- delete | retain - the default deletion policy is retain")
+	return cmd
+}
+
+// CmdDeleteBucketClass returns a CLI command
+func CmdDeleteBucketClass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <bucket-class-name>",
+		Short: "Delete a COSI bucket class",
+		Run:   RunDeleteBucketClass,
+	}
+
+	return cmd
+}
+
+// CmdStatusBucketClass returns a CLI command
+func CmdStatusBucketClass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <bucket-class-name>",
+		Short: "Status of a COSI bucket class",
+		Run:   RunStatusBucketClass,
+	}
+	return cmd
+}
+
+// CmdListBucketClass returns a CLI command
+func CmdListBucketClass() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List COSI bucket classes",
+		Run:   RunListBucketClass,
+		Args:  cobra.NoArgs,
+	}
+	return cmd
+}
+
+// RunCreateSingleNamespaceBucketClass runs a CLI command
+func RunCreateSingleNamespaceBucketClass(cmd *cobra.Command, args []string) {
+	createCommonCOSIBucketclass(cmd, args, nbv1.NSBucketClassTypeSingle, bucketclass.PopulateSingleNamespaceBucketClass)
+}
+
+// RunCreateMultiNamespaceBucketClass runs a CLI command
+func RunCreateMultiNamespaceBucketClass(cmd *cobra.Command, args []string) {
+	createCommonCOSIBucketclass(cmd, args, nbv1.NSBucketClassTypeMulti, bucketclass.PopulateMultiNamespaceBucketClass)
+}
+
+// RunCreateCacheNamespaceBucketClass runs a CLI command
+func RunCreateCacheNamespaceBucketClass(cmd *cobra.Command, args []string) {
+	createCommonCOSIBucketclass(cmd, args, nbv1.NSBucketClassTypeCache, bucketclass.PopulateCacheNamespaceBucketClass)
+}
+
+// RunCreatePlacementBucketClass runs a CLI command
+func RunCreatePlacementBucketClass(cmd *cobra.Command, args []string) {
+	createCommonCOSIBucketclass(cmd, args, "", bucketclass.PopulatePlacementBucketClass)
+}
+
+// createCommonBucketclass runs a CLI command
+func createCommonCOSIBucketclass(cmd *cobra.Command, args []string, bucketClassType nbv1.NSBucketClassType, populate func(cmd *cobra.Command, bucketClassSpec *nbv1.BucketClassSpec) ([]string, []string)) {
+
+	log := util.Logger()
+	if len(args) != 1 || args[0] == "" {
+		log.Fatalf(`❌ Missing expected arguments: <bucket-class-name> %s`, cmd.UsageString())
+	}
+	name := args[0]
+
+	// Check and get system
+	o := util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml)
+	sys := o.(*nbv1.NooBaa)
+	sys.Name = options.SystemName
+	sys.Namespace = options.Namespace
+
+	o = util.KubeObject(bundle.File_deploy_cosi_bucket_class_yaml)
+	bucketClass := o.(*nbv1.COSIBucketClass)
+	bucketClass.Name = name
+	bucketClass.DriverName = options.COSIDriverName()
+
+	deletionPolicy, _ := cmd.Flags().GetString("deletion-policy")
+	if deletionPolicy == "delete" {
+		bucketClass.DeletionPolicy = nbv1.COSIDeletionPolicyDelete
+	} else if deletionPolicy == "retain" {
+		bucketClass.DeletionPolicy = nbv1.COSIDeletionPolicyRetain
+	} else {
+		log.Fatalf(`❌ Invalid deletion policy, valid values are delete or retain %s`, deletionPolicy)
+	}
+
+	if !util.KubeCheck(sys) {
+		log.Fatalf(`❌ Could not find NooBaa system %q in namespace %q`, sys.Name, sys.Namespace)
+	}
+
+	err := util.KubeClient().Get(util.Context(), util.ObjectKey(bucketClass), bucketClass)
+	if err == nil {
+		log.Fatalf(`❌ BucketClass %q already exists in namespace %q`, bucketClass.Name, bucketClass.Namespace)
+	}
+
+	bucketClassSpec := &nbv1.BucketClassSpec{}
+	if bucketClassType != "" {
+		bucketClassSpec.NamespacePolicy = &nbv1.NamespacePolicy{
+			Type: bucketClassType,
+		}
+	}
+	if bucketClassType == "" || bucketClassType == nbv1.NSBucketClassTypeCache {
+		bucketClassSpec.PlacementPolicy = &nbv1.PlacementPolicy{
+			Tiers: []nbv1.Tier{},
+		}
+	}
+	namespaceStoresArr, backingStoresArr := populate(cmd, bucketClassSpec)
+
+	bucketClassObj := &nbv1.BucketClass{
+		TypeMeta: metav1.TypeMeta{Kind: "BucketClass"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bucketClass.Name,
+			Namespace: options.Namespace,
+		},
+		Spec: *bucketClassSpec,
+	}
+	err = validations.ValidateBucketClass(bucketClassObj)
+	if err != nil {
+		log.Fatalf(`❌ Bucket class validation failed %q`, err)
+	}
+
+	// check that namespace stores exists
+	for _, name := range namespaceStoresArr {
+		nsStore := &nbv1.NamespaceStore{
+			TypeMeta: metav1.TypeMeta{Kind: "NamespaceStore"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: options.Namespace,
+			},
+		}
+		if !util.KubeCheck(nsStore) {
+			log.Fatalf(`❌ Could not get NamespaceStore %q in namespace %q`,
+				nsStore.Name, nsStore.Namespace)
+		}
+	}
+
+	// check that backing stores exists (for cache buckets)
+	for _, name := range backingStoresArr {
+		backStore := &nbv1.BackingStore{
+			TypeMeta: metav1.TypeMeta{Kind: "BackingStore"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: options.Namespace,
+			},
+		}
+		if !util.KubeCheck(backStore) {
+			log.Fatalf(`❌ Could not get BackingStore %q in namespace %q`,
+				backStore.Name, backStore.Namespace)
+		}
+	}
+
+	replicationPolicyJSON, _ := cmd.Flags().GetString("replication-policy")
+	if replicationPolicyJSON != "" {
+		replication, err := util.LoadBucketReplicationJSON(replicationPolicyJSON)
+		if err != nil {
+			log.Fatalf(`❌ %q`, err)
+		}
+		bucketClassSpec.ReplicationPolicy = replication
+	}
+	bucketClass.Parameters = map[string]string{}
+
+	if bucketClassSpec.PlacementPolicy != nil {
+		pp, err := json.Marshal(bucketClassSpec.PlacementPolicy)
+		if err != nil {
+			log.Fatalf(`❌ Could not marshal BucketClass spec placement policy %q %+v`, bucketClass.Name, bucketClassSpec)
+		}
+		bucketClass.Parameters["placementPolicy"] = string(pp)
+	}
+
+	if bucketClassSpec.NamespacePolicy != nil {
+		np, err := json.Marshal(bucketClassSpec.NamespacePolicy)
+		if err != nil {
+			log.Fatalf(`❌ Could not marshal BucketClass spec namespace policy %q %+v`, bucketClass.Name, bucketClassSpec)
+		}
+		bucketClass.Parameters["namespacePolicy"] = string(np)
+	}
+
+	if bucketClassSpec.Quota != nil {
+		q, err := json.Marshal(bucketClassSpec.Quota)
+		if err != nil {
+			log.Fatalf(`❌ Could not marshal BucketClass spec quota %q %+v`, bucketClass.Name, bucketClassSpec)
+		}
+		bucketClass.Parameters["quota"] = string(q)
+
+	}
+
+	if bucketClassSpec.ReplicationPolicy != "" {
+		rp, err := json.Marshal(bucketClassSpec.ReplicationPolicy)
+		if err != nil {
+			log.Fatalf(`❌ Could not marshal BucketClass spec replication policy %q %+v`, bucketClass.Name, bucketClassSpec)
+		}
+		bucketClass.Parameters["replicationPolicy"] = string(rp)
+
+	}
+
+	if !util.KubeCreateFailExisting(bucketClass) {
+		log.Fatalf(`❌ Could not create BucketClass %q in Namespace %q (conflict)`, bucketClass.Name, bucketClass.Namespace)
+	}
+
+	log.Printf("")
+	util.PrintThisNoteWhenFinishedApplyingAndStartWaitLoop()
+	log.Printf("")
+	RunStatusBucketClass(cmd, args)
+}
+
+// RunDeleteBucketClass runs a CLI command
+func RunDeleteBucketClass(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+
+	if len(args) != 1 || args[0] == "" {
+		log.Fatalf(`Missing expected arguments: <bucket-class-name> %s`, cmd.UsageString())
+	}
+
+	cosiBucketClass := util.KubeObject(bundle.File_deploy_cosi_bucket_class_yaml).(*nbv1.COSIBucketClass)
+	cosiBucketClass.Name = args[0]
+
+	if !util.KubeDelete(cosiBucketClass) {
+		log.Fatalf(`❌ Could not delete COSI bucket class %q`, cosiBucketClass.Name)
+	}
+}
+
+// RunStatusBucketClass runs a CLI command
+func RunStatusBucketClass(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+
+	if len(args) != 1 || args[0] == "" {
+		log.Fatalf(`Missing expected arguments: <bucket-class-name> %s`, cmd.UsageString())
+	}
+
+	cosiBucketClass := util.KubeObject(bundle.File_deploy_cosi_bucket_class_yaml).(*nbv1.COSIBucketClass)
+	cosiBucketClass.Name = args[0]
+
+	if !util.KubeCheck(cosiBucketClass) {
+		log.Fatalf(`❌ Could not get BucketClass %q`, cosiBucketClass.Name)
+	}
+
+	fmt.Println()
+	fmt.Println("# BucketClass spec:")
+	fmt.Printf("Name:\n %s\n", cosiBucketClass.Name)
+	fmt.Printf("DeletionPolicy:\n %s\n", cosiBucketClass.DeletionPolicy)
+	fmt.Printf("Spec:\n %+v", cosiBucketClass.Parameters)
+	fmt.Println()
+}
+
+// RunListBucketClass runs a CLI command
+func RunListBucketClass(cmd *cobra.Command, args []string) {
+	list := &nbv1.COSIBucketClassList{
+		TypeMeta: metav1.TypeMeta{Kind: "BucketClass"},
+	}
+
+	if !util.KubeList(list, &client.ListOptions{}) {
+		return
+	}
+	if len(list.Items) == 0 {
+		fmt.Printf("No bucket classes found.\n")
+		return
+	}
+	table := (&util.PrintTable{}).AddRow(
+		"NAME",
+		"PLACEMENT",
+		"NAMESPACE-POLICY",
+		"QUOTA",
+		"AGE",
+	)
+	for i := range list.Items {
+		bc := &list.Items[i]
+		pp := bc.Parameters["placementPolicy"]
+		np := bc.Parameters["namespacePolicy"]
+		quota := bc.Parameters["quota"]
+		table.AddRow(
+			bc.Name,
+			pp,
+			np,
+			quota,
+			util.HumanizeDuration(time.Since(bc.CreationTimestamp.Time).Round(time.Second)),
+		)
+	}
+	fmt.Print(table.String())
+}

--- a/pkg/cosi/cosi_cli_test.go
+++ b/pkg/cosi/cosi_cli_test.go
@@ -1,0 +1,144 @@
+package cosi
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	namespacestore "github.com/noobaa/noobaa-operator/v5/pkg/namespacestore"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/system"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("COSI driver/provisioner tests", func() {
+	os.Setenv("TEST_ENV", "true")
+	options.Namespace = "test"
+
+	CLIPath := "../../build/_output/bin/noobaa-operator-local"
+	defaultBackingStoreName := "noobaa-default-backing-store"
+	firstBucket := "first.bucket"
+	pcBCName := "pc-bucket-class-cli"
+	nsBCName := "ns-bucket-class-cli"
+	invalidNsBCName := "invalid-ns-bucket-class-cli"
+	claimName := "cosi-claim-cli"
+	cosiNSResourceName := "cosi-nsr-cli"
+	var nsResource *nbv1.NamespaceStore
+	log := util.Logger()
+
+	sysClient, err := system.Connect(true)
+	if err != nil {
+		log.Infof("COSI bucket creation tests, can't create sysclient: err= %q", err)
+	}
+
+	// create namespace resource on top of first.bucket
+	nsResource = getNamespaceResourceObj(cosiNSResourceName, firstBucket, sysClient)
+	Expect(util.KubeCreateSkipExisting(nsResource)).To(BeTrue())
+	namespacestore.WaitReady(nsResource)
+
+	Context("Bucket class CLI functions", func() {
+
+		It("cosi placement bucketclass create", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclass", "create", "placement-bucketclass", pcBCName, "--backingstores", defaultBackingStoreName, "--deletion-policy", "retain", "-n", options.Namespace)
+			log.Printf("Running command: create %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: class pc create out %s ", string(out))
+			Expect(err).To(BeNil())
+			Expect(strings.Contains(string(out), "✅ Created: BucketClass")).To(BeTrue())
+		})
+
+		It("cosi namespace bucketclass create", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclass", "create", "namespace-bucketclass", "single", nsBCName, "--resource", cosiNSResourceName, "--deletion-policy", "delete", "-n", options.Namespace)
+			log.Printf("Running command: create %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: class ns create out %s ", string(out))
+			Expect(err).To(BeNil())
+			Expect(strings.Contains(string(out), "✅ Created: BucketClass")).To(BeTrue())
+		})
+
+		It("cosi namespace bucketclass create invalid deletion policy", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclass", "create", "namespace-bucketclass", "single", invalidNsBCName, "--resource", cosiNSResourceName, "--deletion-policy", "invalid-deletion-policy", "-n", options.Namespace)
+			log.Printf("Running command: create %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: class ns create out %s %+v", string(out), err)
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("cosi namespace bucketclass status", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclass", "status", pcBCName, "-n", options.Namespace)
+			log.Printf("Running command: status %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: class pc status out %s ", string(out))
+			Expect(err).To(BeNil())
+			Expectedstatus := "Spec:\n map[placementPolicy:{\"tiers\":[{\"backingStores\":[\"noobaa-default-backing-store\"]}]}]"
+			Expect(strings.Contains(string(out), Expectedstatus)).To(BeTrue())
+		})
+
+		It("cosi namespace bucketclass list", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclass", "list", "-n", options.Namespace)
+			log.Printf("Running command: list %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: class pc list out %s ", string(out))
+			Expect(err).To(BeNil())
+			cleanupKubeResources(nsResource)
+		})
+
+		It("cosi namespace bucketclass delete", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclass", "delete", nsBCName, "-n", options.Namespace)
+			log.Printf("Running command: status %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: class pc delete out %s ", string(out))
+			Expect(err).To(BeNil())
+			expectedDeleteMsg := "Deleted : BucketClass \\\"ns-bucket-class-cli\\\""
+			Expect(strings.Contains(string(out), expectedDeleteMsg)).To(BeTrue())
+		})
+	})
+
+	Context("Bucket claim CLI functions", func() {
+
+		It("cosi bucketclaim create", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclaim", "create", claimName, "--bucketclass", pcBCName, "-n", options.Namespace)
+			log.Printf("Running command: claim create %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: claim create out=%s \n err=%+v", string(out), err)
+			Expect(err).To(BeNil())
+			// TODO - add read bucket and compare
+		})
+
+		It("cosi bucketclaim status", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclaim", "status", claimName, "-n", options.Namespace)
+			log.Printf("Running command: status %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: claim pc status out %s ", string(out))
+			Expect(err).To(BeNil())
+		})
+
+		It("cosi bucketclaim list", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclaim", "list", "-n", options.Namespace)
+			log.Printf("Running command: list %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: claim list out %s ", string(out))
+			Expect(err).To(BeNil())
+		})
+
+		It("cosi bucketclaim delete", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclaim", "delete", claimName, "-n", options.Namespace)
+			log.Printf("Running command: status %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: claim delete out %s ", string(out))
+			Expect(err).To(BeNil())
+		})
+
+		It("cosi placement bucketclass delete", func() {
+			cmd := exec.Command(CLIPath, "cosi", "bucketclass", "delete", pcBCName, "-n", options.Namespace)
+			log.Printf("Running command: status %v args %v ", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			log.Printf("Running command: class pc delete out %s ", string(out))
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/pkg/cosi/validation.go
+++ b/pkg/cosi/validation.go
@@ -3,39 +3,40 @@ package cosi
 import (
 	"fmt"
 
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 )
 
 // ValidateCOSIBucketClaim validate COSI bucket claim
-func ValidateCOSIBucketClaim(objectName string, req *APIRequest) error {
-	return validateAdditionalParameters(objectName, req)
+func ValidateCOSIBucketClaim(objectName string, namespace string, spec nbv1.BucketClassSpec) error {
+	return validateAdditionalParameters(objectName, namespace, spec)
 }
 
 // Validate additional parameters of the cosi bucket
-func validateAdditionalParameters(bucketName string, req *APIRequest) error {
-	placementPolicy := req.BucketClass.PlacementPolicy
-	if err := validations.ValidatePlacementPolicy(placementPolicy, req.Provisioner.Namespace); err != nil {
+func validateAdditionalParameters(bucketName string, namespace string, spec nbv1.BucketClassSpec) error {
+	placementPolicy := spec.PlacementPolicy
+	if err := validations.ValidatePlacementPolicy(placementPolicy, namespace); err != nil {
 		return util.ValidationError{
 			Msg: fmt.Sprintf("cosi bucket claim %q validation error: invalid placementPolicy %v, %v", bucketName, placementPolicy, err),
 		}
 	}
 
-	namespacePolicy := req.BucketClass.NamespacePolicy
-	if err := validations.ValidateNamespacePolicy(namespacePolicy, req.Provisioner.Namespace); err != nil {
+	namespacePolicy := spec.NamespacePolicy
+	if err := validations.ValidateNamespacePolicy(namespacePolicy, namespace); err != nil {
 		return util.ValidationError{
 			Msg: fmt.Sprintf("cosi bucket claim %q validation error: invalid namespacePolicy %v, %v", bucketName, namespacePolicy, err),
 		}
 	}
 
-	replicationPolicy := req.BucketClass.ReplicationPolicy
+	replicationPolicy := spec.ReplicationPolicy
 	if err := validations.ValidateReplicationPolicy(bucketName, replicationPolicy, false); err != nil {
 		return util.ValidationError{
 			Msg: fmt.Sprintf("cosi bucket claim %q validation error: invalid replicationPolicy %v, %v", bucketName, replicationPolicy, err),
 		}
 	}
 
-	quota := req.BucketClass.Quota
+	quota := spec.Quota
 	if err := validations.ValidateQuotaConfig(bucketName, quota); err != nil {
 		return util.ValidationError{
 			Msg: fmt.Sprintf("cosi bucket claim %q validation error: invalid quota %v, %v", bucketName, quota, err),

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/utils/pointer"
+	cosiv1 "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -160,6 +161,7 @@ func init() {
 	Panic(apiextv1.AddToScheme(scheme.Scheme))
 	Panic(nbapis.AddToScheme(scheme.Scheme))
 	Panic(obv1.AddToScheme(scheme.Scheme))
+	Panic(cosiv1.AddToScheme(scheme.Scheme))
 	Panic(monitoringv1.AddToScheme(scheme.Scheme))
 	Panic(cloudcredsv1.AddToScheme(scheme.Scheme))
 	Panic(operv1.AddToScheme(scheme.Scheme))


### PR DESCRIPTION
### Explain the changes
1. Added cosi bucket claim and bucket class commands to noobaa cli.
2. Supported create, list, status and delete for both COSI bucketclaim and bucketclass
3. Refactored bucketclass cli in order to use the same populate functions for cosi bucketclass.
4. Added COSI types 
5. Added COSI bucket crd yaml to be used on COSI bucket claim creation.
6. Updated docs
7. Added cli integration tests

### Issues: Fixed #xxx / Gap #xxx


### Testing Instructions:
1. make test-cosi

- [x] Doc added/updated
- [x] Tests added
