### PR TITLE
Update AWS Regions with New Region

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1114,6 +1114,7 @@ func GetAWSRegion() (string, error) {
 		"us-west-1":      "us-west-1",
 		"us-west-2":      "us-west-2",
 		"ca-central-1":   "ca-central-1",
+		"ca-west-1":      "ca-west-1",
 		"eu-central-1":   "eu-central-1",
 		"eu-central-2":   "eu-central-2",
 		"eu-west-1":      "eu-west-1",


### PR DESCRIPTION
### Explain the changes
1. Update AWS regions with `ca-west-1` (see [here](https://aws.amazon.com/blogs/aws/the-aws-canada-west-calgary-region-is-now-available/
)).

### Issues: Fixed [BZ 2266629](https://bugzilla.redhat.com/show_bug.cgi?id=2266629)
1. Currently we don't have the region `ca-west-1` that was added lately.

### Testing Instructions:
1. none.

- [ ] Doc added/updated
- [ ] Tests added



### Issues: Fixed [BZ 2266629](https://bugzilla.redhat.com/show_bug.cgi?id=2266629)
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
