### PR TITLE
CI | Update Checkout and Setup-Go Version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -16,10 +16,10 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set branch
         run: echo "BRANCH=${{ github.event.inputs.base_branch }}" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH }}
       - name: Fetch all tags

--- a/.github/workflows/run_admission_test.yml
+++ b/.github/workflows/run_admission_test.yml
@@ -10,13 +10,13 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout noobaa-operator
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "noobaa/noobaa-operator"
           path: "noobaa-operator"
 
       - name: Setup Go on runner
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-go@v2 # Could not change to version 3, see issue:
         # https://github.com/noobaa/noobaa-operator/issues/1031
         with:
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-go@v2
         with:
           go-version: "1.20"
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-go@v2
         with:
           go-version: "1.20"

--- a/.github/workflows/run_cosi_test.yaml
+++ b/.github/workflows/run_cosi_test.yaml
@@ -12,13 +12,13 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout noobaa-operator
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "noobaa/noobaa-operator"
           path: "noobaa-operator"
 
       - name: Setup Go on runner
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/run_hac_test.yml
+++ b/.github/workflows/run_hac_test.yml
@@ -10,8 +10,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/run_kms_dev_test.yml
+++ b/.github/workflows/run_kms_dev_test.yml
@@ -10,8 +10,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/run_kms_ibm_kp_test.yml
+++ b/.github/workflows/run_kms_ibm_kp_test.yml
@@ -13,8 +13,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/run_kms_kmip_test.yml
+++ b/.github/workflows/run_kms_kmip_test.yml
@@ -10,8 +10,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/run_kms_rotate_test.yml
+++ b/.github/workflows/run_kms_rotate_test.yml
@@ -10,8 +10,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/run_kms_tls_sa_test.yml
+++ b/.github/workflows/run_kms_tls_sa_test.yml
@@ -10,8 +10,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/run_kms_tls_token_test.yml
+++ b/.github/workflows/run_kms_tls_token_test.yml
@@ -10,8 +10,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,8 +10,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 


### PR DESCRIPTION
### Explain the changes
1. Update the checkout and setup-go version from 3 to 4.

### Issues: Fixed #xxx / Gap #xxx
1. Currently we have a warning in our CI:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-go@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

### Testing Instructions:
1. none, will be tested in the CI.


- [ ] Doc added/updated
- [ ] Tests added
