### PR TITLE
Add Logs to `Setdesirednoobaadb` Before Record an Event

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -374,6 +374,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 				}
 				if r.NooBaa.Spec.DBVolumeResources != nil &&
 					!reflect.DeepEqual(pvc.Spec.Resources, *r.NooBaa.Spec.DBVolumeResources) {
+					r.Logger.Infof("No match between DB volume resources")
 					r.Recorder.Eventf(r.NooBaa, corev1.EventTypeWarning, "DBVolumeResourcesIsImmutable",
 						"spec.dbVolumeResources is immutable and cannot be updated for volume %q in existing %s %q"+
 							" since it requires volume recreate and migrate which is unsupported by the operator",

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -364,6 +364,8 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 				if r.NooBaa.Spec.DBStorageClass != nil {
 					desiredClass = *r.NooBaa.Spec.DBStorageClass
 					if desiredClass != currentClass {
+						r.Logger.Infof("No match between desired DB storage class in noobaa %s and current class in pvc %s",
+							desiredClass, currentClass)
 						r.Recorder.Eventf(r.NooBaa, corev1.EventTypeWarning, "DBStorageClassIsImmutable",
 							"spec.dbStorageClass is immutable and cannot be updated for volume %q in existing %s %q"+
 								" since it requires volume recreate and migrate which is unsupported by the operator",

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -351,7 +351,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 		}
 
 		// when already exists we check that there is no update requested to the volumes
-		// otherwise we report that volume updarte is unsupported
+		// otherwise we report that volume update is unsupported
 		for i := range NooBaaDB.Spec.VolumeClaimTemplates {
 			pvc := &NooBaaDB.Spec.VolumeClaimTemplates[i]
 			switch pvc.Name {


### PR DESCRIPTION
### Explain the changes
1. add logs when the storage class of DB is different (print the name of them).
2. Add logs in case DB volume resources are different (without values).
3. Fix a typo in a comment.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. Build the image and deploy noobaa on local cluster (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Change the storage class of DB in noobaa: 
`kubectl edit noobaa -n <your-namespace>`
and paste under "dbType: postgres"
"dbStorageClass: lala" ("lala" has no meaning, just not an empty string).
3. You can see the events in `kubectl describe noobaa -n <your-namespace>`:

> Warning  DBStorageClassIsImmutable  46s (x36 over 5m52s)  noobaa-operator  spec.dbStorageClass is immutable and cannot be updated for volume "db" in existing StatefulSet "noobaa-core" since it requires volume recreate and migrate which is unsupported by the operator

4. In operator logs you can see:

> time="2023-11-08T15:16:52Z" level=info msg="No match between desired DB storage class in noobaa lala and current class in pvc local-path" sys=test1/noobaa

- [ ] Doc added/updated
- [ ] Tests added
