### PR TITLE
Default Backingstore IBM COS - Change Comment and Variable Name

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -788,9 +788,9 @@ func (r *Reconciler) ReconcileIBMCredentials() error {
 	// Currently IBM Cloud is not supported by cloud credential operator
 	// In IBM Cloud, the COS Creds will be provided through Secret.
 	r.Logger.Info("Running in IBM Cloud")
-	util.KubeCheck(r.IBMCloudCOSCreds)
-	if r.IBMCloudCOSCreds.UID == "" {
-		r.Logger.Infof("%q secret is not present", r.IBMCloudCOSCreds.Name)
+	util.KubeCheck(r.IBMCosBucketCreds)
+	if r.IBMCosBucketCreds.UID == "" {
+		r.Logger.Infof("%q secret is not present", r.IBMCosBucketCreds.Name)
 		return nil
 	}
 	return nil

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -98,7 +98,7 @@ type Reconciler struct {
 	AzureContainerCreds       *corev1.Secret
 	GCPBucketCreds            *corev1.Secret
 	GCPCloudCreds             *cloudcredsv1.CredentialsRequest
-	IBMCloudCOSCreds          *corev1.Secret
+	IBMCosBucketCreds         *corev1.Secret
 	DefaultBackingStore       *nbv1.BackingStore
 	DefaultBucketClass        *nbv1.BucketClass
 	OBCStorageClass           *storagev1.StorageClass
@@ -164,7 +164,7 @@ func NewReconciler(
 		AWSCloudCreds:             util.KubeObject(bundle.File_deploy_internal_cloud_creds_aws_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		AzureCloudCreds:           util.KubeObject(bundle.File_deploy_internal_cloud_creds_azure_cr_yaml).(*cloudcredsv1.CredentialsRequest),
 		GCPCloudCreds:             util.KubeObject(bundle.File_deploy_internal_cloud_creds_gcp_cr_yaml).(*cloudcredsv1.CredentialsRequest),
-		IBMCloudCOSCreds:          util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
+		IBMCosBucketCreds:         util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		DefaultBackingStore:       util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml).(*nbv1.BackingStore),
 		DefaultBucketClass:        util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml).(*nbv1.BucketClass),
 		OBCStorageClass:           util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass),
@@ -211,7 +211,7 @@ func NewReconciler(
 	r.AzureCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
 	r.GCPCloudCreds.Namespace = r.Request.Namespace
 	r.GCPCloudCreds.Spec.SecretRef.Namespace = r.Request.Namespace
-	r.IBMCloudCOSCreds.Namespace = r.Request.Namespace
+	r.IBMCosBucketCreds.Namespace = r.Request.Namespace
 	r.DefaultBackingStore.Namespace = r.Request.Namespace
 	r.DefaultBucketClass.Namespace = r.Request.Namespace
 	r.PrometheusRule.Namespace = r.Request.Namespace
@@ -255,7 +255,7 @@ func NewReconciler(
 	r.GCPCloudCreds.Name = r.Request.Name + "-gcp-cloud-creds"
 	r.GCPCloudCreds.Spec.SecretRef.Name = r.Request.Name + "-gcp-cloud-creds-secret"
 	r.CephObjectStoreUser.Name = r.Request.Name + "-ceph-objectstore-user"
-	r.IBMCloudCOSCreds.Name = ibmCOSCred
+	r.IBMCosBucketCreds.Name = ibmCosBucketCred
 	r.DefaultBackingStore.Name = r.Request.Name + "-default-backing-store"
 	r.DefaultBucketClass.Name = r.Request.Name + "-default-bucket-class"
 	r.PrometheusRule.Name = r.Request.Name + "-prometheus-rules"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1078,7 +1078,7 @@ func IsIBMPlatform() bool {
 	}
 	isIBM := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "ibm")
 	if isIBM {
-		// Incase of Satellite cluster is deployed in user provided infrastructure
+		// In case of Satellite cluster is deployed in user provided infrastructure
 		if strings.Contains(nodesList.Items[0].Spec.ProviderID, "/sat-") {
 			isIBM = false
 		}


### PR DESCRIPTION
### Explain the changes
1. Change variable name `IBMCloudCOSCreds` to `IBMCosBucketCreds` - since `CloudCred` suffix is for `CredentialsRequest` and currently we don't use `CredentialsRequest` in IBM COS.
2. Change the comment in `prepareIBMBackingStore` related to "cred request" (because there is no `CredentialsRequest`).
3. Change printing from hard-coded ("PV-Pool") to const variable.
4. Fix typo in comment

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added
