### PR TITLE
Support Azure log-based replication optimization credentials

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -642,6 +642,7 @@ func (r *Reconciler) ReadSystemInfo() error {
 				Name:     conn.Name,
 				Identity: conn.Identity,
 				Secret:   conn.Secret,
+				AzureLogAccessKeys: conn.AzureLogAccessKeys,
 			}
 		}
 	}
@@ -812,6 +813,19 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		conn.Endpoint = "https://blob.core.windows.net"
 		conn.Identity = r.Secret.StringData["AccountName"]
 		conn.Secret = r.Secret.StringData["AccountKey"]
+		tenantID := r.Secret.StringData["TenantID"]
+		appID := r.Secret.StringData["ApplicationID"]
+		appSecret := r.Secret.StringData["ApplicationSecret"]
+		logsAnalyticsWorkspaceID := r.Secret.StringData["LogsAnalyticsWorkspaceID"]
+
+		if tenantID != "" && appID != "" && appSecret != "" && logsAnalyticsWorkspaceID != "" {
+			conn.AzureLogAccessKeys = nb.AzureLogAccessKeysParams{
+				AzureTenantID: tenantID,
+				AzureClientID: appID,
+				AzureClientSecret: appSecret,
+				AzureLogsAnalyticsWorkspaceID: logsAnalyticsWorkspaceID,
+			}
+		}
 
 	case nbv1.StoreTypeGoogleCloudStorage:
 		conn.EndpointType = nb.EndpointTypeGoogle
@@ -876,6 +890,7 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 		Secret:       r.AddExternalConnectionParams.Secret,
 		AuthMethod:   r.AddExternalConnectionParams.AuthMethod,
 		AWSSTSARN:    r.AddExternalConnectionParams.AWSSTSARN,
+		AzureLogAccessKeys: r.AddExternalConnectionParams.AzureLogAccessKeys,
 	}
 
 	if r.UpdateExternalConnectionParams != nil {

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -482,6 +482,7 @@ func (r *Reconciler) ReadSystemInfo() error {
 				Name:     conn.Name,
 				Identity: conn.Identity,
 				Secret:   conn.Secret,
+				AzureLogAccessKeys: conn.AzureLogAccessKeys,
 			}
 		}
 	}
@@ -639,6 +640,19 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		conn.Endpoint = "https://blob.core.windows.net"
 		conn.Identity = r.Secret.StringData["AccountName"]
 		conn.Secret = r.Secret.StringData["AccountKey"]
+		tenantID := r.Secret.StringData["TenantID"]
+		appID := r.Secret.StringData["ApplicationID"]
+		appSecret := r.Secret.StringData["ApplicationSecret"]
+		logsAnalyticsWorkspaceID := r.Secret.StringData["LogsAnalyticsWorkspaceID"]
+
+		if tenantID != "" && appID != "" && appSecret != "" && logsAnalyticsWorkspaceID != "" {
+			conn.AzureLogAccessKeys = nb.AzureLogAccessKeysParams{
+				AzureTenantID: tenantID,
+				AzureClientID: appID,
+				AzureClientSecret: appSecret,
+				AzureLogsAnalyticsWorkspaceID: logsAnalyticsWorkspaceID,
+			}
+		}
 
 	case nbv1.NSStoreTypeGoogleCloudStorage:
 		conn.EndpointType = nb.EndpointTypeGoogle
@@ -714,6 +728,7 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 		Secret:       r.AddExternalConnectionParams.Secret,
 		AuthMethod:   r.AddExternalConnectionParams.AuthMethod,
 		AWSSTSARN:    r.AddExternalConnectionParams.AWSSTSARN,
+		AzureLogAccessKeys: r.AddExternalConnectionParams.AzureLogAccessKeys,
 	}
 
 	if r.UpdateExternalConnectionParams != nil {

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -671,28 +671,38 @@ type ExternalConnectionInfo struct {
 	} `json:"usage"`
 }
 
+// AzureLogAccessKeysParams is used to map between the Azure secret CR fields and the API ones
+type AzureLogAccessKeysParams struct {
+	AzureTenantID                 string `json:"azure_tenant_id"`
+	AzureClientID                 string `json:"azure_client_id"`
+	AzureClientSecret             string `json:"azure_client_secret"`
+	AzureLogsAnalyticsWorkspaceID string `json:"azure_logs_analytics_workspace_id"`
+}
+
 // AddExternalConnectionParams is the params of account_api.add_external_connection()
 type AddExternalConnectionParams struct {
-	Name         string          `json:"name"`
-	EndpointType EndpointType    `json:"endpoint_type"`
-	Endpoint     string          `json:"endpoint"`
-	Identity     string          `json:"identity"`
-	Secret       string          `json:"secret"`
-	AuthMethod   CloudAuthMethod `json:"auth_method,omitempty"`
-	AWSSTSARN    string          `json:"aws_sts_arn,omitempty"`
-	Region       string          `json:"region,omitempty"`
+	Name               string                   `json:"name"`
+	EndpointType       EndpointType             `json:"endpoint_type"`
+	Endpoint           string                   `json:"endpoint"`
+	Identity           string                   `json:"identity"`
+	Secret             string                   `json:"secret"`
+	AuthMethod         CloudAuthMethod          `json:"auth_method,omitempty"`
+	AWSSTSARN          string                   `json:"aws_sts_arn,omitempty"`
+	Region             string                   `json:"region,omitempty"`
+	AzureLogAccessKeys AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
 }
 
 // CheckExternalConnectionParams is the params of account_api.check_external_connection()
 type CheckExternalConnectionParams struct {
-	Name                   string          `json:"name"`
-	EndpointType           EndpointType    `json:"endpoint_type"`
-	Endpoint               string          `json:"endpoint"`
-	Identity               string          `json:"identity"`
-	Secret                 string          `json:"secret"`
-	AuthMethod             CloudAuthMethod `json:"auth_method,omitempty"`
-	AWSSTSARN              string          `json:"aws_sts_arn,omitempty"`
-	IgnoreNameAlreadyExist bool            `json:"ignore_name_already_exist,omitempty"`
+	Name                   string                   `json:"name"`
+	EndpointType           EndpointType             `json:"endpoint_type"`
+	Endpoint               string                   `json:"endpoint"`
+	Identity               string                   `json:"identity"`
+	Secret                 string                   `json:"secret"`
+	AuthMethod             CloudAuthMethod          `json:"auth_method,omitempty"`
+	AWSSTSARN              string                   `json:"aws_sts_arn,omitempty"`
+	IgnoreNameAlreadyExist bool                     `json:"ignore_name_already_exist,omitempty"`
+	AzureLogAccessKeys     AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
 }
 
 // CheckExternalConnectionReply is the reply of account_api.check_external_connection()
@@ -706,9 +716,10 @@ type CheckExternalConnectionReply struct {
 
 // UpdateExternalConnectionParams is the params of account_api.update_external_connection()
 type UpdateExternalConnectionParams struct {
-	Name     string `json:"name"`
-	Identity string `json:"identity"`
-	Secret   string `json:"secret"`
+	Name               string                   `json:"name"`
+	Identity           string                   `json:"identity"`
+	Secret             string                   `json:"secret"`
+	AzureLogAccessKeys AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
 }
 
 // DeleteExternalConnectionParams is the params of account_api.delete_external_connection()

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20230426"
+	ContainerImageTag = "master-20230710"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
### Explain the changes
1. Support the new secret fields that are required for https://github.com/noobaa/noobaa-core/pull/7308

The changes were also inserted into the backingstores' `reconciler.go` for cases in which the same secret is used for Azure backingstores and namespacestores