### PR TITLE
Fix the operator image make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ cli: gen
 .PHONY: cli
 
 image: $(docker) gen
-	go build -o $(BIN)/noobaa-operator -gcflags all=-trimpath="$(MK_PARENT)" -asmflags all=-trimpath="$(MK_PARENT)" -mod=vendor $(CMD_MANAGER)
+	GOOS=linux CGO_ENABLED=$(or ${CGO_ENABLED},0) go build -o $(BIN)/noobaa-operator -gcflags all=-trimpath="$(MK_PARENT)" -asmflags all=-trimpath="$(MK_PARENT)" -mod=vendor $(CMD_MANAGER)
 	docker build -f build/Dockerfile -t $(IMAGE) .
 	@echo "✅ image"
 .PHONY: image


### PR DESCRIPTION
### Explain the changes
1. Restore [Operator SDK behavior](https://github.com/operator-framework/operator-sdk/blob/581265d8448c75bdbae619238c4aa0fdcc50765f/cmd/operator-sdk/build/cmd.go#L99-L104) when building the operator image to have `GOOS` set to `linux` and to be open to receive `CGO_ENABLED` from the user

### Issues: Fixed #xxx / Gap #xxx
1. Fixes the issue where the operator pod would fail to go up due to `exec format error` since the binary was compiled for the host machine's OS instead of `linux` when compiled on machines not running Linux
