### PR TITLE
Fix - Added force_md5_etag in NoobaaAccount CmdUpdate 

### DIFF
--- a/pkg/apis/noobaa/v1alpha1/noobaaaccount_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaaaccount_types.go
@@ -69,7 +69,7 @@ type NooBaaAccountSpec struct {
 
 	// ForceMd5Etag specifies whether MD5 Etags should be calculated for the account or not
 	// +optional
-	ForceMd5Etag bool `json:"force_md5_etag,omitempty"`
+	ForceMd5Etag *bool `json:"force_md5_etag,omitempty"`
 }
 
 // AccountNsfsConfig is the configuration of NSFS of CreateAccountParams

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -983,6 +983,11 @@ func (in *NooBaaAccountSpec) DeepCopyInto(out *NooBaaAccountSpec) {
 		*out = new(AccountNsfsConfig)
 		**out = **in
 	}
+	if in.ForceMd5Etag != nil {
+		in, out := &in.ForceMd5Etag, &out.ForceMd5Etag
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -589,7 +589,7 @@ type UpdateAccountS3AccessParams struct {
 	Email               string                  `json:"email"`
 	S3Access            bool                    `json:"s3_access"`
 	DefaultResource     *string                 `json:"default_resource,omitempty"`
-	ForceMd5Etag        bool                    `json:"force_md5_etag,omitempty"`
+	ForceMd5Etag        *bool                   `json:"force_md5_etag,omitempty"`
 	AllowBucketCreation *bool                   `json:"allow_bucket_creation,omitempty"`
 	NsfsAccountConfig   *nbv1.AccountNsfsConfig `json:"nsfs_account_config,omitempty"`
 }

--- a/pkg/noobaaaccount/reconciler.go
+++ b/pkg/noobaaaccount/reconciler.go
@@ -333,6 +333,7 @@ func (r *Reconciler) CreateNooBaaAccount() error {
 		DefaultResource:   r.NooBaaAccount.Spec.DefaultResource,
 		HasLogin:          false,
 		S3Access:          true,
+		ForceMd5Etag:      *r.NooBaaAccount.Spec.ForceMd5Etag,
 		AllowBucketCreate: r.NooBaaAccount.Spec.AllowBucketCreate,
 	}
 
@@ -391,6 +392,7 @@ func (r *Reconciler) UpdateNooBaaAccount() error {
 			Email:               r.NooBaaAccount.Name,
 			DefaultResource:     &r.NooBaaAccount.Spec.DefaultResource,
 			S3Access:            true,
+			ForceMd5Etag:        r.NooBaaAccount.Spec.ForceMd5Etag,
 			AllowBucketCreation: &r.NooBaaAccount.Spec.AllowBucketCreate,
 		}
 


### PR DESCRIPTION
### Explain the changes
1. Added force_md5_etag in NoobaaAccount CmdUpdate

### Issues: Fixed #xxx / Gap #xxx
1. force_md5_etag was missing in NoobaaAccount CmdUpdate.