### PR TITLE
Use `AzureLogAccessKeysParams` as a pointer instead of a nested struct

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -819,7 +819,7 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		logsAnalyticsWorkspaceID := r.Secret.StringData["LogsAnalyticsWorkspaceID"]
 
 		if tenantID != "" && appID != "" && appSecret != "" && logsAnalyticsWorkspaceID != "" {
-			conn.AzureLogAccessKeys = nb.AzureLogAccessKeysParams{
+			conn.AzureLogAccessKeys = &nb.AzureLogAccessKeysParams{
 				AzureTenantID: tenantID,
 				AzureClientID: appID,
 				AzureClientSecret: appSecret,

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -646,7 +646,7 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		logsAnalyticsWorkspaceID := r.Secret.StringData["LogsAnalyticsWorkspaceID"]
 
 		if tenantID != "" && appID != "" && appSecret != "" && logsAnalyticsWorkspaceID != "" {
-			conn.AzureLogAccessKeys = nb.AzureLogAccessKeysParams{
+			conn.AzureLogAccessKeys = &nb.AzureLogAccessKeysParams{
 				AzureTenantID: tenantID,
 				AzureClientID: appID,
 				AzureClientSecret: appSecret,

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -681,28 +681,28 @@ type AzureLogAccessKeysParams struct {
 
 // AddExternalConnectionParams is the params of account_api.add_external_connection()
 type AddExternalConnectionParams struct {
-	Name               string                   `json:"name"`
-	EndpointType       EndpointType             `json:"endpoint_type"`
-	Endpoint           string                   `json:"endpoint"`
-	Identity           string                   `json:"identity"`
-	Secret             string                   `json:"secret"`
-	AuthMethod         CloudAuthMethod          `json:"auth_method,omitempty"`
-	AWSSTSARN          string                   `json:"aws_sts_arn,omitempty"`
-	Region             string                   `json:"region,omitempty"`
-	AzureLogAccessKeys AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
+	Name               string                    `json:"name"`
+	EndpointType       EndpointType              `json:"endpoint_type"`
+	Endpoint           string                    `json:"endpoint"`
+	Identity           string                    `json:"identity"`
+	Secret             string                    `json:"secret"`
+	AuthMethod         CloudAuthMethod           `json:"auth_method,omitempty"`
+	AWSSTSARN          string                    `json:"aws_sts_arn,omitempty"`
+	Region             string                    `json:"region,omitempty"`
+	AzureLogAccessKeys *AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
 }
 
 // CheckExternalConnectionParams is the params of account_api.check_external_connection()
 type CheckExternalConnectionParams struct {
-	Name                   string                   `json:"name"`
-	EndpointType           EndpointType             `json:"endpoint_type"`
-	Endpoint               string                   `json:"endpoint"`
-	Identity               string                   `json:"identity"`
-	Secret                 string                   `json:"secret"`
-	AuthMethod             CloudAuthMethod          `json:"auth_method,omitempty"`
-	AWSSTSARN              string                   `json:"aws_sts_arn,omitempty"`
-	IgnoreNameAlreadyExist bool                     `json:"ignore_name_already_exist,omitempty"`
-	AzureLogAccessKeys     AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
+	Name                   string                    `json:"name"`
+	EndpointType           EndpointType              `json:"endpoint_type"`
+	Endpoint               string                    `json:"endpoint"`
+	Identity               string                    `json:"identity"`
+	Secret                 string                    `json:"secret"`
+	AuthMethod             CloudAuthMethod           `json:"auth_method,omitempty"`
+	AWSSTSARN              string                    `json:"aws_sts_arn,omitempty"`
+	IgnoreNameAlreadyExist bool                      `json:"ignore_name_already_exist,omitempty"`
+	AzureLogAccessKeys     *AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
 }
 
 // CheckExternalConnectionReply is the reply of account_api.check_external_connection()
@@ -716,10 +716,10 @@ type CheckExternalConnectionReply struct {
 
 // UpdateExternalConnectionParams is the params of account_api.update_external_connection()
 type UpdateExternalConnectionParams struct {
-	Name               string                   `json:"name"`
-	Identity           string                   `json:"identity"`
-	Secret             string                   `json:"secret"`
-	AzureLogAccessKeys AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
+	Name               string                    `json:"name"`
+	Identity           string                    `json:"identity"`
+	Secret             string                    `json:"secret"`
+	AzureLogAccessKeys *AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
 }
 
 // DeleteExternalConnectionParams is the params of account_api.delete_external_connection()


### PR DESCRIPTION
### Explain the changes
1. The use of the struct as a pointer allows it to become `nil`  when uninitialized, which then allows it to be omitted by `omitempty` due to being a primitive type and not an empty object

### Issues: Fixed #xxx / Gap #xxx
1. Addresses https://github.com/noobaa/noobaa-core/pull/7394#discussion_r1267935376

