### PR TITLE
[Backport to 5.15] use injected root CAs also when for  AWS and IBM

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -861,6 +861,10 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 				*result.Credentials.SecretAccessKey,
 				*result.Credentials.SessionToken,
 			),
+			HTTPClient: &http.Client{
+				Transport: util.SecureHTTPTransport,
+				Timeout:   10 * time.Second,
+			},
 			Region: &region,
 		}
 	} else { // handle AWS long-lived credentials (not STS)
@@ -870,6 +874,10 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 				cloudCredsSecret.StringData["aws_secret_access_key"],
 				"",
 			),
+			HTTPClient: &http.Client{
+				Transport: util.SecureHTTPTransport,
+				Timeout:   10 * time.Second,
+			},
 			Region: &region,
 		}
 	}
@@ -1116,6 +1124,10 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 			secretAccessKey,
 			"",
 		),
+		HTTPClient: &http.Client{
+			Transport: util.SecureHTTPTransport,
+			Timeout:   10 * time.Second,
+		},
 		Region: &location,
 	}
 	if err := r.createS3BucketForBackingStore(s3Config, bucketName); err != nil {


### PR DESCRIPTION
When creating a backingstore bucket in AWS and IBM, we did not use the injected root CAs.

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit a5ddaccce0947c52e1a20e6b332dfb3e3ae21eb5)

### Explain the changes
1. Backported https://github.com/noobaa/noobaa-operator/pull/1299 

### Issues: Fixed #xxx / Gap #xxx
1.  https://bugzilla.redhat.com/show_bug.cgi?id=2262252

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
