### PR TITLE
Fixing issue with bounded COSI socket

### DIFF
--- a/pkg/cosi/provisioner.go
+++ b/pkg/cosi/provisioner.go
@@ -59,7 +59,7 @@ func RunProvisioner(client client.Client, scheme *runtime.Scheme, recorder recor
 	}
 	// Create and run the s3 provisioner controller.
 	// It implements the Provisioner interface expected by the cosi lib.
-	cosiProv, err := provisioner.NewDefaultCOSIProvisionerServer(options.CosiDriverAddress, identityServer, p)
+	cosiProv, err := provisioner.NewDefaultCOSIProvisionerServer(fmt.Sprintf("unix://%s", options.CosiDriverPath), identityServer, p)
 	if err != nil {
 		log.Error(err, "failed to create noobaa cosi provisioner/driver")
 		return err
@@ -68,6 +68,8 @@ func RunProvisioner(client client.Client, scheme *runtime.Scheme, recorder recor
 	log.Info("running noobaa cosi provisioner/driver", driverName)
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
+		// remove socket in case it is already bound
+		os.Remove(options.CosiDriverPath)
 		util.Panic(cosiProv.Run(ctx))
 	}()
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -121,8 +121,8 @@ var DevEnv = false
 // DisableLoadBalancerService is used for setting the service type to ClusterIP instead of LoadBalancer
 var DisableLoadBalancerService = false
 
-// CosiDriverAddress is the cosi socket address
-var CosiDriverAddress = "unix:///var/lib/cosi/cosi.sock"
+// CosiDriverPath is the cosi socket fs path
+var CosiDriverPath = "/var/lib/cosi/cosi.sock"
 
 // AdmissionWebhook is used for deploying the system with admission validation webhook
 var AdmissionWebhook = false
@@ -253,8 +253,8 @@ func init() {
 		false, "Set the service type to ClusterIP instead of LoadBalancer",
 	)
 	FlagSet.StringVar(
-		&CosiDriverAddress, "cosi-driver-addr",
-		CosiDriverAddress, "unix socket address for COSI",
+		&CosiDriverPath, "cosi-driver-path",
+		CosiDriverPath, "unix socket path for COSI",
 	)
 	FlagSet.BoolVar(
 		&AdmissionWebhook, "admission",


### PR DESCRIPTION
### Explain the changes
1. Removing the path to the COSI socket in case of an old Panic that left it open and will deny cosi provisioner from starting
2. Changed CosiDriverAddress to CosiDriverPath so we can use it in both places: in removal and when creating new provisioner 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
