### PR TITLE
[backport to 5.14] Fix the operator image make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ cli: gen
 .PHONY: cli
 
 image: $(docker) gen
-	go build -o $(BIN)/noobaa-operator -gcflags all=-trimpath="$(MK_PARENT)" -asmflags all=-trimpath="$(MK_PARENT)" -mod=vendor $(CMD_MANAGER)
+	GOOS=linux CGO_ENABLED=$(or ${CGO_ENABLED},0) go build -o $(BIN)/noobaa-operator -gcflags all=-trimpath="$(MK_PARENT)" -asmflags all=-trimpath="$(MK_PARENT)" -mod=vendor $(CMD_MANAGER)
 	docker build -f build/Dockerfile -t $(IMAGE) .
 	@echo "✅ image"
 .PHONY: image


### PR DESCRIPTION
Signed-off-by: Ben <belimele@redhat.com>
(cherry picked from commit 554dfff5c11aa5cae78ed25dcdfebe1c431d569d)

### Explain the changes
1. backport https://github.com/noobaa/noobaa-operator/pull/1198 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
