### PR TITLE
Added preStop hook to DB statefulset

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -309,6 +309,15 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 			if r.NooBaa.Spec.DBResources != nil {
 				c.Resources = *r.NooBaa.Spec.DBResources
 			}
+
+			c.Lifecycle = &corev1.Lifecycle{
+				PreStop: &corev1.LifecycleHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"/bin/sh", "-c", "pg_ctl -D /var/lib/pgsql/data/userdata/ -w -t 60 -m fast stop"},
+					},
+				},
+			}
+
 		}
 	}
 


### PR DESCRIPTION
### Explain the changes
1. The preStop hook will will be executed before terminating the pod. Will call the following command:
   ```
   pg_ctl -D /var/lib/pgsql/data/userdata/ -w -t 60 -m fast stop
   ``` 
2. `-m fast` will cause a rollback of all active transactions and stop the server. by default postgres will wait for all active connections to complete before exiting. 
3. the default grace period of Kubernetes for pod shutdown is 30 seconds, and after that, it sends SIGKILL to the process. If there are long-running pending queries, this can lead to WAL corruption 


### Issues: Fixed #xxx / Gap #xxx
1.  https://bugzilla.redhat.com/show_bug.cgi?id=2165907 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
