### PR TITLE
[Backport into 5.15] backporting some bug fixes

### DIFF
--- a/doc/psql15-upgrade.md
+++ b/doc/psql15-upgrade.md
@@ -1,0 +1,46 @@
+[NooBaa Operator](../README.md) /
+# Postgresql 15 automatic upgrade
+
+As part of ODF ver. 15, NooBaa operator will run an automatic upgrade in order to update the DB data to work with this new version.
+
+## The auto-upgrade state machine
+
+![](https://github.com/noobaa/noobaa-operator/assets/20266280/dd12ab01-0a2d-42c7-8048-a3a0c5e5a80e)
+
+#
+### Those are the different steps running during the upgrade: 
+
+## Prepare
+Will start the upgrade procedure and will add a 2nd init container running [dumpdb.sh](../deploy/internal/configmap-postgres-initdb.yaml#L42) that will dump the old data.
+
+in case of the DB pod using more than 33% of the attached PV space - this step will intentionelly fail and move to revert. 
+
+## Upgrade
+Will change the running version from 12 to 15 and add a 2nd init container running [upgradedb.sh](../deploy/internal/configmap-postgres-initdb.yaml#L58) - this one will save the 12 data to a backup and will run the db_dump on the new 15 DB.
+
+in case of the DB pod using more than 33% of the attached PV space - this step will intentionelly fail and move to revert.
+
+## Clean
+Will remove the init container and will start a new db pod running version 15 with the new data.
+
+## Revert
+In case of a failure in any of the above steps, will start the revert procedure and will add a 2nd init container running [revertdb.sh](../deploy/internal/configmap-postgres-initdb.yaml#L80) that will copy the old data over the new and will start the OLD DB.
+
+## Failed
+After revert has finished - will stop reconciling the new DB and will keep running the old pgsql version 12. 
+
+It will wait until new annotation will be added to NooBaa CR:
+### retry_upgrade
+Will be used in case of expending the attached PV so that it will be using less than 33% -  will restart the upgrade procedure from Prepare.
+```bash
+kubectl annotate noobaa noobaa retry_upgrade=true
+```
+### manual_upgrade_completed
+Will be used after running a manual upgrade and will set the upgrade to finished.
+```bash
+kubectl annotate noobaa noobaa manual_upgrade_completed=true
+```
+
+## Finished
+DB upgrade has successfully finished and will never run again.
+

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -1059,16 +1059,15 @@ func RunReconcile(cmd *cobra.Command, args []string) {
 	}))
 }
 
-// MapSecretToBackingStores returns a list of backingstores that uses the secret in their secretRefernce
-// used by backingstore_contorller to watch secrets changes
+// MapSecretToBackingStores returns a list of backingstores that uses the secret in their secretReference
+// used by backingstore_controller to watch secrets changes
 func MapSecretToBackingStores(secret types.NamespacedName) []reconcile.Request {
 	log := util.Logger()
-	log.Infof("checking which backingstore to reconcile. mapping secret %v to backingstores", secret)
 	bsList := &nbv1.BackingStoreList{
 		TypeMeta: metav1.TypeMeta{Kind: "BackingStoreList"},
 	}
 	if !util.KubeList(bsList, &client.ListOptions{Namespace: secret.Namespace}) {
-		log.Infof("Cloud not found backingStores in namespace %q, while trying to find Backingstore that uses %s secrte", secret.Namespace, secret.Name)
+		log.Infof("Could not found backingStores in namespace %q, while trying to find Backingstore that uses %s secret", secret.Namespace, secret.Name)
 		return nil
 	}
 
@@ -1088,21 +1087,19 @@ func MapSecretToBackingStores(secret types.NamespacedName) []reconcile.Request {
 			})
 		}
 	}
-	log.Infof("will reconcile these backingstores: %v", reqs)
 
 	return reqs
 }
 
 // MapNoobaaToBackingStores returns a list of backingstores that are inside Noobaa system
-// used by backingstore_contorller to watch Noobaa CR changes
+// used by backingstore_controller to watch Noobaa CR changes
 func MapNoobaaToBackingStores(noobaa types.NamespacedName) []reconcile.Request {
 	log := util.Logger()
-	log.Infof("checking which backingstore to reconcile. mapping Noobaa %v to backingstores", noobaa)
 	bsList := &nbv1.BackingStoreList{
 		TypeMeta: metav1.TypeMeta{Kind: "BackingStoreList"},
 	}
 	if !util.KubeList(bsList, &client.ListOptions{Namespace: noobaa.Namespace}) {
-		log.Infof("Cloud not found backingStores in namespace %q, while trying to find Backingstore that inside %s Noobaa system", noobaa.Namespace, noobaa.Name)
+		log.Infof("Could not found backingStores in namespace %q, while trying to find Backingstore that inside %s Noobaa system", noobaa.Namespace, noobaa.Name)
 		return nil
 	}
 
@@ -1116,7 +1113,6 @@ func MapNoobaaToBackingStores(noobaa types.NamespacedName) []reconcile.Request {
 			},
 		})
 	}
-	log.Infof("will reconcile all backingstores: %v", reqs)
 
 	return reqs
 }

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -21,7 +21,6 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/sirupsen/logrus"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -173,16 +172,6 @@ func (r *Reconciler) Reconcile() (reconcile.Result, error) {
 	if util.EnsureCommonMetaFields(r.BackingStore, nbv1.Finalizer) {
 		if !util.KubeUpdate(r.BackingStore) {
 			err := fmt.Errorf("❌ BackingStore %q failed to add mandatory meta fields", r.BackingStore.Name)
-			return r.completeReconcile(err)
-		}
-	}
-
-	oldStatefulSet := &appsv1.StatefulSet{}
-	oldStatefulSet.Name = fmt.Sprintf("%s-%s-noobaa", r.BackingStore.Name, options.SystemName)
-	oldStatefulSet.Namespace = r.Request.Namespace
-
-	if util.KubeCheck(oldStatefulSet) {
-		if err := r.upgradeBackingStore(oldStatefulSet); err != nil {
 			return r.completeReconcile(err)
 		}
 	}
@@ -1348,51 +1337,6 @@ func (r *Reconciler) deletePvPool() error {
 	util.KubeList(podsList, client.InNamespace(options.Namespace), client.MatchingLabels{"pool": r.BackingStore.Name})
 	util.KubeDeleteAllOf(&corev1.Pod{}, client.InNamespace(options.Namespace), client.MatchingLabels{"pool": r.BackingStore.Name})
 	util.KubeDeleteAllOf(&corev1.PersistentVolumeClaim{}, client.InNamespace(options.Namespace), client.MatchingLabels{"pool": r.BackingStore.Name})
-	return nil
-}
-
-func (r *Reconciler) upgradeBackingStore(sts *appsv1.StatefulSet) error {
-	r.Logger.Infof("Deleting old statefulset: %s", sts.Name)
-	envVar := util.GetEnvVariable(&sts.Spec.Template.Spec.Containers[0].Env, "AGENT_CONFIG")
-	if envVar == nil {
-		return util.NewPersistentError("NoAgentConfig", "Old BackingStore stateful set not having agent config")
-	}
-	agentConfig := envVar.Value
-	replicas := sts.Spec.Replicas
-	stsName := sts.Name
-	util.KubeDelete(sts, client.PropagationPolicy("Orphan")) // delete STS leave pods behind
-	o := util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml)
-	secret := o.(*corev1.Secret)
-	secret.Name = fmt.Sprintf("backing-store-%s-%s", nbv1.StoreTypePVPool, r.BackingStore.Name)
-	secret.Namespace = options.Namespace
-	util.KubeCheck(secret)
-	secret.StringData["AGENT_CONFIG"] = agentConfig // update secret for future pods
-	util.KubeUpdate(secret)
-	for i := 0; i < int(*replicas); i++ {
-		pod := &corev1.Pod{}
-		pod.Name = fmt.Sprintf("%s-%d", stsName, i)
-		pod.Namespace = r.BackingStore.Namespace
-		if util.KubeCheck(pod) {
-			pod.Spec.Containers[0].Image = r.NooBaa.Status.ActualImage
-			if r.NooBaa.Spec.ImagePullSecret == nil {
-				pod.Spec.ImagePullSecrets =
-					[]corev1.LocalObjectReference{}
-			} else {
-				pod.Spec.ImagePullSecrets =
-					[]corev1.LocalObjectReference{*r.NooBaa.Spec.ImagePullSecret}
-			}
-			pod.Labels = map[string]string{"pool": r.BackingStore.Name}
-			r.Own(pod)
-			util.KubeUpdate(pod)
-			pvc := &corev1.PersistentVolumeClaim{}
-			pvc.Name = fmt.Sprintf("noobaastorage-%s", pod.Name)
-			pvc.Namespace = pod.Namespace
-			util.KubeCheck(pvc)
-			pvc.Labels = map[string]string{"pool": r.BackingStore.Name}
-			r.Own(pvc)
-			util.KubeUpdate(pvc)
-		}
-	}
 	return nil
 }
 

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -134,8 +134,10 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 			return err
 		}
 
-		if err := r.UpgradePostgresDB(); err != nil {
-			return err
+		if r.NooBaa.Spec.DBType == "postgres" {
+			if err := r.UpgradePostgresDB(); err != nil {
+				return err
+			}
 		}
 
 		if err := r.ReconcileDB(); err != nil {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -445,6 +445,7 @@ func RunUpgrade(cmd *cobra.Command, args []string) {
 	if options.NooBaaImage != "" {
 		image := options.NooBaaImage
 		sys.Spec.Image = &image
+		sys.Namespace = options.Namespace
 	}
 	util.KubeApply(sys)
 }


### PR DESCRIPTION
### Explain the changes
1. Adding document on pgsql upgrade procedure
2. Fix the CLI upgrade option by adding a missing namespace field to the system's YAML (#1285)
3. fix - don't run db 15 upgrade for mongoDB
4. Remove upgradeBackingStore

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2255586
2. Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2258681


