### PR TITLE
Noobaa/Bucket Logging : syslog service for log transfer

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -25,6 +25,10 @@ spec:
       jsonPath: .status.services.serviceSts.nodePorts
       name: Sts-Endpoints
       type: string
+    - description: Syslog Endpoints
+      jsonPath: .status.services.serviceSyslog.nodePorts
+      name: Syslog-Endpoints
+      type: string
     - description: Actual Image
       jsonPath: .status.actualImage
       name: Image
@@ -1875,6 +1879,59 @@ spec:
                         type: array
                     type: object
                   serviceSts:
+                    description: ServiceStatus is the status info and network addresses
+                      of a service
+                    properties:
+                      externalDNS:
+                        description: ExternalDNS are external public addresses for
+                          the service
+                        items:
+                          type: string
+                        type: array
+                      externalIP:
+                        description: ExternalIP are external public addresses for
+                          the service LoadBalancerPorts such as AWS ELB provide public
+                          address and load balancing for the service IngressPorts
+                          are manually created public addresses for the service https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+                          https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+                          https://kubernetes.io/docs/concepts/services-networking/ingress/
+                        items:
+                          type: string
+                        type: array
+                      internalDNS:
+                        description: InternalDNS are internal addresses of the service
+                          inside the cluster
+                        items:
+                          type: string
+                        type: array
+                      internalIP:
+                        description: InternalIP are internal addresses of the service
+                          inside the cluster https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                        items:
+                          type: string
+                        type: array
+                      nodePorts:
+                        description: NodePorts are the most basic network available.
+                          NodePorts use the networks available on the hosts of kubernetes
+                          nodes. This generally works from within a pod, and from
+                          the internal network of the nodes, but may fail from public
+                          network. https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                        items:
+                          type: string
+                        type: array
+                      podPorts:
+                        description: 'PodPorts are the second most basic network address.
+                          Every pod has an IP in the cluster and the pods network
+                          is a mesh so the operator running inside a pod in the cluster
+                          can use this address. Note: pod IPs are not guaranteed to
+                          persist over restarts, so should be rediscovered. Note2:
+                          when running the operator outside of the cluster, pod IP
+                          is not accessible.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  serviceSyslog:
                     description: ServiceStatus is the status info and network addresses
                       of a service
                     properties:

--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -84,6 +84,7 @@ spec:
                   name: noobaa-config
                   key: NOOBAA_LOG_LEVEL
             - name: MGMT_ADDR
+            - name: SYSLOG_ADDR
             - name: BG_ADDR
             - name: MD_ADDR
             - name: HOSTED_AGENTS_ADDR

--- a/deploy/internal/service-syslog.yaml
+++ b/deploy/internal/service-syslog.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: SYSNAME-syslog
+  labels:
+    app: noobaa
+    noobaa-syslog-svc: "true"
+spec:
+  type: ClusterIP
+  selector:
+    noobaa-mgmt: SYSNAME
+  ports:
+    - protocol: UDP
+      port: 514
+      name: syslog
+      targetPort: 514

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -33,6 +33,7 @@ type AnnotationsSpec map[string]Annotations
 // +kubebuilder:resource:shortName=nb
 // +kubebuilder:printcolumn:name="S3-Endpoints",type="string",JSONPath=".status.services.serviceS3.nodePorts",description="S3 Endpoints"
 // +kubebuilder:printcolumn:name="Sts-Endpoints",type="string",JSONPath=".status.services.serviceSts.nodePorts",description="STS Endpoints"
+// +kubebuilder:printcolumn:name="Syslog-Endpoints",type="string",JSONPath=".status.services.serviceSyslog.nodePorts",description="Syslog Endpoints"
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.actualImage",description="Actual Image"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Phase"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
@@ -407,10 +408,11 @@ type AccountsStatus struct {
 
 // ServicesStatus is the status info of the system's services
 type ServicesStatus struct {
-	ServiceMgmt ServiceStatus `json:"serviceMgmt"`
-	ServiceS3   ServiceStatus `json:"serviceS3"`
+	ServiceMgmt   ServiceStatus `json:"serviceMgmt"`
+	ServiceS3     ServiceStatus `json:"serviceS3"`
 	// +optional
-	ServiceSts ServiceStatus `json:"serviceSts,omitempty"`
+	ServiceSts    ServiceStatus `json:"serviceSts,omitempty"`
+	ServiceSyslog ServiceStatus `json:"serviceSyslog,omitempty"`
 }
 
 // UserStatus is the status info of a user secret

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -1399,6 +1399,7 @@ func (in *ServicesStatus) DeepCopyInto(out *ServicesStatus) {
 	in.ServiceMgmt.DeepCopyInto(&out.ServiceMgmt)
 	in.ServiceS3.DeepCopyInto(&out.ServiceS3)
 	in.ServiceSts.DeepCopyInto(&out.ServiceSts)
+	in.ServiceSyslog.DeepCopyInto(&out.ServiceSyslog)
 	return
 }
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1471,7 +1471,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "87997842fc69b23f31b716777b6c3df7b12db2ae12758f890f63ce8d910a89f2"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "343bbc46804fc8442eb4473f8ee3dcd0cd3d05b95ce670f9aad035770e2ba9d3"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -1499,6 +1499,10 @@ spec:
     - description: STS Endpoints
       jsonPath: .status.services.serviceSts.nodePorts
       name: Sts-Endpoints
+      type: string
+    - description: Syslog Endpoints
+      jsonPath: .status.services.serviceSyslog.nodePorts
+      name: Syslog-Endpoints
       type: string
     - description: Actual Image
       jsonPath: .status.actualImage
@@ -3402,6 +3406,59 @@ spec:
                           type: string
                         type: array
                     type: object
+                  serviceSyslog:
+                    description: ServiceStatus is the status info and network addresses
+                      of a service
+                    properties:
+                      externalDNS:
+                        description: ExternalDNS are external public addresses for
+                          the service
+                        items:
+                          type: string
+                        type: array
+                      externalIP:
+                        description: ExternalIP are external public addresses for
+                          the service LoadBalancerPorts such as AWS ELB provide public
+                          address and load balancing for the service IngressPorts
+                          are manually created public addresses for the service https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+                          https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+                          https://kubernetes.io/docs/concepts/services-networking/ingress/
+                        items:
+                          type: string
+                        type: array
+                      internalDNS:
+                        description: InternalDNS are internal addresses of the service
+                          inside the cluster
+                        items:
+                          type: string
+                        type: array
+                      internalIP:
+                        description: InternalIP are internal addresses of the service
+                          inside the cluster https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                        items:
+                          type: string
+                        type: array
+                      nodePorts:
+                        description: NodePorts are the most basic network available.
+                          NodePorts use the networks available on the hosts of kubernetes
+                          nodes. This generally works from within a pod, and from
+                          the internal network of the nodes, but may fail from public
+                          network. https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                        items:
+                          type: string
+                        type: array
+                      podPorts:
+                        description: 'PodPorts are the second most basic network address.
+                          Every pod has an IP in the cluster and the pods network
+                          is a mesh so the operator running inside a pod in the cluster
+                          can use this address. Note: pod IPs are not guaranteed to
+                          persist over restarts, so should be rediscovered. Note2:
+                          when running the operator outside of the cluster, pod IP
+                          is not accessible.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
                 required:
                 - serviceMgmt
                 - serviceS3
@@ -3741,7 +3798,7 @@ data:
           exit 0
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "b3dab0839de6aa382833772ab278feb245067b27591dee988b29184de90961b6"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "ffcf95c206c68b6d6b783d847d219e45a61e79d374cad4f36e6a7ec4f7fb4d0a"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -3829,6 +3886,7 @@ spec:
                   name: noobaa-config
                   key: NOOBAA_LOG_LEVEL
             - name: MGMT_ADDR
+            - name: SYSLOG_ADDR
             - name: BG_ADDR
             - name: MD_ADDR
             - name: HOSTED_AGENTS_ADDR
@@ -4705,6 +4763,26 @@ spec:
       targetPort: 7443
       name: sts-https
 
+`
+
+const Sha256_deploy_internal_service_syslog_yaml = "68e2f27b91e8859055f18ca18d5d1cebdaac13a386b507a015c5e81d1f882241"
+
+const File_deploy_internal_service_syslog_yaml = `apiVersion: v1
+kind: Service
+metadata:
+  name: SYSNAME-syslog
+  labels:
+    app: noobaa
+    noobaa-syslog-svc: "true"
+spec:
+  type: ClusterIP
+  selector:
+    noobaa-mgmt: SYSNAME
+  ports:
+    - protocol: UDP
+      port: 514
+      name: syslog
+      targetPort: 514
 `
 
 const Sha256_deploy_internal_service_admission_webhook_yaml = "810a70b263d44621713864aa6e6e72e6079bbdc02f6e2b9143ba9ebf4ab52102"

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -85,6 +85,9 @@ func (r *Reconciler) ReconcilePhaseCreating() error {
 		r.Logger.Errorf("failed to create CredentialsRequest. will retry in phase 4. error: %v", err)
 		return err
 	}
+	if err := r.ReconcileObjectOptional(r.ServiceSyslog, r.SetDesiredServiceSyslog); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -201,6 +204,13 @@ func (r *Reconciler) SetDesiredServiceAccount() error {
 func (r *Reconciler) SetDesiredServiceMgmt() error {
 	r.ServiceMgmt.Spec.Selector["noobaa-mgmt"] = r.Request.Name
 	r.ServiceMgmt.Labels["noobaa-mgmt-svc"] = "true"
+	return nil
+}
+
+// SetDesiredServiceSyslog updates the ServiceSyslog as desired for reconciling
+func (r *Reconciler) SetDesiredServiceSyslog() error {
+	r.ServiceSyslog.Spec.Selector["noobaa-mgmt"] = r.Request.Name
+	r.ServiceSyslog.Labels["noobaa-syslog-svc"] = "true"
 	return nil
 }
 

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -310,10 +310,12 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 			}
 			mgmtBaseAddr := ""
 			s3BaseAddr := ""
+			syslogBaseAddr := ""
 			util.MergeEnvArrays(&c.Env, &r.DefaultDeploymentEndpoint.Containers[0].Env)
 			if r.JoinSecret == nil {
 				mgmtBaseAddr = fmt.Sprintf(`wss://%s.%s.svc`, r.ServiceMgmt.Name, r.Request.Namespace)
 				s3BaseAddr = fmt.Sprintf(`wss://%s.%s.svc`, r.ServiceS3.Name, r.Request.Namespace)
+				syslogBaseAddr = fmt.Sprintf(`udp://%s.%s.svc`, r.ServiceSyslog.Name, r.Request.Namespace)
 				r.setDesiredCoreEnv(c)
 			}
 
@@ -325,6 +327,13 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 						c.Env[j].Value = fmt.Sprintf(`%s:%d`, mgmtBaseAddr, port.Port)
 					} else {
 						c.Env[j].Value = r.JoinSecret.StringData["mgmt_addr"]
+					}
+				case "SYSLOG_ADDR":
+					if r.JoinSecret == nil {
+						port := nb.FindPortByName(r.ServiceSyslog, "syslog")
+						c.Env[j].Value = fmt.Sprintf(`%s:%d`, syslogBaseAddr, port.Port)
+					} else {
+						c.Env[j].Value = r.JoinSecret.StringData["syslog"]
 					}
 				case "BG_ADDR":
 					if r.JoinSecret == nil {

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -84,6 +84,7 @@ type Reconciler struct {
 	ServiceSts                *corev1.Service
 	ServiceDb                 *corev1.Service
 	ServiceDbPg               *corev1.Service
+	ServiceSyslog             *corev1.Service
 	SecretServer              *corev1.Secret
 	SecretDB                  *corev1.Secret
 	SecretOp                  *corev1.Secret
@@ -153,6 +154,7 @@ func NewReconciler(
 		ServiceMgmt:               util.KubeObject(bundle.File_deploy_internal_service_mgmt_yaml).(*corev1.Service),
 		ServiceS3:                 util.KubeObject(bundle.File_deploy_internal_service_s3_yaml).(*corev1.Service),
 		ServiceSts:                util.KubeObject(bundle.File_deploy_internal_service_sts_yaml).(*corev1.Service),
+		ServiceSyslog:             util.KubeObject(bundle.File_deploy_internal_service_syslog_yaml).(*corev1.Service),
 		SecretServer:              util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretDB:                  util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretOp:                  util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
@@ -197,6 +199,7 @@ func NewReconciler(
 	r.ServiceSts.Namespace = r.Request.Namespace
 	r.ServiceDb.Namespace = r.Request.Namespace
 	r.ServiceDbPg.Namespace = r.Request.Namespace
+	r.ServiceSyslog.Namespace = r.Request.Namespace
 	r.SecretServer.Namespace = r.Request.Namespace
 	r.SecretDB.Namespace = r.Request.Namespace
 	r.SecretOp.Namespace = r.Request.Namespace
@@ -236,6 +239,7 @@ func NewReconciler(
 	r.NooBaaMongoDB.Name = r.Request.Name + "-db"
 	r.NooBaaPostgresDB.Name = r.Request.Name + "-db-pg"
 	r.ServiceMgmt.Name = r.Request.Name + "-mgmt"
+	r.ServiceSyslog.Name = "noobaa-syslog"
 	r.ServiceS3.Name = "s3"
 	r.ServiceSts.Name = "sts"
 	r.ServiceDb.Name = r.Request.Name + "-db"
@@ -308,6 +312,7 @@ func (r *Reconciler) CheckAll() {
 	util.KubeCheck(r.ServiceMgmt)
 	util.KubeCheck(r.ServiceS3)
 	util.KubeCheck(r.ServiceSts)
+	util.KubeCheck(r.ServiceSyslog)
 	if r.NooBaa.Spec.MongoDbURL == "" && r.NooBaa.Spec.ExternalPgSecret == nil {
 		if r.NooBaa.Spec.DBType == "postgres" {
 			util.KubeCheck(r.SecretDB)


### PR DESCRIPTION
Whenever an object operation comes to endpoint, handle_request function process it and logs it to its /var/log/messages.

We need these logs to be sent on noobaa core so that we can process it further and accordingly write it to log bucket as log objects.

In this code change we are creating a service noobaa-syslog. We will send logs from end point to this service which in turn deliver it to noobaa core.

Credit goes to aprinzse@redhat.com for the code contribution.
