### PR TITLE
Edit CLI Short of Creation of Type `aws-sts-s3` in BS and NS

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -72,7 +73,7 @@ func CmdCreate() *cobra.Command {
 func CmdCreateAWSSTSS3() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws-sts-s3 <backing-store-name>",
-		Short: "Create aws-sts-s3 backing store",
+		Short: "Create aws-s3 backing store (using STS, short-lived credentials)",
 		Run:   RunCreateAWSSTSS3,
 	}
 	cmd.Flags().String(
@@ -94,7 +95,7 @@ func CmdCreateAWSSTSS3() *cobra.Command {
 func CmdCreateAWSS3() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws-s3 <backing-store-name>",
-		Short: "Create aws-s3 backing store",
+		Short: "Create aws-s3 backing store (using long-lived credentials)",
 		Run:   RunCreateAWSS3,
 	}
 	cmd.Flags().String(
@@ -481,6 +482,9 @@ func RunCreateAWSSTSS3(cmd *cobra.Command, args []string) {
 		log.Fatalf(`❌ BackingStore %q already exists in namespace %q`, backStore.Name, backStore.Namespace)
 	}
 	awsSTSARN := util.GetFlagStringOrPrompt(cmd, "aws-sts-arn")
+	if !arn.IsARN(awsSTSARN) {
+		log.Fatalf(`❌ aws-sts-arn %q is invalid`, awsSTSARN)
+	}
 	targetBucket := util.GetFlagStringOrPrompt(cmd, "target-bucket")
 	region, _ := cmd.Flags().GetString("region")
 	backStore.Spec.AWSS3 = &nbv1.AWSS3Spec{

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,7 +70,7 @@ func CmdCreate() *cobra.Command {
 func CmdCreateAWSS3() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws-s3 <namespace-store-name>",
-		Short: "Create aws-s3 namespace store",
+		Short: "Create aws-s3 namespace store (using long-lived credentials)",
 		Run:   RunCreateAWSS3,
 	}
 	cmd.Flags().String(
@@ -103,7 +104,7 @@ func CmdCreateAWSS3() *cobra.Command {
 func CmdCreateAWSSTSS3() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws-sts-s3 <namespace-store-name>",
-		Short: "Create aws-sts-s3 namespace store",
+		Short: "Create aws-s3 namespace store (using STS, short-lived credentials)",
 		Run:   RunCreateAWSSTSS3,
 	}
 	cmd.Flags().String(
@@ -491,6 +492,9 @@ func RunCreateAWSSTSS3(cmd *cobra.Command, args []string) {
 		log.Fatalf(`❌ NamespaceStore %q already exists in namespace %q`, namespaceStore.Name, namespaceStore.Namespace)
 	}
 	awsSTSARN := util.GetFlagStringOrPrompt(cmd, "aws-sts-arn")
+	if !arn.IsARN(awsSTSARN) {
+		log.Fatalf(`❌ aws-sts-arn %q is invalid`, awsSTSARN)
+	}
 	targetBucket := util.GetFlagStringOrPrompt(cmd, "target-bucket")
 	region, _ := cmd.Flags().GetString("region")
 	namespaceStore.Spec.AWSS3 = &nbv1.AWSS3Spec{


### PR DESCRIPTION
### Explain the changes
1. Edit noobaa CLI short of creation of `noobaa backingstore create aws-sts`.
2. Add validation to `aws-sts-arn` that the user enters.
3. Add the above changes to `noobaa namespacestore create aws-sts`.

### Issues: Fixed #xxx / Gap #xxx
1. none, I thought that the description creates an expectation to see a new type of `aws-sts-s3` which is not true (it is `aws-s3`), hence suggesting to change it.

### Testing Instructions:
To see the new changes in the noobaa CLI build the image using `make cli`.
1. `noobaa backingstore create --help` attached partial output:
> Available Commands:
>   aws-s3                 Create aws-s3 backing store (using long-lived credentials)
>   aws-sts-s3          Create aws-s3 backing store (using STS, short-lived credentials)
2.  `noobaa namespacestore create --help` attached partial output:
> Available Commands:
>   aws-s3                 Create aws-s3 namespace store (using long-lived credentials)
>   aws-sts-s3          Create aws-s3 namespace store (using STS, short-lived credentials)

To see the changes related to the `aws-sts-arn` validation
1. Create AWS STS Setup on Minikube (the guide will be in the operator repo, meanwhile this is the PR #noobaa/noobaa-operator#1244.
2. Build the image and deploy noobaa on MInikube (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
3. Create backingstore:
`nooba backingstore create aws-sts-s3 <backingstore-name> -n <your-namespace>`
Then in the prompted `Enter aws-sts-arn:` type a short string, for example: 'dd'
You'll see a message:
> FATA[0001] ❌ aws-sts-arn "dd" is invalid
4. 3. Create namespacestore:
`nooba namespacestore create aws-sts-s3 <namespacestore-name> -n <your-namespace>`
Then in the prompted `Enter aws-sts-arn:` type a short string, for example: 'dd'
You'll see a message:
> FATA[0001] ❌ aws-sts-arn "dd" is invalid


- [ ] Doc added/updated
- [ ] Tests added
