### PR TITLE
Bug Fix BZ 2242414 | Use `appNamespace` Instead of `options.Namespace` For Secret

### DIFF
--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -261,7 +261,7 @@ func RunRegenerate(cmd *cobra.Command, args []string) {
 
 	accountName := ob.Spec.AdditionalState["account"]
 
-	err := GenerateAccountKeys(name, accountName)
+	err := GenerateAccountKeys(name, accountName, appNamespace)
 	if err != nil {
 		log.Fatalf(`❌ Could not regenerate credentials for %q: %v`, name, err)
 	}
@@ -518,7 +518,7 @@ func CheckPhase(obc *nbv1.ObjectBucketClaim) {
 }
 
 // GenerateAccountKeys regenerate noobaa OBC account S3 keys
-func GenerateAccountKeys(name string, accountName string) error {
+func GenerateAccountKeys(name, accountName, appNamespace string) error {
 	log := util.Logger()
 
 	if accountName == "" {
@@ -534,7 +534,7 @@ func GenerateAccountKeys(name string, accountName string) error {
 
 	// Checking that we can find the secret before we are calling the RPC to change the credentials.
 	secret := util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret)
-	secret.Namespace = options.Namespace
+	secret.Namespace = appNamespace
 	secret.Name = name
 	if !util.KubeCheckQuiet(secret) {
 		log.Fatalf(`❌  Could not find secret: %s, will not regenerate keys.`, secret.Name)


### PR DESCRIPTION
### Explain the changes
1. Use `appNamespace` instead of `options.Namespace` for secret namespace (`obc regenerate`).

### Issues: [BZ 2242414](https://bugzilla.redhat.com/show_bug.cgi?id=2242414)
1. Without this change we would get an Error: "Could not find secret: name-of-obc, will not regenerate keys."
2. PR #1230 added the option to use the flag, this fix is also needed also (for using the command with this flag).

### Testing Instructions:
After we have an image of noobaa-cli with those changes and we installed noobaa (tested on the cluster-bot):
1. Create new namespace: `oc new-project craig-ns1`
2. Create an OBC in the namespace "craig-ns1": `noobaa obc create craig-test-obc2 --app-namespace craig-ns1`.
3. Regenerating an OBC in the namespace "craig-ns1": `noobaa obc regenerate craig-test-obc2 --app-namespace craig-ns1`.

- [ ] Doc added/updated
- [ ] Tests added
