### PR TITLE
Adding basic support for working with external postgres DB

### DIFF
--- a/deploy/crds/noobaa.io_noobaas_crd.yaml
+++ b/deploy/crds/noobaa.io_noobaas_crd.yaml
@@ -1393,6 +1393,19 @@ spec:
                         type: object
                     type: object
                 type: object
+              externalPgSecret:
+                description: ExternalPgSecret (optional) holds an optional secret
+                  with a url to an extrenal Postgres DB to be used
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
               image:
                 description: Image (optional) overrides the default image for the
                   server container

--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -88,6 +88,7 @@ spec:
             - name: DB_TYPE
             - name: MONGODB_URL
             - name: POSTGRES_HOST
+            - name: POSTGRES_PORT
             - name: POSTGRES_DBNAME
               value: nbcore
             - name: POSTGRES_USER

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -99,6 +99,7 @@ spec:
               value: "mongodb://noobaa-db-0.noobaa-db/nbcore"
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
+            - name: POSTGRES_PORT
             - name: POSTGRES_DBNAME
               value: nbcore
             - name: POSTGRES_USER

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -117,6 +117,10 @@ type NooBaaSpec struct {
 	// +optional
 	MongoDbURL string `json:"mongoDbURL,omitempty"`
 
+	// ExternalPgSecret (optional) holds an optional secret with a url to an extrenal Postgres DB to be used
+	// +optional
+	ExternalPgSecret *corev1.SecretReference `json:"externalPgSecret,omitempty"`
+
 	// DebugLevel (optional) sets the debug level
 	// +optional
 	// +kubebuilder:validation:Enum=all;nsfs;warn;default_level

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -1090,6 +1090,11 @@ func (in *NooBaaSpec) DeepCopyInto(out *NooBaaSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ExternalPgSecret != nil {
+		in, out := &in.ExternalPgSecret, &out.ExternalPgSecret
+		*out = new(corev1.SecretReference)
+		**out = **in
+	}
 	if in.PVPoolDefaultStorageClass != nil {
 		in, out := &in.PVPoolDefaultStorageClass, &out.PVPoolDefaultStorageClass
 		*out = new(string)

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1437,7 +1437,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "5d42c4e8e815c9fed4705d6bf312848202aa4b8f7733d971151fb1cac8eea279"
+const Sha256_deploy_crds_noobaa_io_noobaas_crd_yaml = "ada3ba6a3a6aecc2a957947d822baaad68c87f4d04eda5df31e883354dcbff71"
 
 const File_deploy_crds_noobaa_io_noobaas_crd_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2834,6 +2834,19 @@ spec:
                         type: object
                     type: object
                 type: object
+              externalPgSecret:
+                description: ExternalPgSecret (optional) holds an optional secret
+                  with a url to an extrenal Postgres DB to be used
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
               image:
                 description: Image (optional) overrides the default image for the
                   server container
@@ -3585,7 +3598,7 @@ data:
           su postgres -c "bash -x /usr/bin/run-postgresql"
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "591b74cab691e57295c490d0963131b4eefb345aef08c383ef01a9ed4e19ca2b"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "b87bb78e630d9e007b71b5aa7745f5d6b6f1771cdd949735652ddc6ebb6ff9d5"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -3677,6 +3690,7 @@ spec:
             - name: DB_TYPE
             - name: MONGODB_URL
             - name: POSTGRES_HOST
+            - name: POSTGRES_PORT
             - name: POSTGRES_DBNAME
               value: nbcore
             - name: POSTGRES_USER
@@ -4600,7 +4614,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "acb0b7199dfc55c7e4ceaff49d2ab754c527ad6bc9be7af539153e10b07294d3"
+const Sha256_deploy_internal_statefulset_core_yaml = "71a1afa6000a2ad334ec234951f0cd245d44ceea36fe57c444869accce9c75b7"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4703,6 +4717,7 @@ spec:
               value: "mongodb://noobaa-db-0.noobaa-db/nbcore"
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
+            - name: POSTGRES_PORT
             - name: POSTGRES_DBNAME
               value: nbcore
             - name: POSTGRES_USER

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -97,6 +97,10 @@ var DBStorageClass = ""
 // it can be overridden for testing or different url.
 var MongoDbURL = ""
 
+// PostgresDbURL is used for providing postgres url
+// it can be overridden for testing or different url.
+var PostgresDbURL = ""
+
 // DebugLevel can be used to override the default debug level
 var DebugLevel = "default_level"
 
@@ -223,6 +227,10 @@ func init() {
 	FlagSet.StringVar(
 		&MongoDbURL, "mongodb-url",
 		MongoDbURL, "url for mongodb",
+	)
+	FlagSet.StringVar(
+		&PostgresDbURL, "postgres-url",
+		PostgresDbURL, "url for postgresql",
 	)
 	FlagSet.StringVar(
 		&DebugLevel, "debug-level",


### PR DESCRIPTION
### Explain the changes
1. Adding support to provide a secret reference to a postgres DB URL in noobaa CRD. The secret has to have a key called "db_url" and to be in this format: **potgres://**_user_**:**_password_**@**_full DNS name of external server_**:**_port_**/**_db-name_
2. Adding a CLI option to add postgres-url in the same format in 1. for example:
```
noobaa install --postgres-url="postgres://postgres:GWHMacB1ajy1SkY4Q5FH4myc60lJHTbF3I99LLCCwnLj32Je815cWd92JeQeBSiz@externalserver.namespace.svc:5432/nbcore"
``` 
CLI will create the expected secret and attach it to the noobaa system CRD

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
