### PR TITLE
[backport to 5.14] Skip hpav2 resources if metrics type is Resource

### DIFF
--- a/pkg/system/autoscaler.go
+++ b/pkg/system/autoscaler.go
@@ -59,6 +59,13 @@ func (r *Reconciler) reconcileAutoscaler() error {
 			return err
 		}
 	case nbv1.AutoscalerTypeHPAV2:
+		if r.AdapterHPA.Spec.Metrics[0].Type == autoscalingv2.ResourceMetricSourceType {
+			r.Logger.Debugf("HPAV2 autoscaler type is %s, skipping HPAV2 resource creation", autoscalingv2.ResourceMetricSourceType)
+			if err := r.ReconcileObject(r.AdapterHPA, r.reconcileAdapterHPA); err != nil {
+				return err
+			}
+			return nil
+		}
 		prometheus, err := getPrometheus(log, prometheusNamespace)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: naveenpaul1 <napaul@redhat.com>
(cherry picked from commit 349e04e9f9dfedd78d43a89df29368888ff4af40)

### Explain the changes
1. backport of #1190 

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2228805

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
