### PR TITLE
[5.15 BACKPORT] Utilize the refreshing global CA bundle for the Azure and Google clients

### DIFF
--- a/pkg/system/azure_utils.go
+++ b/pkg/system/azure_utils.go
@@ -3,7 +3,9 @@ package system
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -11,12 +13,30 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 )
 
 func (r *Reconciler) getStorageAccountsClient() storage.AccountsClient {
 	storageAccountsClient := storage.NewAccountsClient(r.AzureContainerCreds.StringData["azure_subscription_id"])
 	auth, _ := r.GetResourceManagementAuthorizer()
 	storageAccountsClient.Authorizer = auth
+	// Inject the global refreshing CA pool into the one used by the Azure client
+	var httpClient = &http.Client{
+		Transport: util.GlobalCARefreshingTransport,
+		Timeout:   10 * time.Second,
+	}
+	underlyingHTTPClient, ok := storageAccountsClient.Sender.(*http.Client)
+	if !ok {
+		log.Fatalf("failed to cast underlyingHTTPClient to *http.Client")
+	}
+	underlyingHTTPClient.Transport = httpClient.Transport
+	underlyingTransport, ok := underlyingHTTPClient.Transport.(*http.Transport)
+	if !ok {
+		log.Fatalf("failed to cast underlyingTransport to *http.Transport")
+	}
+	underlyingTransport.TLSClientConfig.RootCAs = util.GlobalCARefreshingTransport.TLSClientConfig.RootCAs
+
 	err := storageAccountsClient.AddToUserAgent("Go-http-client/1.1")
 	if err != nil {
 		log.Fatalf("got error on storageAccountsClient.AddToUserAgent %v", err)

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -862,7 +863,7 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 				*result.Credentials.SessionToken,
 			),
 			HTTPClient: &http.Client{
-				Transport: util.SecureHTTPTransport,
+				Transport: util.GlobalCARefreshingTransport,
 				Timeout:   10 * time.Second,
 			},
 			Region: &region,
@@ -875,7 +876,7 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 				"",
 			),
 			HTTPClient: &http.Client{
-				Transport: util.SecureHTTPTransport,
+				Transport: util.GlobalCARefreshingTransport,
 				Timeout:   10 * time.Second,
 			},
 			Region: &region,
@@ -1021,7 +1022,30 @@ func (r *Reconciler) prepareGCPBackingStore() error {
 	}
 	r.GCPBucketCreds.StringData["GoogleServiceAccountPrivateKeyJson"] = cloudCredsSecret.StringData["service_account.json"]
 	ctx := context.Background()
-	gcpclient, err := storage.NewClient(ctx, option.WithCredentialsJSON([]byte(cloudCredsSecret.StringData["service_account.json"])))
+	// Inject the global refreshing CA pool into the one used by the Google client
+	parsedGoogleCredsOption := option.WithCredentialsJSON([]byte(cloudCredsSecret.StringData["service_account.json"]))
+	tempgcpclient, err := storage.NewClient(ctx, parsedGoogleCredsOption)
+	if err != nil {
+		r.Logger.Info(err)
+		return err
+	}
+	// Read gcpclient's internal HTTPClient via reflection since it is private
+	tempclientInternalHTTPClient := reflect.ValueOf(tempgcpclient).Elem().FieldByName("hc")
+	castTempclientInternalHTTPClient, ok := tempclientInternalHTTPClient.Interface().(*http.Client)
+	if !ok {
+		r.Logger.Errorf("failed to cast castTempclientInternalHTTPClient to *http.Client")
+		return fmt.Errorf("failed to cast castTempclientInternalHTTPClient to *http.Client")
+	}
+	tempClient := &http.Client{
+		Transport: castTempclientInternalHTTPClient.Transport,
+	}
+	tempTransport, ok := tempClient.Transport.(*http.Transport)
+	if !ok {
+		r.Logger.Errorf("failed to cast tempTransport to *http.Transport")
+		return fmt.Errorf("failed to cast tempTransport to *http.Transport")
+	}
+	tempTransport.TLSClientConfig.RootCAs = util.GlobalCARefreshingTransport.TLSClientConfig.RootCAs
+	gcpclient, err := storage.NewClient(ctx, option.WithHTTPClient(tempClient), parsedGoogleCredsOption)
 	if err != nil {
 		r.Logger.Info(err)
 		return err
@@ -1125,7 +1149,7 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 			"",
 		),
 		HTTPClient: &http.Client{
-			Transport: util.SecureHTTPTransport,
+			Transport: util.GlobalCARefreshingTransport,
 			Timeout:   10 * time.Second,
 		},
 		Region: &location,
@@ -1209,7 +1233,7 @@ func (r *Reconciler) prepareCephBackingStore() error {
 		Timeout:   10 * time.Second,
 	}
 	if r.ApplyCAsToPods != "" {
-		client.Transport = util.SecureHTTPTransport
+		client.Transport = util.GlobalCARefreshingTransport
 	}
 
 	s3Config := &aws.Config{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -112,8 +112,8 @@ var (
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
-	// SecureHTTPTransport is a global secure http transport
-	SecureHTTPTransport = &http.Transport{
+	// GlobalCARefreshingTransport is a global secure http transport
+	GlobalCARefreshingTransport = &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
 	}
 
@@ -130,7 +130,7 @@ var (
 	}
 )
 
-// AddToRootCAs adds a local cert file to Our SecureHttpTransport
+// AddToRootCAs adds a local cert file to Our GlobalCARefreshingTransport
 func AddToRootCAs(localCertFile string) error {
 	rootCAs := x509.NewCertPool()
 
@@ -155,7 +155,7 @@ func AddToRootCAs(localCertFile string) error {
 		// Trust the augmented cert pool in our client
 		log.Infof("Successfuly appended %q to RootCAs", certFile)
 	}
-	SecureHTTPTransport.TLSClientConfig.RootCAs = rootCAs
+	GlobalCARefreshingTransport.TLSClientConfig.RootCAs = rootCAs
 	return nil
 }
 


### PR DESCRIPTION
### Explain the changes
1. Backported #1304 

