### PR TITLE
Correcting misaligned .PHONY in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ vendor:
 run: gen
 	go build -o $(NOOBAA_OPERATOR_LOCAL) -mod=vendor $(CMD_MANAGER)
 	$(BIN)/noobaa-operator-local operator run
-	.PHONY: run
+.PHONY: run
 
 clean:
 	rm -rf $(OUTPUT)


### PR DESCRIPTION
Correcting the syntax error introduced in https://github.com/noobaa/noobaa-operator/pull/1183
