### PR TITLE
Bug Fix #1259 | Fix Bug Operator Restart on GCP Cluster

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1007,6 +1007,10 @@ func (r *Reconciler) prepareGCPBackingStore() error {
 		return err
 	}
 	projectID := authJSON.ProjectID
+	if r.GCPBucketCreds.StringData == nil {
+		r.Logger.Infof("Secret %q does not contain a map of StringData yet. retry on next reconcile...", secretName)
+		return fmt.Errorf("cloud credentials secret %q is not ready yet (does not contain a map of StringData yet)", secretName)
+	}
 	r.GCPBucketCreds.StringData["GoogleServiceAccountPrivateKeyJson"] = cloudCredsSecret.StringData["service_account.json"]
 	ctx := context.Background()
 	gcpclient, err := storage.NewClient(ctx, option.WithCredentialsJSON([]byte(cloudCredsSecret.StringData["service_account.json"])))


### PR DESCRIPTION
### Explain the changes
1. Add a condition before assignment to map, to avoid the error: panic: assignment to entry in nil map.

### Issues: Fixed #1259
1. Details are in the issue.

### Testing Instructions:
1. Written in the issue.

- [ ] Doc added/updated
- [ ] Tests added
