### PR TITLE
Fix - don't run db 15 upgrade for mongoDB

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -134,8 +134,10 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 			return err
 		}
 
-		if err := r.UpgradePostgresDB(); err != nil {
-			return err
+		if r.NooBaa.Spec.DBType == "postgres" {
+			if err := r.UpgradePostgresDB(); err != nil {
+				return err
+			}
 		}
 
 		if err := r.ReconcileDB(); err != nil {


### PR DESCRIPTION
### Explain the changes
1. in case of MongoDB we still ran the upgrade process for Postgres - we shouldn't 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
