### PR TITLE
Fix the label-based IBM cluster region lookup

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1089,8 +1089,11 @@ func IsIBMPlatform() bool {
 // GetIBMRegion returns the cluster's region in IBM Cloud
 func GetIBMRegion() (string, error) {
 	nodesList := &corev1.NodeList{}
-	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
-		return "", fmt.Errorf("failed to list kubernetes nodes")
+	if ok := KubeList(nodesList, client.HasLabels{ibmRegion}); !ok {
+		return "", fmt.Errorf("failed to list Kubernetes nodes with the IBM region label")
+	}
+	if len(nodesList.Items) == 0 {
+		return "", fmt.Errorf("no Kubernetes nodes with the IBM region label found")
 	}
 	labels := nodesList.Items[0].GetLabels()
 	region := labels[ibmRegion]


### PR DESCRIPTION
### Explain the changes
1. `GetIBMRegion` used to look for the IBM region label in _any_ node, despite the fact [the label is only applied to worker nodes](https://cloud.ibm.com/docs/containers?topic=containers-storage_cos_install). The changes now specifically look for nodes that contain the relevant label

The problem was encountered when QE tried to install ODF over OCP over IBM which has led to [2255557](https://bugzilla.redhat.com/show_bug.cgi?id=2255557). 
The NooBaa logs point to `dial tcp: lookup s3.direct..cloud-object-storage.appdomain.cloud: no such host` - which makes sense, since there are two dots between `direct` and `clod-object-storage` - where `region` is supposed to reside. `region` is kept empty, which then leads to a failure to create the default backing store, which in turn prevents the product from starting up properly.

### Issues: Fixed #xxx / Gap #xxx
N/A

### Testing Instructions:
1. Install MCG on an IBM cluster successfully

