### PR TITLE
[backport to 5.15] Fix the label-based IBM cluster region lookup (#1279)

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1089,8 +1089,11 @@ func IsIBMPlatform() bool {
 // GetIBMRegion returns the cluster's region in IBM Cloud
 func GetIBMRegion() (string, error) {
 	nodesList := &corev1.NodeList{}
-	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
-		return "", fmt.Errorf("failed to list kubernetes nodes")
+	if ok := KubeList(nodesList, client.HasLabels{ibmRegion}); !ok {
+		return "", fmt.Errorf("failed to list Kubernetes nodes with the IBM region label")
+	}
+	if len(nodesList.Items) == 0 {
+		return "", fmt.Errorf("no Kubernetes nodes with the IBM region label found")
 	}
 	labels := nodesList.Items[0].GetLabels()
 	region := labels[ibmRegion]


### PR DESCRIPTION
Signed-off-by: Ben <belimele@redhat.com>
(cherry picked from commit e59f5e872e6ec08d5a36b26b359c3975dc9f36a1)

### Explain the changes
1. backported PR #1279 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
