### PR TITLE
Pass Region in Analyze Resource

### DIFF
--- a/deploy/job_analyze_resource.yml
+++ b/deploy/job_analyze_resource.yml
@@ -25,6 +25,7 @@ spec:
           - name: RESOURCE_NAME
           - name: BUCKET
           - name: ENDPOINT
+          - name: REGION
           - name: S3_SIGNATURE_VERSION
           - name: HTTP_PROXY
           - name: HTTPS_PROXY

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5051,7 +5051,7 @@ const File_deploy_internal_text_system_status_readme_rejected_tmpl = `
 	NooBaa Operator Version: {{.OperatorVersion}}
 `
 
-const Sha256_deploy_job_analyze_resource_yml = "a171cf51d8c8561de04d921fbccb43b87f25daadd86211900765a4cf1ae080a5"
+const Sha256_deploy_job_analyze_resource_yml = "c80810baeda94fd9dd97a6c62241be5c582e08009bdbb1f2a13992c99d90ea33"
 
 const File_deploy_job_analyze_resource_yml = `apiVersion: batch/v1
 kind: Job
@@ -5080,6 +5080,7 @@ spec:
           - name: RESOURCE_NAME
           - name: BUCKET
           - name: ENDPOINT
+          - name: REGION
           - name: S3_SIGNATURE_VERSION
           - name: HTTP_PROXY
           - name: HTTPS_PROXY

--- a/pkg/diagnostics/analyze.go
+++ b/pkg/diagnostics/analyze.go
@@ -270,6 +270,16 @@ func setBackingStoreDetailsInJob(backingStore *nbv1.BackingStore, cmd *cobra.Com
 			backingStore.Kind, backingStore.Name, backingStore.Namespace)
 	}
 
+	// in case it is aws endpoint, we would pass the region
+	if backingStore.Spec.Type == nbv1.StoreTypeAWSS3 {
+		region := util.GetEnvVariable(&analyzeResourceJob.Spec.Template.Spec.Containers[0].Env, "REGION")
+		if region == nil {
+			log.Fatalf("❌ Could not get region in %s %q in Namespace %q",
+				analyzeResourceJob.Kind, analyzeResourceJob.Name, analyzeResourceJob.Namespace)
+		}
+		region.Value = backingStore.Spec.AWSS3.Region
+	}
+
 	// signature version
 	signatureVersion := util.GetEnvVariable(&analyzeResourceJob.Spec.Template.Spec.Containers[0].Env, "S3_SIGNATURE_VERSION")
 	if signatureVersion == nil {
@@ -336,6 +346,16 @@ func setNamespacetoreDetailsInJob(namespaceStore *nbv1.NamespaceStore, cmd *cobr
 	if err != nil {
 		log.Fatalf("❌ Could not get endpoint  in %s %q in Namespace %q",
 			namespaceStore.Kind, namespaceStore.Name, namespaceStore.Namespace)
+	}
+
+	// in case it is aws endpoint, we would pass the region
+	if namespaceStore.Spec.Type == nbv1.NSStoreTypeAWSS3 {
+		region := util.GetEnvVariable(&analyzeResourceJob.Spec.Template.Spec.Containers[0].Env, "REGION")
+		if region == nil {
+			log.Fatalf("❌ Could not get region in %s %q in Namespace %q",
+				analyzeResourceJob.Kind, analyzeResourceJob.Name, analyzeResourceJob.Namespace)
+		}
+		region.Value = namespaceStore.Spec.AWSS3.Region
 	}
 
 	// signature version


### PR DESCRIPTION
### Explain the changes
1. pass region in analyze resource.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
Note: to actually run the test you'll need to add the changes from this noobaa/noobaa-core#7452.
1. Deploy noobaa on MInikube or Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. For backingstore, Run:
`nb backingstore create aws-s3 <backing-store-name>` (optional: add the `--region` flag).
`nb diagnostics analyze backingstore <backing-store-name>`
3. For namespacestore, Run:
`nb namespacestore create aws-s3 <namespace-store-name>`  (optional: add the `--region` flag).
`nb diagnostics analyze namespacestore <namespace-store-name>`
3. For all resources (backingstore and namespacestore), Run:
`nb diagnostics analyze resources`
* It creates the log files and then deletes the created job.
4. Cases:
1 - s3-compatible - Noobaa bucket (with noobaa system as a server, the endpoint was taken from the field `InternalDNS` under `S3 Addresses`).
2 - aws-s3 without flag region on a bucket in a region that is not 'us-east-1' (for example 'us-west-1') and aws-s3 with flag region.


- [ ] Doc added/updated
- [ ] Tests added
