### PR TITLE
Skip hpav2 resources if metrics type is Resource

### DIFF
--- a/pkg/system/autoscaler.go
+++ b/pkg/system/autoscaler.go
@@ -59,6 +59,13 @@ func (r *Reconciler) reconcileAutoscaler() error {
 			return err
 		}
 	case nbv1.AutoscalerTypeHPAV2:
+		if r.AdapterHPA.Spec.Metrics[0].Type == autoscalingv2.ResourceMetricSourceType {
+			r.Logger.Debugf("HPAV2 autoscaler type is %s, skipping HPAV2 resource creation", autoscalingv2.ResourceMetricSourceType)
+			if err := r.ReconcileObject(r.AdapterHPA, r.reconcileAdapterHPA); err != nil {
+				return err
+			}
+			return nil
+		}
 		prometheus, err := getPrometheus(log, prometheusNamespace)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Explain the changes
1. Skip hpav2 resources creation if the metrics type is `Resource`

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2228805#c2

### Testing Instructions:
1. install noobaa and Prometheus adaptor should not be created if metrics type is Resource

- [ ] Doc added/updated
- [ ] Tests added
