### PR TITLE
BugFix - [MCG] RPC method "list_objects" fails with "RPC: object.list…

### DIFF
--- a/pkg/nb/router.go
+++ b/pkg/nb/router.go
@@ -199,9 +199,6 @@ func FindPortByName(srv *corev1.Service, portName string) *corev1.ServicePort {
 
 // GetAPIPortName maps every noobaa api name to the service port name that serves it.
 func GetAPIPortName(api string) string {
-	if api == "object_api" || api == "func_api" {
-		return "md-https"
-	}
 	if api == "scrubber_api" {
 		return "bg-https"
 	}


### PR DESCRIPTION
…_objects() Call failed: failed to WebSocket dial"

### Explain the changes
1. Before we are returning `md-https` as port name for object_api and func_api, which is causing the failure as `md-https` was not present in noobaa-mgmt service. So we modified the code and returning `mgmt-https` as port for both api calls now.

### Issues
https://bugzilla.redhat.com/show_bug.cgi?id=2227835
1. Certain OCS-CI tests were failing due the failing of RPC API call for list_objects : 
[MCG] RPC method "list_objects" fails with "RPC: object.list_objects() Call failed: failed to WebSocket dial"
