### PR TITLE
[Backport to 5.11] BugFix - [MCG] RPC method "list_objects" fails with "RPC: object.list_objects() Call failed: failed to WebSocket dial"

### DIFF
--- a/pkg/nb/router.go
+++ b/pkg/nb/router.go
@@ -199,9 +199,6 @@ func FindPortByName(srv *corev1.Service, portName string) *corev1.ServicePort {
 
 // GetAPIPortName maps every noobaa api name to the service port name that serves it.
 func GetAPIPortName(api string) string {
-	if api == "object_api" || api == "func_api" {
-		return "md-https"
-	}
 	if api == "scrubber_api" {
 		return "bg-https"
 	}


### PR DESCRIPTION
Signed-off-by: Aayush Chouhan <aayush.chouhan97@gmail.com>
(cherry picked from commit 0f3dd04f29952dbe87b357653c8ac4ab6f6fb2f3)

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2246336

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
