### PR TITLE
Update AWS Regions

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1135,6 +1135,7 @@ func GetAWSRegion() (string, error) {
 		"us-gov-west-1":  "us-gov-west-1",
 		"us-gov-east-1":  "us-gov-east-1",
 		"af-south-1":     "af-south-1",
+		"il-central-1":   "il-central-1",
 	}
 	nodesList := &corev1.NodeList{}
 	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {


### PR DESCRIPTION
### Explain the changes
1. Update AWS regions with `il-central-1` (see [here](https://aws.amazon.com/blogs/aws/now-open-aws-israel-tel-aviv-region/)).

### Issues: Fixed #xxx / Gap #xxx
1. Gap: use the aws-sdk-go to get automated and most updated list of regions.
2. Related to #1086.

### Testing Instructions:
1. none.

- [ ] Doc added/updated
- [ ] Tests added
