### PR TITLE
fixing error for collation external PG

### DIFF
--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -252,7 +252,7 @@ func (r *Reconciler) checkExternalPg(postgresDbURL string) error {
 	if collation != "C" {
 		return util.NewPersistentError("InvalidExternalPgCollation",
 			fmt.Sprintf("collation of external DB url: %q, is not supported: %s",
-				dbURL, err))
+				dbURL, collation))
 	}
 	return nil
 }


### PR DESCRIPTION
### Explain the changes
1. we are printing: `collation of external DB url: "BLA", is not supported: %!s(<nil>)`. we will now print with the correct collation.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
