### PR TITLE
fixed default cosi image for make gen-odf-package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ BIN ?= $(OUTPUT)/bin
 OLM ?= $(OUTPUT)/olm
 MANIFESTS ?= $(OUTPUT)/manifests
 obc-crd ?= required
+cosi-sidecar-image ?= "gcr.io/k8s-staging-sig-storage/objectstorage-sidecar/objectstorage-sidecar:v20221117-v0.1.0-22-g0e67387"
 VENV ?= $(OUTPUT)/venv
 
 # OPERATOR_SDK_VERSION is for build perpuse only, the dependencies themself are 

--- a/build/gen-odf-package.sh
+++ b/build/gen-odf-package.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-if [ "${MANIFESTS}" == "" ] || [ "${CSV_NAME}" == "" ] || [ "${CORE_IMAGE}" == "" ] || [ "${DB_IMAGE}" == "" ] || [ "${OPERATOR_IMAGE}" == "" ]
+if [ "${MANIFESTS}" == "" ] || [ "${CSV_NAME}" == "" ] || [ "${CORE_IMAGE}" == "" ] || [ "${DB_IMAGE}" == "" ] || [ "${OPERATOR_IMAGE}" == "" ] || [ "${COSI_SIDECAR_IMAGE}" == "" ]
 then
   echo "gen-odf-package.sh: not all required envs were supplied"
   exit 1
 fi
+
+echo "--obc-crd=${OBC_CRD}"
 
 ./build/_output/bin/noobaa-operator-local olm catalog -n openshift-storage \
 --dir ${MANIFESTS} \


### PR DESCRIPTION
### Explain the changes
1. when cosi image was not given, the flags passed to the cli command were `--cosi-sidecar-image --obc-crd=owned`
2. the olm cli evaluated `--obc-crd` to be the default `required`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
