### PR TITLE
Pass Region Param to External Connection

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -639,10 +639,11 @@ func (r *Reconciler) ReadSystemInfo() error {
 			pool.CloudInfo.Identity != conn.Identity {
 			r.Logger.Warnf("using existing pool but connection mismatch %+v pool %+v %+v", conn, pool, pool.CloudInfo)
 			r.UpdateExternalConnectionParams = &nb.UpdateExternalConnectionParams{
-				Name:     conn.Name,
-				Identity: conn.Identity,
-				Secret:   conn.Secret,
+				Name:               conn.Name,
+				Identity:           conn.Identity,
+				Secret:             conn.Secret,
 				AzureLogAccessKeys: conn.AzureLogAccessKeys,
+				Region:             conn.Region,
 			}
 		}
 	}
@@ -820,9 +821,9 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 
 		if tenantID != "" && appID != "" && appSecret != "" && logsAnalyticsWorkspaceID != "" {
 			conn.AzureLogAccessKeys = &nb.AzureLogAccessKeysParams{
-				AzureTenantID: tenantID,
-				AzureClientID: appID,
-				AzureClientSecret: appSecret,
+				AzureTenantID:                 tenantID,
+				AzureClientID:                 appID,
+				AzureClientSecret:             appSecret,
 				AzureLogsAnalyticsWorkspaceID: logsAnalyticsWorkspaceID,
 			}
 		}
@@ -883,13 +884,14 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 	}
 
 	checkConnectionParams := &nb.CheckExternalConnectionParams{
-		Name:         r.AddExternalConnectionParams.Name,
-		EndpointType: r.AddExternalConnectionParams.EndpointType,
-		Endpoint:     r.AddExternalConnectionParams.Endpoint,
-		Identity:     r.AddExternalConnectionParams.Identity,
-		Secret:       r.AddExternalConnectionParams.Secret,
-		AuthMethod:   r.AddExternalConnectionParams.AuthMethod,
-		AWSSTSARN:    r.AddExternalConnectionParams.AWSSTSARN,
+		Name:               r.AddExternalConnectionParams.Name,
+		EndpointType:       r.AddExternalConnectionParams.EndpointType,
+		Endpoint:           r.AddExternalConnectionParams.Endpoint,
+		Region:             r.AddExternalConnectionParams.Region,
+		Identity:           r.AddExternalConnectionParams.Identity,
+		Secret:             r.AddExternalConnectionParams.Secret,
+		AuthMethod:         r.AddExternalConnectionParams.AuthMethod,
+		AWSSTSARN:          r.AddExternalConnectionParams.AWSSTSARN,
 		AzureLogAccessKeys: r.AddExternalConnectionParams.AzureLogAccessKeys,
 	}
 

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -479,10 +479,11 @@ func (r *Reconciler) ReadSystemInfo() error {
 			nsr.Identity != conn.Identity {
 			r.Logger.Warnf("using existing namespace resource but connection mismatch %+v namespace store %+v", conn, nsr)
 			r.UpdateExternalConnectionParams = &nb.UpdateExternalConnectionParams{
-				Name:     conn.Name,
-				Identity: conn.Identity,
-				Secret:   conn.Secret,
+				Name:               conn.Name,
+				Identity:           conn.Identity,
+				Secret:             conn.Secret,
 				AzureLogAccessKeys: conn.AzureLogAccessKeys,
+				Region:             conn.Region,
 			}
 		}
 	}
@@ -608,6 +609,7 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		}
 		if awsS3.Region != "" {
 			u.Host = fmt.Sprintf("s3.%s.amazonaws.com", awsS3.Region)
+			conn.Region = awsS3.Region
 		}
 		conn.Endpoint = u.String()
 
@@ -647,9 +649,9 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 
 		if tenantID != "" && appID != "" && appSecret != "" && logsAnalyticsWorkspaceID != "" {
 			conn.AzureLogAccessKeys = &nb.AzureLogAccessKeysParams{
-				AzureTenantID: tenantID,
-				AzureClientID: appID,
-				AzureClientSecret: appSecret,
+				AzureTenantID:                 tenantID,
+				AzureClientID:                 appID,
+				AzureClientSecret:             appSecret,
 				AzureLogsAnalyticsWorkspaceID: logsAnalyticsWorkspaceID,
 			}
 		}
@@ -721,14 +723,15 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 	}
 
 	checkConnectionParams := &nb.CheckExternalConnectionParams{
-		Name:         r.AddExternalConnectionParams.Name,
-		EndpointType: r.AddExternalConnectionParams.EndpointType,
-		Endpoint:     r.AddExternalConnectionParams.Endpoint,
-		Identity:     r.AddExternalConnectionParams.Identity,
-		Secret:       r.AddExternalConnectionParams.Secret,
-		AuthMethod:   r.AddExternalConnectionParams.AuthMethod,
-		AWSSTSARN:    r.AddExternalConnectionParams.AWSSTSARN,
+		Name:               r.AddExternalConnectionParams.Name,
+		EndpointType:       r.AddExternalConnectionParams.EndpointType,
+		Endpoint:           r.AddExternalConnectionParams.Endpoint,
+		Identity:           r.AddExternalConnectionParams.Identity,
+		Secret:             r.AddExternalConnectionParams.Secret,
+		AuthMethod:         r.AddExternalConnectionParams.AuthMethod,
+		AWSSTSARN:          r.AddExternalConnectionParams.AWSSTSARN,
 		AzureLogAccessKeys: r.AddExternalConnectionParams.AzureLogAccessKeys,
+		Region:             r.AddExternalConnectionParams.Region,
 	}
 
 	if r.UpdateExternalConnectionParams != nil {

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -703,6 +703,7 @@ type CheckExternalConnectionParams struct {
 	AWSSTSARN              string                    `json:"aws_sts_arn,omitempty"`
 	IgnoreNameAlreadyExist bool                      `json:"ignore_name_already_exist,omitempty"`
 	AzureLogAccessKeys     *AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
+	Region                 string                    `json:"region,omitempty"`
 }
 
 // CheckExternalConnectionReply is the reply of account_api.check_external_connection()
@@ -720,6 +721,7 @@ type UpdateExternalConnectionParams struct {
 	Identity           string                    `json:"identity"`
 	Secret             string                    `json:"secret"`
 	AzureLogAccessKeys *AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
+	Region             string                    `json:"region,omitempty"`
 }
 
 // DeleteExternalConnectionParams is the params of account_api.delete_external_connection()


### PR DESCRIPTION
### Explain the changes
1. Pass region param to connection.

### Issues: Fixed #xxx / Gap #xxx
1. none.

### Testing Instructions:
Need to build with noobaa change noobaa/noobaa-core#7433.
1. Deploy noobaa on MInikube or Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create namespacestore/backingstore and pass the region explicitly:
`nb namespacestore create aws-s3  <namespace-store-name> --region=<target-bucket-region>`.
`nb backingstore create aws-s3  <backingstore-store-name> --region=<target-bucket-region>`.
3. Add printings to `check_external_connection`, `check_aws_connection` and see that the region passed.
Note: test on buckets in the regions 'us-east-1' and 'us-west-1'.

- [ ] Doc added/updated
- [ ] Tests added
