### PR TITLE
use injected root CAs also when for  AWS and IBM

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -870,6 +870,10 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 				*result.Credentials.SecretAccessKey,
 				*result.Credentials.SessionToken,
 			),
+			HTTPClient: &http.Client{
+				Transport: util.SecureHTTPTransport,
+				Timeout:   10 * time.Second,
+			},
 			Region: &region,
 		}
 	} else { // handle AWS long-lived credentials (not STS)
@@ -879,6 +883,10 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 				cloudCredsSecret.StringData["aws_secret_access_key"],
 				"",
 			),
+			HTTPClient: &http.Client{
+				Transport: util.SecureHTTPTransport,
+				Timeout:   10 * time.Second,
+			},
 			Region: &region,
 		}
 	}
@@ -1125,6 +1133,10 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 			secretAccessKey,
 			"",
 		),
+		HTTPClient: &http.Client{
+			Transport: util.SecureHTTPTransport,
+			Timeout:   10 * time.Second,
+		},
 		Region: &location,
 	}
 	if err := r.createS3BucketForBackingStore(s3Config, bucketName); err != nil {


### PR DESCRIPTION
### Explain the changes
1. When creating a backingstore bucket in AWS and IBM, we did not use the injected root CAs.
2. in some cases, if the root ca is not present by default, the bucket creation fails.
3. added the injected CAs also when accessing AWS and IBM and not only for Ceph.


### Issues: Fixed #xxx / Gap #xxx
1.  https://bugzilla.redhat.com/show_bug.cgi?id=2262252 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
