### PR TITLE
Fix the CLI upgrade option by adding a missing namespace field to the system's YAML

### DIFF
--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -445,6 +445,7 @@ func RunUpgrade(cmd *cobra.Command, args []string) {
 	if options.NooBaaImage != "" {
 		image := options.NooBaaImage
 		sys.Spec.Image = &image
+		sys.Namespace = options.Namespace
 	}
 	util.KubeApply(sys)
 }


### PR DESCRIPTION
Up until now, trying to run `nb upgrade` would lead to a panic due to a missing `namespace` field in the `System apply` stage -
```
INFO[0000] ✅ Updated: Deployment "noobaa-operator"      
INFO[0000] 
System apply:                               
PANI[0000] ☠️  Panic Attack: [] an empty namespace may not be set when a resource name is provided 
panic: (*logrus.Entry) 0xc0004dabd0

goroutine 1 [running]:
github.com/sirupsen/logrus.(*Entry).log(0xc0009a6070, 0x0, {0xc00107a5a0, 0x5b})
        /home/atlas/repos/noobaa-operator/vendor/github.com/sirupsen/logrus/entry.go:260 +0x491
github.com/sirupsen/logrus.(*Entry).Log(0xc0009a6070, 0x0, {0xc000fd1970?, 0x2?, 0x2?})
        /home/atlas/repos/noobaa-operator/vendor/github.com/sirupsen/logrus/entry.go:304 +0x48
github.com/sirupsen/logrus.(*Entry).Logf(0xc0009a6070, 0x0, {0x26b20c7?, 0xc00053c120?}, {0xc000fd19d0?, 0xc000fd19f0?, 0xcd149d?})
        /home/atlas/repos/noobaa-operator/vendor/github.com/sirupsen/logrus/entry.go:349 +0x7c
github.com/sirupsen/logrus.(*Entry).Panicf(...)
        /home/atlas/repos/noobaa-operator/vendor/github.com/sirupsen/logrus/entry.go:387
github.com/noobaa/noobaa-operator/v5/pkg/util.Panic({0x2d0e940, 0xc000c048c0})
        /home/atlas/repos/noobaa-operator/pkg/util/util.go:789 +0xae
github.com/noobaa/noobaa-operator/v5/pkg/util.KubeApply({0x2d52630, 0xc0007f2a80})
        /home/atlas/repos/noobaa-operator/pkg/util/util.go:300 +0x485
github.com/noobaa/noobaa-operator/v5/pkg/system.RunUpgrade(0xc0009a6070?, {0x4?, 0x2688eae?, 0x0?})
        /home/atlas/repos/noobaa-operator/pkg/system/system.go:449 +0xa8
github.com/noobaa/noobaa-operator/v5/pkg/install.RunUpgrade(0xc000764d00?, {0x41ad940, 0x0, 0x0})
        /home/atlas/repos/noobaa-operator/pkg/install/install.go:132 +0x185
github.com/spf13/cobra.(*Command).execute(0xc000257800, {0x41ad940, 0x0, 0x0})
        /home/atlas/repos/noobaa-operator/vendor/github.com/spf13/cobra/command.go:987 +0xaa3
github.com/spf13/cobra.(*Command).ExecuteC(0xc000256900)
        /home/atlas/repos/noobaa-operator/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/atlas/repos/noobaa-operator/vendor/github.com/spf13/cobra/command.go:1039
github.com/noobaa/noobaa-operator/v5/pkg/cli.Run()
        /home/atlas/repos/noobaa-operator/pkg/cli/cli.go:61 +0x18
main.main()
        /home/atlas/repos/noobaa-operator/cmd/manager/main.go:14 +0xf
```


### Explain the changes
1. Add the missing `namespace` field

### Testing Instructions:
1. Run `nb upgrade`