### PR TITLE
CLI | Fix creation and validation of OBC with replication

### DIFF
--- a/pkg/cosi/cosi_bucket_claim.go
+++ b/pkg/cosi/cosi_bucket_claim.go
@@ -120,7 +120,7 @@ func RunCreateBucketClaim(cmd *cobra.Command, args []string) {
 	if errMsg != "" {
 		log.Fatalf(`❌ Could not create BucketClass spec out of bucketclass parameters %q %q`, bucketClass.Name, bucketClass.Parameters)
 	}
-	err := ValidateCOSIBucketClaim(cosiBucketClaim.Name, options.Namespace, *bucketClassSpec)
+	err := ValidateCOSIBucketClaim(cosiBucketClaim.Name, options.Namespace, *bucketClassSpec, true)
 	if err != nil {
 		log.Fatalf(`❌ Could not validate COSI bucket claim %q in namespace %q validation failed %q`, cosiBucketClaim.Name, cosiBucketClaim.Namespace, err)
 	}

--- a/pkg/cosi/provisioner.go
+++ b/pkg/cosi/provisioner.go
@@ -108,7 +108,7 @@ func (p *Provisioner) DriverCreateBucket(ctx context.Context,
 		return nil, err
 	}
 
-	err = ValidateCOSIBucketClaim(req.GetName(), r.Provisioner.Namespace, *r.BucketClass)
+	err = ValidateCOSIBucketClaim(req.GetName(), r.Provisioner.Namespace, *r.BucketClass, false)
 	log.Infof("DriverCreateBucket: ValidateCOSIBucketClaim err %q", err)
 
 	if err != nil {

--- a/pkg/cosi/validation.go
+++ b/pkg/cosi/validation.go
@@ -9,12 +9,12 @@ import (
 )
 
 // ValidateCOSIBucketClaim validate COSI bucket claim
-func ValidateCOSIBucketClaim(objectName string, namespace string, spec nbv1.BucketClassSpec) error {
-	return validateAdditionalParameters(objectName, namespace, spec)
+func ValidateCOSIBucketClaim(objectName string, namespace string, spec nbv1.BucketClassSpec, isCLI bool) error {
+	return validateAdditionalParameters(objectName, namespace, spec, isCLI)
 }
 
 // Validate additional parameters of the cosi bucket
-func validateAdditionalParameters(bucketName string, namespace string, spec nbv1.BucketClassSpec) error {
+func validateAdditionalParameters(bucketName string, namespace string, spec nbv1.BucketClassSpec, isCLI bool) error {
 	placementPolicy := spec.PlacementPolicy
 	if err := validations.ValidatePlacementPolicy(placementPolicy, namespace); err != nil {
 		return util.ValidationError{
@@ -30,7 +30,7 @@ func validateAdditionalParameters(bucketName string, namespace string, spec nbv1
 	}
 
 	replicationPolicy := spec.ReplicationPolicy
-	if err := validations.ValidateReplicationPolicy(bucketName, replicationPolicy, false); err != nil {
+	if err := validations.ValidateReplicationPolicy(bucketName, replicationPolicy, false, isCLI); err != nil {
 		return util.ValidationError{
 			Msg: fmt.Sprintf("cosi bucket claim %q validation error: invalid replicationPolicy %v, %v", bucketName, replicationPolicy, err),
 		}

--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -185,7 +185,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 		obc.Spec.AdditionalConfig["maxObjects"] = maxObjects
 	}
 
-	err := ValidateOBC(obc)
+	err := ValidateOBC(obc, true)
 	if err != nil {
 		log.Fatalf(`❌ Could not create OBC %q in namespace %q validation failed %q`, obc.Name, obc.Namespace, err)
 	}

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -98,7 +98,7 @@ func (p *Provisioner) Provision(bucketOptions *obAPI.BucketOptions) (*nbv1.Objec
 	log := p.Logger
 	log.Infof("Provision: got request to provision bucket %q", bucketOptions.BucketName)
 
-	err := ValidateOBC(bucketOptions.ObjectBucketClaim)
+	err := ValidateOBC(bucketOptions.ObjectBucketClaim, false)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (p *Provisioner) Update(ob *nbv1.ObjectBucket) error {
 	log := p.Logger
 	log.Infof("Update: got request to Update bucket %q", ob.Name)
 
-	err := ValidateOB(ob)
+	err := ValidateOB(ob, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/obc/validation.go
+++ b/pkg/obc/validation.go
@@ -7,23 +7,23 @@ import (
 )
 
 // ValidateOBC validate object bucket claim
-func ValidateOBC(obc *nbv1.ObjectBucketClaim) error {
+func ValidateOBC(obc *nbv1.ObjectBucketClaim, isCLI bool) error {
 	if obc == nil {
 		return nil
 	}
-	return validateAdditionalConfig(obc.Name, obc.Spec.AdditionalConfig, false)
+	return validateAdditionalConfig(obc.Name, obc.Spec.AdditionalConfig, false, isCLI)
 }
 
 // ValidateOB validate object bucket
-func ValidateOB(ob *nbv1.ObjectBucket) error {
+func ValidateOB(ob *nbv1.ObjectBucket, isCLI bool) error {
 	if ob == nil {
 		return nil
 	}
-	return validateAdditionalConfig(ob.Name, ob.Spec.Endpoint.AdditionalConfigData, true)
+	return validateAdditionalConfig(ob.Name, ob.Spec.Endpoint.AdditionalConfigData, true, isCLI)
 }
 
 // Validate additional config
-func validateAdditionalConfig(objectName string, additionalConfig map[string]string, update bool) error {
+func validateAdditionalConfig(objectName string, additionalConfig map[string]string, update bool, isCLI bool) error {
 	if additionalConfig == nil {
 		return nil
 	}
@@ -36,7 +36,7 @@ func validateAdditionalConfig(objectName string, additionalConfig map[string]str
 		return err
 	}
 
-	if err := validations.ValidateReplicationPolicy(objectName, replicationPolicy, update); err != nil {
+	if err := validations.ValidateReplicationPolicy(objectName, replicationPolicy, update, isCLI); err != nil {
 		return err
 	}
 

--- a/pkg/validations/common_bucket_validation_integ_test.go
+++ b/pkg/validations/common_bucket_validation_integ_test.go
@@ -10,46 +10,48 @@ import (
 const (
 	firstBucket  = "first.bucket"
 	secondBucket = "second.bucket"
+	// setting it to false since this is already testEnv
+	isCLI = false
 )
 
 var _ = Describe("Replication Validation tests", func() {
 
 	It("validate valid replication policy", func() {
 		validReplicationPolicy := getValidReplicationPolicy()
-		err := ValidateReplicationPolicy(secondBucket, validReplicationPolicy, false)
+		err := ValidateReplicationPolicy(secondBucket, validReplicationPolicy, false, isCLI)
 		Expect(err).To(BeNil())
 	})
 
 	It("validate invalid replication policy - should fail", func() {
 		invalidReplicationPolicy := getInvalidReplicationPolicy()
-		err := ValidateReplicationPolicy(firstBucket, invalidReplicationPolicy, false)
+		err := ValidateReplicationPolicy(firstBucket, invalidReplicationPolicy, false, isCLI)
 		expectedErrMsg := fmt.Sprintf("Provisioner Failed to validate replication of bucket \"%s\" with error: INVALID_SCHEMA_PARAMS SERVER bucket_api#/methods/validate_replication", firstBucket)
 		Expect(err.Error()).To(Equal(expectedErrMsg))
 	})
 
 	It("validate invalid replication policy json - should fail", func() {
 		invalidReplicationPolicyJSON := getInvalidReplicationPolicyJSON()
-		err := ValidateReplicationPolicy(firstBucket, invalidReplicationPolicyJSON, false)
+		err := ValidateReplicationPolicy(firstBucket, invalidReplicationPolicyJSON, false, isCLI)
 		expectedErrMsg := "Failed to parse replication json {[] <nil>}: unexpected end of JSON input"
 		Expect(err.Error()).To(Equal(expectedErrMsg))
 	})
 
 	It("validate empty replication policy valid", func() {
 		emptyReplicationPolicy := getEmptyReplicationPolicy()
-		err := ValidateReplicationPolicy(firstBucket, emptyReplicationPolicy, false)
+		err := ValidateReplicationPolicy(firstBucket, emptyReplicationPolicy, false, isCLI)
 		Expect(err).To(BeNil())
 	})
 
 	It("validate empty replication rules array on create bucket - should fail", func() {
 		emptyRulesArrReplicationPolicy := getEmptyRulesArrReplicationPolicy()
-		err := ValidateReplicationPolicy(firstBucket, emptyRulesArrReplicationPolicy, false)
+		err := ValidateReplicationPolicy(firstBucket, emptyRulesArrReplicationPolicy, false, isCLI)
 		expectedErrMsg := fmt.Sprintf("replication rules array of bucket \"%s\" is empty {[] <nil>}", firstBucket)
 		Expect(err.Error()).To(Equal(expectedErrMsg))
 	})
 
 	It("validate empty replication rules array on create bucket", func() {
 		emptyRulesArrReplicationPolicy := getEmptyRulesArrReplicationPolicy()
-		err := ValidateReplicationPolicy(firstBucket, emptyRulesArrReplicationPolicy, true)
+		err := ValidateReplicationPolicy(firstBucket, emptyRulesArrReplicationPolicy, true, isCLI)
 		Expect(err).To(BeNil())
 
 	})

--- a/pkg/validations/common_bucket_validations.go
+++ b/pkg/validations/common_bucket_validations.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ValidateReplicationPolicy validates and replication params and returns the replication policy object
-func ValidateReplicationPolicy(bucketName string, replicationPolicy string, update bool) error {
+func ValidateReplicationPolicy(bucketName string, replicationPolicy string, update bool, isCLI bool) error {
 	log := util.Logger()
 	if replicationPolicy == "" {
 		return nil
@@ -37,7 +37,7 @@ func ValidateReplicationPolicy(bucketName string, replicationPolicy string, upda
 
 	log.Infof("ValidateReplicationPolicy: validating replication: replicationParams: %+v", replicationParams)
 	IsExternalRPCConnection := false
-	if util.IsTestEnv() {
+	if util.IsTestEnv() || isCLI {
 		IsExternalRPCConnection = true
 	}
 	sysClient, err := system.Connect(IsExternalRPCConnection)


### PR DESCRIPTION
### Explain the changes
1. In the latest validation refactoring - https://github.com/noobaa/noobaa-operator/commit/a64c96dc3adcbabbec210ad1bdfc69970c6bdfe6  , replication validation was added to OBC validations, but the cli was not able to communicate with noobaa core using an internal RPC connection, tests env var hid this issue on the CI, found it on manual testing. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
