### PR TITLE
Supporting core connection string in operator

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -93,6 +93,7 @@ spec:
               value: nbcore
             - name: POSTGRES_USER
             - name: POSTGRES_PASSWORD
+            - name: POSTGRES_CONNECTION_STRING
             - name: VIRTUAL_HOSTS
             - name: REGION
             - name: ENDPOINT_GROUP_ID

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -104,6 +104,7 @@ spec:
               value: nbcore
             - name: POSTGRES_USER
             - name: POSTGRES_PASSWORD
+            - name: POSTGRES_CONNECTION_STRING
             - name: DB_TYPE
               value: mongodb
             - name: CONTAINER_PLATFORM

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3655,7 +3655,7 @@ data:
           su postgres -c "bash -x /usr/bin/run-postgresql"
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "b87bb78e630d9e007b71b5aa7745f5d6b6f1771cdd949735652ddc6ebb6ff9d5"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "bdbc90cf86e4b67acccc7e7413522d46dacf1c2d04d1d5d5e823a2b45e5c9b97"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -3752,6 +3752,7 @@ spec:
               value: nbcore
             - name: POSTGRES_USER
             - name: POSTGRES_PASSWORD
+            - name: POSTGRES_CONNECTION_STRING
             - name: VIRTUAL_HOSTS
             - name: REGION
             - name: ENDPOINT_GROUP_ID
@@ -4671,7 +4672,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "71a1afa6000a2ad334ec234951f0cd245d44ceea36fe57c444869accce9c75b7"
+const Sha256_deploy_internal_statefulset_core_yaml = "7020d2a21cd88a51c9e1056c2aac33163f47168b4c1fb326497d22554e31392e"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4779,6 +4780,7 @@ spec:
               value: nbcore
             - name: POSTGRES_USER
             - name: POSTGRES_PASSWORD
+            - name: POSTGRES_CONNECTION_STRING
             - name: DB_TYPE
               value: mongodb
             - name: CONTAINER_PLATFORM

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20230725"
+	ContainerImageTag = "master-20230830"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -31,14 +31,23 @@ function post_install_tests {
 }
 
 function main {
-    noobaa_install
+    local install_external=$((RANDOM%2))
+    if [ ${install_external} -eq 0 ]
+    then
+        noobaa_install_external
+    else
+        noobaa_install
+    fi
     if [ "${CM}" == "true" ]
     then
         check_core_config_map
     else
         post_install_tests
     fi
-    noobaa_uninstall
+    if [ ${install_external} -eq 0 ]
+    then
+        delete_external_postgres
+    fi
  }
 
 function usage {


### PR DESCRIPTION
### Explain the changes
1. After adding support of connection-string to noobaa-core. We adapting some of the options to support external DB to work with connection strings.
2. Now we won't create 2 secrets, the same secret created/given to the operator will also be used in 'core'
3. Added some more verifications to the connection string. Once SSL is introduced we will switch it with the operator actually trying to connect to the DB itself and these temp checks won't be needed.
4. Changing core version to be after the push of connection string to master.
5. Adding new test case to cli flow to install and uninstall noobaa connected to external DB (the test starting a pod with postgres:15 as the external DB) 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
