### PR TITLE
Adding SSL support to External Postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,11 @@ test-cli-flow:
 	@echo "✅ test-cli-flow"
 .PHONY: test-cli-flow
 
+test-cli-flow-dev:
+	$(TIME) ./test/cli/test_cli_flow.sh --dev
+	@echo "✅ test-cli-flow-dev"
+.PHONY: test-cli-flow-dev
+
 test-core-config-map-flow:
 	$(TIME) ./test/cli/test_cli_flow.sh --check_core_config_map
 	@echo "✅ test-core-config-map-flow"

--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1417,6 +1417,29 @@ spec:
                         type: object
                     type: object
                 type: object
+              externalPgSSLRequired:
+                description: ExternalPgSSLRequired (optional) holds an optional boolean
+                  to force ssl connections to the external Postgres DB
+                type: boolean
+              externalPgSSLSecret:
+                description: ExternalPgSSLSecret (optional) holds an optional secret
+                  with client key and cert used for connecting to external Postgres
+                  DB
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              externalPgSSLUnauthorized:
+                description: ExternalPgSSLUnauthorized (optional) holds an optional
+                  boolean to allow unauthorized connections to external Postgres DB
+                type: boolean
               externalPgSecret:
                 description: ExternalPgSecret (optional) holds an optional secret
                   with a url to an extrenal Postgres DB to be used

--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -32,6 +32,10 @@ spec:
           secret:
             secretName: noobaa-s3-serving-cert
             optional: true
+        - name: external-db-ssl-secret
+          secret:
+            secretName: noobaa-external-db-cert
+            optional: true 
         - name: oidc-token
           projected:
             sources:
@@ -94,6 +98,8 @@ spec:
             - name: POSTGRES_USER
             - name: POSTGRES_PASSWORD
             - name: POSTGRES_CONNECTION_STRING
+            - name: POSTGRES_SSL_REQUIRED
+            - name: POSTGRES_SSL_UNAUTHORIZED
             - name: VIRTUAL_HOSTS
             - name: REGION
             - name: ENDPOINT_GROUP_ID
@@ -125,6 +131,9 @@ spec:
               readOnly: true
             - name: s3-secret
               mountPath: /etc/s3-secret
+              readOnly: true
+            - name: external-db-ssl-secret
+              mountPath: /etc/external-db-secret
               readOnly: true
             - name: noobaa-auth-token
               mountPath: /etc/noobaa-auth-token

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -33,6 +33,10 @@ spec:
           secret:
             secretName: noobaa-s3-serving-cert
             optional: true
+        - name: external-db-ssl-secret
+          secret:
+            secretName: noobaa-external-db-cert
+            optional: true 
         - name: noobaa-server
           secret:
             secretName: noobaa-server
@@ -58,6 +62,9 @@ spec:
               readOnly: true
             - name: s3-secret
               mountPath: /etc/s3-secret
+              readOnly: true
+            - name: external-db-ssl-secret
+              mountPath: /etc/external-db-secret
               readOnly: true
             - name: noobaa-server
               mountPath: /etc/noobaa-server
@@ -105,6 +112,8 @@ spec:
             - name: POSTGRES_USER
             - name: POSTGRES_PASSWORD
             - name: POSTGRES_CONNECTION_STRING
+            - name: POSTGRES_SSL_REQUIRED
+            - name: POSTGRES_SSL_UNAUTHORIZED
             - name: DB_TYPE
               value: mongodb
             - name: CONTAINER_PLATFORM

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -121,6 +121,18 @@ type NooBaaSpec struct {
 	// +optional
 	ExternalPgSecret *corev1.SecretReference `json:"externalPgSecret,omitempty"`
 
+	// ExternalPgSSLRequired (optional) holds an optional boolean to force ssl connections to the external Postgres DB
+	// +optional
+	ExternalPgSSLRequired bool `json:"externalPgSSLRequired,omitempty"`
+
+	// ExternalPgSSLUnauthorized (optional) holds an optional boolean to allow unauthorized connections to external Postgres DB
+	// +optional
+	ExternalPgSSLUnauthorized bool `json:"externalPgSSLUnauthorized,omitempty"`
+
+	// ExternalPgSSLSecret (optional) holds an optional secret with client key and cert used for connecting to external Postgres DB
+	// +optional
+	ExternalPgSSLSecret *corev1.SecretReference `json:"externalPgSSLSecret,omitempty"`
+
 	// DebugLevel (optional) sets the debug level
 	// +optional
 	// +kubebuilder:validation:Enum=all;nsfs;warn;default_level

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -1100,6 +1100,11 @@ func (in *NooBaaSpec) DeepCopyInto(out *NooBaaSpec) {
 		*out = new(corev1.SecretReference)
 		**out = **in
 	}
+	if in.ExternalPgSSLSecret != nil {
+		in, out := &in.ExternalPgSSLSecret, &out.ExternalPgSSLSecret
+		*out = new(corev1.SecretReference)
+		**out = **in
+	}
 	if in.PVPoolDefaultStorageClass != nil {
 		in, out := &in.PVPoolDefaultStorageClass, &out.PVPoolDefaultStorageClass
 		*out = new(string)

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -242,6 +242,10 @@ const (
 	// Test ENV minimal resources
 	testEnvMinCPUString    string = "50m"
 	testEnvMinMemoryString string = "200Mi"
+
+	// Dev ENV minimal resources
+	devEnvMinCPUString    string = "500m"
+	devEnvMinMemoryString string = "500Mi"
 )
 
 // CmdCreatePVPool returns a CLI command

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -1397,6 +1397,7 @@ func (r *Reconciler) upgradeBackingStore(sts *appsv1.StatefulSet) error {
 }
 
 func (r *Reconciler) reconcileResources(src, dst *corev1.ResourceList, minCPU, minMem resource.Quantity) error {
+	log := r.Logger
 	cpu := minCPU
 	mem := minMem
 
@@ -1416,6 +1417,7 @@ func (r *Reconciler) reconcileResources(src, dst *corev1.ResourceList, minCPU, m
 			mem = qty
 		}
 	}
+	log.Infof("BackingStore %q was created with resurce cpu:%v mem:%v.", r.BackingStore.Name, cpu, mem)
 
 	(*dst)[corev1.ResourceCPU] = cpu
 	(*dst)[corev1.ResourceMemory] = mem
@@ -1430,6 +1432,10 @@ func getMinimalResourcesByEnv() (string, string) {
 	if util.IsTestEnv() {
 		minCPUStringByEnv = testEnvMinCPUString
 		minMemoryStringByEnv = testEnvMinMemoryString
+	}
+	if util.IsDevEnv() {
+		minCPUStringByEnv = devEnvMinCPUString
+		minMemoryStringByEnv = devEnvMinMemoryString
 	}
 	return minCPUStringByEnv, minMemoryStringByEnv
 }

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1465,7 +1465,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "a4f5cbe942a050321ada72a0c77e61898d65000b6074e72d784cf1c0ef1816a3"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "ff8f0cf9e0a1429984e9518f0a143634644cfd0b1a955449d36917550ea060ce"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -2886,6 +2886,29 @@ spec:
                         type: object
                     type: object
                 type: object
+              externalPgSSLRequired:
+                description: ExternalPgSSLRequired (optional) holds an optional boolean
+                  to force ssl connections to the external Postgres DB
+                type: boolean
+              externalPgSSLSecret:
+                description: ExternalPgSSLSecret (optional) holds an optional secret
+                  with client key and cert used for connecting to external Postgres
+                  DB
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              externalPgSSLUnauthorized:
+                description: ExternalPgSSLUnauthorized (optional) holds an optional
+                  boolean to allow unauthorized connections to external Postgres DB
+                type: boolean
               externalPgSecret:
                 description: ExternalPgSecret (optional) holds an optional secret
                   with a url to an extrenal Postgres DB to be used
@@ -3655,7 +3678,7 @@ data:
           su postgres -c "bash -x /usr/bin/run-postgresql"
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "bdbc90cf86e4b67acccc7e7413522d46dacf1c2d04d1d5d5e823a2b45e5c9b97"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "c6b23dc4cd61b35fcdd53df59074a95df46526823ebd42862289886c8b11ae0f"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -3691,6 +3714,10 @@ spec:
           secret:
             secretName: noobaa-s3-serving-cert
             optional: true
+        - name: external-db-ssl-secret
+          secret:
+            secretName: noobaa-external-db-cert
+            optional: true 
         - name: oidc-token
           projected:
             sources:
@@ -3753,6 +3780,8 @@ spec:
             - name: POSTGRES_USER
             - name: POSTGRES_PASSWORD
             - name: POSTGRES_CONNECTION_STRING
+            - name: POSTGRES_SSL_REQUIRED
+            - name: POSTGRES_SSL_UNAUTHORIZED
             - name: VIRTUAL_HOSTS
             - name: REGION
             - name: ENDPOINT_GROUP_ID
@@ -3784,6 +3813,9 @@ spec:
               readOnly: true
             - name: s3-secret
               mountPath: /etc/s3-secret
+              readOnly: true
+            - name: external-db-ssl-secret
+              mountPath: /etc/external-db-secret
               readOnly: true
             - name: noobaa-auth-token
               mountPath: /etc/noobaa-auth-token
@@ -4672,7 +4704,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "7020d2a21cd88a51c9e1056c2aac33163f47168b4c1fb326497d22554e31392e"
+const Sha256_deploy_internal_statefulset_core_yaml = "d794c900f09e09b0e2be94869f5537271cbc2ab6d806d5182fb7fe2ff950b8ae"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4709,6 +4741,10 @@ spec:
           secret:
             secretName: noobaa-s3-serving-cert
             optional: true
+        - name: external-db-ssl-secret
+          secret:
+            secretName: noobaa-external-db-cert
+            optional: true 
         - name: noobaa-server
           secret:
             secretName: noobaa-server
@@ -4734,6 +4770,9 @@ spec:
               readOnly: true
             - name: s3-secret
               mountPath: /etc/s3-secret
+              readOnly: true
+            - name: external-db-ssl-secret
+              mountPath: /etc/external-db-secret
               readOnly: true
             - name: noobaa-server
               mountPath: /etc/noobaa-server
@@ -4781,6 +4820,8 @@ spec:
             - name: POSTGRES_USER
             - name: POSTGRES_PASSWORD
             - name: POSTGRES_CONNECTION_STRING
+            - name: POSTGRES_SSL_REQUIRED
+            - name: POSTGRES_SSL_UNAUTHORIZED
             - name: DB_TYPE
               value: mongodb
             - name: CONTAINER_PLATFORM

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -122,6 +122,15 @@ func RunInstall(cmd *cobra.Command, args []string) {
 		})
 		c.Deployment.Spec.Template.Spec.Containers[0].Env = operatorContainer.Env
 	}
+	devEnv, _ := cmd.Flags().GetBool("dev")
+	if devEnv {
+		operatorContainer := c.Deployment.Spec.Template.Spec.Containers[0]
+		operatorContainer.Env = append(operatorContainer.Env, corev1.EnvVar{
+			Name:  "DEV_ENV",
+			Value: "true",
+		})
+		c.Deployment.Spec.Template.Spec.Containers[0].Env = operatorContainer.Env
+	}
 
 	admission, _ := cmd.Flags().GetBool("admission")
 	if admission {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -101,6 +101,20 @@ var MongoDbURL = ""
 // it can be overridden for testing or different url.
 var PostgresDbURL = ""
 
+// PostgresSSLRequired is used to force noobaa to work with SSL with external pgsql
+// when using an external postgres DB.
+var PostgresSSLRequired = false
+
+// PostgresSSLSelfSigned is used to allow noobaa to work with self-signed SSL with external pgsql
+// when using an external postgres DB.
+var PostgresSSLSelfSigned = false
+
+// PostgresSSLKey is used for providing the path to the client SSL key file when working with external pgsql
+var PostgresSSLKey = ""
+
+// PostgresSSLCert is used for providing the path to the client SSL cert file when working with external pgsql
+var PostgresSSLCert = ""
+
 // DebugLevel can be used to override the default debug level
 var DebugLevel = "default_level"
 
@@ -231,6 +245,22 @@ func init() {
 	FlagSet.StringVar(
 		&PostgresDbURL, "postgres-url",
 		PostgresDbURL, "url for postgresql",
+	)
+	FlagSet.BoolVar(
+		&PostgresSSLRequired, "pg-ssl-required",
+		false, "Force noobaa to work with ssl (external postgres - server-side) [if server cert is self-signed, needs to add --ssl-unauthorized]",
+	)
+	FlagSet.BoolVar(
+		&PostgresSSLSelfSigned, "pg-ssl-unauthorized",
+		false, "Allow the client to work with self-signed ssl (external postgres - server-side)",
+	)
+	FlagSet.StringVar(
+		&PostgresSSLKey, "pg-ssl-key",
+		PostgresSSLKey, "ssl key for postgres (client-side cert - need to be signed by external pg accepted CA)",
+	)
+	FlagSet.StringVar(
+		&PostgresSSLCert, "pg-ssl-cert",
+		PostgresSSLCert, "ssl cert for postgres (client-side cert - need to be signed by external pg accepted CA)",
 	)
 	FlagSet.StringVar(
 		&DebugLevel, "debug-level",

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -458,6 +458,14 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 					},
 				}
 			}
+		case "POSTGRES_SSL_REQUIRED":
+			if r.NooBaa.Spec.DBType == "postgres" && r.NooBaa.Spec.ExternalPgSSLRequired {
+				c.Env[j].Value = "true"
+			}
+		case "POSTGRES_SSL_UNAUTHORIZED":
+			if r.NooBaa.Spec.DBType == "postgres" && r.NooBaa.Spec.ExternalPgSSLUnauthorized {
+				c.Env[j].Value = "true"
+			}
 		case "NOOBAA_ROOT_SECRET":
 			c.Env[j].Value = r.SecretRootMasterKey
 		case "NODE_EXTRA_CA_CERTS":

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -434,7 +434,7 @@ func KubeDelete(obj client.Object, opts ...client.DeleteOption) bool {
 	}
 
 	time.Sleep(10 * time.Millisecond)
-	
+
 	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		err := klient.Delete(ctx, obj, opts...)
 		if err == nil {
@@ -2153,6 +2153,16 @@ func FilterSlice[V any](slice []V, f func(V) bool) []V {
 func IsTestEnv() bool {
 	testEnv, ok := os.LookupEnv("TEST_ENV")
 	if ok && testEnv == "true" {
+		return true
+	}
+	return false
+}
+
+// IsDevEnv checks for DEV_ENV env var existance and equality
+// to true and returns true or false accordingly
+func IsDevEnv() bool {
+	devEnv, ok := os.LookupEnv("DEV_ENV")
+	if ok && devEnv == "true" {
 		return true
 	}
 	return false

--- a/test/cli/resources/external-db-ssl.yaml
+++ b/test/cli/resources/external-db-ssl.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-external
+  namespace: test
+spec:
+  type: ClusterIP
+  selector:
+    app: external-db
+  ports:
+    - port: 5432
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ssl-postgres-conf-sh
+  namespace: test
+  labels:
+    app: noobaa
+data:
+  sslconf.sh: |
+    #!/bin/bash
+    # echo ssl setting into pg_hba.conf configuration file
+    echo 'local all all trust' > /var/lib/postgresql/data/pg_hba.conf
+    echo 'hostssl all all all cert clientcert=verify-full' >> /var/lib/postgresql/data/pg_hba.conf
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: external-db
+  name: postgres-external
+  namespace: test
+spec:
+  initContainers:
+    - name: volume-mount-hack
+      image: postgres:15
+      command: ["sh", "-c", "cp /etc/ssl/server.key /etc/private/server.key && chown root:ssl-cert /etc/private/server.key"]
+      volumeMounts:
+        - name: postgres-ssl
+          mountPath: /etc/ssl
+        - name: key-volume
+          mountPath: /etc/private
+  containers:
+    - name: external-db-ssl
+      image: postgres:15
+      args: 
+        - -c 
+        - ssl=on
+        - -c 
+        - ssl_cert_file=/etc/ssl/server.crt
+        - -c
+        - ssl_key_file=/etc/private/server.key
+        - -c
+        - ssl_ca_file=/etc/ssl/ca.crt
+      imagePullPolicy: IfNotPresent
+      resources:
+        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+        # requests:
+        #   cpu: 100m
+        #   memory: 500Mi
+        # limits:
+        #   cpu: 100m
+        #   memory: 500Mi
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+        limits:
+          cpu: 1000m
+          memory: 2Gi
+      env:
+        - name: POSTGRES_PASSWORD
+          value: noobaa
+        - name: LC_COLLATE
+          value: C
+      ports:
+        - containerPort: 5432
+      volumeMounts:
+        - name: postgres-ssl
+          mountPath: /etc/ssl
+        - name: key-volume
+          mountPath: /etc/private
+        - name: ssl-postgres-conf-sh-volume
+          mountPath: /docker-entrypoint-initdb.d
+  volumes:
+    - name: key-volume
+      emptyDir: {}
+    - name: ssl-postgres-conf-sh-volume
+      configMap:
+        name: ssl-postgres-conf-sh
+        items:
+        - key: sslconf.sh
+          path: sslconf.sh
+    - name: postgres-ssl 
+      secret:
+        secretName: postgres-ssl
+        defaultMode: 0600
+        items:
+        - key: server.key
+          path: server.key
+          mode: 0640
+        - key: server.crt
+          path: server.crt
+          mode: 0777
+        - key: ca.crt
+          path: ca.crt
+          mode: 0777

--- a/test/cli/resources/external-db.yaml
+++ b/test/cli/resources/external-db.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-external
+  namespace: test
+spec:
+  type: ClusterIP
+  selector:
+    app: external-db
+  ports:
+    - port: 5432
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: external-db
+  name: postgres-external
+  namespace: test
+spec:
+  containers:
+    - name: external-db
+      image: postgres:15
+      imagePullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 100m
+          memory: 500Mi
+        limits:
+          cpu: 100m
+          memory: 500Mi
+      env:
+        - name: POSTGRES_PASSWORD
+          value: noobaa
+        - name: LC_COLLATE
+          value: C
+      ports:
+        - containerPort: 5432
+

--- a/test/cli/test_cli_flow.sh
+++ b/test/cli/test_cli_flow.sh
@@ -7,6 +7,7 @@ export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} 
 
 NAMESPACE='test'
 CM=false
+RESOURCE='mini'
 
 function post_install_tests {
     aws_credentials
@@ -31,12 +32,18 @@ function post_install_tests {
 }
 
 function main {
-    local install_external=$((RANDOM%2))
+    local install_external=$((RANDOM%3))
+    install_external=2
     if [ ${install_external} -eq 0 ]
     then
         noobaa_install_external
     else
-        noobaa_install
+        if [ ${install_external} -eq 1 ]
+        then
+            noobaa_install_external_ssl
+        else
+            noobaa_install
+        fi
     fi
     if [ "${CM}" == "true" ]
     then
@@ -47,7 +54,12 @@ function main {
     if [ ${install_external} -eq 0 ]
     then
         delete_external_postgres
-    fi
+    else
+        if [ ${install_external} -eq 1 ]
+        then
+            delete_external_postgres_ssl
+        fi
+    fi 
  }
 
 function usage {
@@ -95,7 +107,11 @@ do
         -n|--namespace)          NAMESPACE=${2}
                                  shift 2;;
         --check_core_config_map) CM=true
-                                 shift;;       
+                                 shift;;
+        --dev)                   RESOURCE='dev'
+                                 shift;;
+        --mini)                  RESOURCE='mini'
+                                 shift;;      
         -h|--help)               usage;;
         *)                       usage;;
     esac


### PR DESCRIPTION
### Explain the changes
Commit 1:
1.  Adding support to SSL with external postgres DB both for server side (ssl-required will validate the certificate of the server), and also for client side (user can use ssl-key and ssl-cert to connect with the server)

Commit 2:
1. Adding an options to run noobaa install with ssl options (both sides)
2. Adding the options to run test-cli with --dev option to make it possible to run on M1 macs

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
