### PR TITLE
Utilize the refreshing global CA bundle for the Azure and Google clients

### DIFF
--- a/pkg/system/azure_utils.go
+++ b/pkg/system/azure_utils.go
@@ -3,7 +3,9 @@ package system
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -11,12 +13,30 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 )
 
 func (r *Reconciler) getStorageAccountsClient() storage.AccountsClient {
 	storageAccountsClient := storage.NewAccountsClient(r.AzureContainerCreds.StringData["azure_subscription_id"])
 	auth, _ := r.GetResourceManagementAuthorizer()
 	storageAccountsClient.Authorizer = auth
+	// Inject the global refreshing CA pool into the one used by the Azure client
+	var httpClient = &http.Client{
+		Transport: util.GlobalCARefreshingTransport,
+		Timeout:   10 * time.Second,
+	}
+	underlyingHTTPClient, ok := storageAccountsClient.Sender.(*http.Client)
+	if !ok {
+		log.Fatalf("failed to cast underlyingHTTPClient to *http.Client")
+	}
+	underlyingHTTPClient.Transport = httpClient.Transport
+	underlyingTransport, ok := underlyingHTTPClient.Transport.(*http.Transport)
+	if !ok {
+		log.Fatalf("failed to cast underlyingTransport to *http.Transport")
+	}
+	underlyingTransport.TLSClientConfig.RootCAs = util.GlobalCARefreshingTransport.TLSClientConfig.RootCAs
+
 	err := storageAccountsClient.AddToUserAgent("Go-http-client/1.1")
 	if err != nil {
 		log.Fatalf("got error on storageAccountsClient.AddToUserAgent %v", err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -112,8 +112,8 @@ var (
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
-	// SecureHTTPTransport is a global secure http transport
-	SecureHTTPTransport = &http.Transport{
+	// GlobalCARefreshingTransport is a global secure http transport
+	GlobalCARefreshingTransport = &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
 	}
 
@@ -130,7 +130,7 @@ var (
 	}
 )
 
-// AddToRootCAs adds a local cert file to Our SecureHttpTransport
+// AddToRootCAs adds a local cert file to Our GlobalCARefreshingTransport
 func AddToRootCAs(localCertFile string) error {
 	rootCAs := x509.NewCertPool()
 
@@ -155,7 +155,7 @@ func AddToRootCAs(localCertFile string) error {
 		// Trust the augmented cert pool in our client
 		log.Infof("Successfuly appended %q to RootCAs", certFile)
 	}
-	SecureHTTPTransport.TLSClientConfig.RootCAs = rootCAs
+	GlobalCARefreshingTransport.TLSClientConfig.RootCAs = rootCAs
 	return nil
 }
 


### PR DESCRIPTION
### Explain the changes
1. The default HTTPClient provided by Go seems to not pick up some of the certs that are collected as part of `AddToRootCAs` - this PR adds the missing CA bundles to the Azure and Google clients that are created as part of the phase 4 of the system
2. The global CA variable was renamed to emphasize its difference and importance over the default bundle

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2265051

### Testing Instructions:
1. Deploy an Azure/GCP OCP+ODF cluster with the IPI FIPS ENCRYPTION preset
3. Verify that the storagecluster reaches a Ready state, as well as NooBaa's default backingstore
