### PR TITLE
Update `ContainerImage` to point to the latest build

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20230710"
+	ContainerImageTag = "master-20230725"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
### Explain the changes
1.  Updating to the latest image in order to support the changes introduced in https://github.com/noobaa/noobaa-operator/pull/1176
