### PR TITLE
Bug Fix BZ 2242854 | Fallback to PV Pool (CCO)

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -44,6 +44,7 @@ const (
 	ibmLocation                           = "%s-standard"
 	ibmCOSCred                            = "ibm-cloud-cos-creds"
 	topologyConstraintsEnabledKubeVersion = "1.26.0"
+	minutesToWaitForDefaultBSCreation     = 10
 )
 
 type gcpAuthJSON struct {
@@ -763,11 +764,30 @@ func (r *Reconciler) preparePVPoolBackingStore() error {
 	return nil
 }
 
+func (r *Reconciler) defaultBSCreationTimedout(timestampCreation time.Time) bool {
+	minutesSinceCreation := time.Since(timestampCreation).Minutes()
+	return minutesSinceCreation > float64(minutesToWaitForDefaultBSCreation)
+}
+
+func (r *Reconciler) fallbackToPVPoolWithEvent(backingStoreType nbv1.StoreType, secretName string) error {
+	message := fmt.Sprintf("Failed to create default backingstore with type %s by %d minutes, "+
+		"fallback to create PV Pool backingstore",
+		backingStoreType, minutesToWaitForDefaultBSCreation)
+	additionalInfoForLogs := fmt.Sprintf(" (could not get Secret %s).", secretName)
+	r.Logger.Info(message + additionalInfoForLogs)
+	r.Recorder.Event(r.NooBaa, corev1.EventTypeWarning, "DefaultBackingStoreFailure", message)
+	if err := r.preparePVPoolBackingStore(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (r *Reconciler) prepareAWSBackingStore() error {
 	// after we have cloud credential request, wait for credentials secret
+	secretName := r.AWSCloudCreds.Spec.SecretRef.Name
 	cloudCredsSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.AWSCloudCreds.Spec.SecretRef.Name,
+			Name:      secretName,
 			Namespace: r.AWSCloudCreds.Spec.SecretRef.Namespace,
 		},
 	}
@@ -776,10 +796,15 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 	if cloudCredsSecret.UID == "" {
 		// TODO: we need to figure out why secret is not created, and react accordingly
 		// e.g. maybe we are running on azure but our CredentialsRequest is for AWS
-		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", r.AWSCloudCreds.Spec.SecretRef.Name)
-		return fmt.Errorf("cloud credentials secret %q is not ready yet", r.AWSCloudCreds.Spec.SecretRef.Name)
+		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", secretName)
+
+		// in case we have a cred request but we do not get a secret
+		if r.defaultBSCreationTimedout(r.AWSCloudCreds.CreationTimestamp.Time) {
+			return r.fallbackToPVPoolWithEvent(nbv1.StoreTypeAWSS3, secretName)
+		}
+		return fmt.Errorf("cloud credentials secret %q is not ready yet", secretName)
 	}
-	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", r.AWSCloudCreds.Spec.SecretRef.Name)
+	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", secretName)
 
 	// create the actual S3 bucket
 	region, err := util.GetAWSRegion()
@@ -813,9 +838,10 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 
 func (r *Reconciler) prepareAzureBackingStore() error {
 	// after we have cloud credential request, wait for credentials secret
+	secretName := r.AzureCloudCreds.Spec.SecretRef.Name
 	cloudCredsSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.AzureCloudCreds.Spec.SecretRef.Name,
+			Name:      secretName,
 			Namespace: r.AzureCloudCreds.Spec.SecretRef.Namespace,
 		},
 	}
@@ -824,10 +850,15 @@ func (r *Reconciler) prepareAzureBackingStore() error {
 	if cloudCredsSecret.UID == "" {
 		// TODO: we need to figure out why secret is not created, and react accordingly
 		// e.g. maybe we are running on AWS but our CredentialsRequest is for Azure
-		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", r.AzureCloudCreds.Spec.SecretRef.Name)
-		return fmt.Errorf("cloud credentials secret %q is not ready yet", r.AzureCloudCreds.Spec.SecretRef.Name)
+		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", secretName)
+
+		// in case we have a cred request but we do not get a secret
+		if r.defaultBSCreationTimedout(r.AzureCloudCreds.CreationTimestamp.Time) {
+			return r.fallbackToPVPoolWithEvent(nbv1.StoreTypeAzureBlob, secretName)
+		}
+		return fmt.Errorf("cloud credentials secret %q is not ready yet", secretName)
 	}
-	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", r.AzureCloudCreds.Spec.SecretRef.Name)
+	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", secretName)
 
 	util.KubeCheck(r.AzureContainerCreds)
 	if r.AzureContainerCreds.UID == "" {
@@ -887,10 +918,10 @@ func (r *Reconciler) prepareAzureBackingStore() error {
 }
 
 func (r *Reconciler) prepareGCPBackingStore() error {
-
+	secretName := r.GCPCloudCreds.Spec.SecretRef.Name
 	cloudCredsSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.GCPCloudCreds.Spec.SecretRef.Name,
+			Name:      secretName,
 			Namespace: r.GCPCloudCreds.Spec.SecretRef.Namespace,
 		},
 	}
@@ -899,10 +930,16 @@ func (r *Reconciler) prepareGCPBackingStore() error {
 	if cloudCredsSecret.UID == "" {
 		// TODO: we need to figure out why secret is not created, and react accordingly
 		// e.g. maybe we are running on AWS but our CredentialsRequest is for GCP
-		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", r.GCPCloudCreds.Spec.SecretRef.Name)
-		return fmt.Errorf("cloud credentials secret %q is not ready yet", r.GCPCloudCreds.Spec.SecretRef.Name)
+		r.Logger.Infof("Secret %q was not created yet by cloud-credentials operator. retry on next reconcile..", secretName)
+
+		// in case we have a cred request but we do not get a secret
+		if r.defaultBSCreationTimedout(r.GCPCloudCreds.CreationTimestamp.Time) {
+			return r.fallbackToPVPoolWithEvent(nbv1.StoreTypeGoogleCloudStorage, secretName)
+
+		}
+		return fmt.Errorf("cloud credentials secret %q is not ready yet", secretName)
 	}
-	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", r.GCPCloudCreds.Spec.SecretRef.Name)
+	r.Logger.Infof("Secret %s was created successfully by cloud-credentials operator", secretName)
 
 	util.KubeCheck(r.GCPBucketCreds)
 	if r.GCPBucketCreds.UID == "" {
@@ -950,6 +987,7 @@ func (r *Reconciler) prepareGCPBackingStore() error {
 
 func (r *Reconciler) prepareIBMBackingStore() error {
 	r.Logger.Info("Preparing backing store in IBM Cloud")
+	secretName := r.IBMCloudCOSCreds.Name
 
 	var (
 		endpoint string
@@ -958,8 +996,13 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 
 	util.KubeCheck(r.IBMCloudCOSCreds)
 	if r.IBMCloudCOSCreds.UID == "" {
-		r.Logger.Errorf("Cloud credentials secret %q is not ready yet", r.IBMCloudCOSCreds.Name)
-		return fmt.Errorf("Cloud credentials secret %q is not ready yet", r.IBMCloudCOSCreds.Name)
+		r.Logger.Errorf("Cloud credentials secret %q is not ready yet", secretName)
+
+		// in case we have a cred request but we do not get a secret
+		if r.defaultBSCreationTimedout(r.IBMCloudCOSCreds.CreationTimestamp.Time) {
+			return r.fallbackToPVPoolWithEvent(nbv1.StoreTypeIBMCos, secretName)
+		}
+		return fmt.Errorf("Cloud credentials secret %q is not ready yet", secretName)
 	}
 
 	if val, ok := r.IBMCloudCOSCreds.StringData["IBM_COS_Endpoint"]; ok {
@@ -1030,7 +1073,7 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 	r.DefaultBackingStore.Spec.IBMCos = &nbv1.IBMCosSpec{
 		TargetBucket: bucketName,
 		Secret: corev1.SecretReference{
-			Name:      r.IBMCloudCOSCreds.Name,
+			Name:      secretName,
 			Namespace: r.IBMCloudCOSCreds.Namespace,
 		},
 		Endpoint:         endpoint,
@@ -1053,10 +1096,16 @@ func (r *Reconciler) createGCPBucketForBackingStore(client *storage.Client, proj
 }
 
 func (r *Reconciler) prepareCephBackingStore() error {
+	objectStoreUserName := r.CephObjectStoreUser.Name
 	util.KubeCheck(r.CephObjectStoreUser)
 	if r.CephObjectStoreUser.UID == "" || r.CephObjectStoreUser.Status.Phase != "Ready" {
-		r.Logger.Infof("Ceph objectstore user %q is not ready. retry on next reconcile..", r.CephObjectStoreUser.Name)
-		return fmt.Errorf("Ceph objectstore user %q is not ready", r.CephObjectStoreUser.Name)
+		r.Logger.Infof("Ceph objectstore user %q is not ready. retry on next reconcile..", objectStoreUserName)
+
+		// in case it takes too long to have CephObjectStoreUser
+		if r.defaultBSCreationTimedout(r.CephObjectStoreUser.CreationTimestamp.Time) {
+			return r.fallbackToPVPoolWithEvent(nbv1.StoreTypeS3Compatible, objectStoreUserName)
+		}
+		return fmt.Errorf("Ceph objectstore user %q is not ready", objectStoreUserName)
 	}
 
 	secretName := r.CephObjectStoreUser.Status.Info["secretName"]
@@ -1075,6 +1124,11 @@ func (r *Reconciler) prepareCephBackingStore() error {
 	util.KubeCheck(cephObjectStoreUserSecret)
 	if cephObjectStoreUserSecret.UID == "" {
 		r.Logger.Infof("Ceph objectstore user secret %q was not created yet. retry on next reconcile..", secretName)
+
+		// in case it takes too long to have cephObjectStoreUserSecret
+		if r.defaultBSCreationTimedout(cephObjectStoreUserSecret.CreationTimestamp.Time) {
+			return r.fallbackToPVPoolWithEvent(nbv1.StoreTypeS3Compatible, secretName)
+		}
 		return fmt.Errorf("Ceph objectstore user secret %q is not ready yet", secretName)
 	}
 


### PR DESCRIPTION
### Explain the changes
1. Fallback to PV pool when cloud credential (CCO) was sent but didn't receive Secrets by the limited time that we defined. In the current implementation, it is 10 minutes (the number was chosen arbitrarily).
2. Record it as an event (using `recorder.Event`).
3. Save variable `secretName` for readability.

### Issues: Fixed [BZ 2242854](https://bugzilla.redhat.com/show_bug.cgi?id=2242854)
1. The option to use CCO with Manual mode was already introduced in 4.13 (as you can see in the [doc of CCO](https://docs.openshift.com/container-platform/4.13/authentication/managing_cloud_provider_credentials/cco-mode-sts.html)) and this change would be backport.

### Testing Instructions:
* Tests were on the cluster bot using `launch 4.14 aws`.

**Before this change:**
1. Install noobaa with default CCO mode - noobaa install should be Ready and we would have default backingstore type will be AWS.
2. Install noobaa with CCO mode as Manual - noobaa is stuck in phase Configuring (you can see in the logs of the operator that the Secret was not created yet (_"Secret \"noobaa-aws-cloud-creds-secret\" was not created yet by cloud-credentials operator. retry on next reconcile.."_).

**After this change:**
1. Install noobaa with default CCO mode (verify same behaviour) - noobaa install should be Ready and we would have default backingstore type will be AWS.
2. Install noobaa with CCO mode as Manual - noobaa install should be Ready and we would have default backingstore type will be PV Pool.  In the logs of the operator you'll see that is writes that it would create pv pool. In addition to that you need to see the new event.

Every step is described in detail in the [comment below](https://github.com/noobaa/noobaa-operator/pull/1223#issuecomment-1755265600).

- [ ] Doc added/updated
- [ ] Tests added
