### PR TITLE
Fix replication policy deletion

### DIFF
--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -701,16 +701,17 @@ func (r *BucketRequest) putBucketTagging() error {
 func PrepareReplicationParams(bucketName string, replicationPolicy string, update bool) (*nb.BucketReplicationParams, *nb.DeleteBucketReplicationParams, error) {
 
 	var replicationRules nb.ReplicationPolicy
+
+	if replicationPolicy == "" && update {
+		deleteReplicationParams := &nb.DeleteBucketReplicationParams{
+			Name: bucketName,
+		}
+		return nil, deleteReplicationParams, nil
+	}
+
 	err := json.Unmarshal([]byte(replicationPolicy), &replicationRules)
 	if err != nil {
 		return nil, nil, fmt.Errorf("PrepareReplicationParams: Failed to parse replication json %q: %v", replicationRules, err)
-	}
-	deleteReplicationParams := &nb.DeleteBucketReplicationParams{
-		Name: bucketName,
-	}
-
-	if replicationPolicy == "" && update {
-		return nil, deleteReplicationParams, nil
 	}
 
 	replicationParams := &nb.BucketReplicationParams{


### PR DESCRIPTION
### Explain the changes
1. Fixed a replication policy deletion bug that'd occur since the function would panic when trying to unmarshal an empty string

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2266805

### Testing Instructions:
1. Apply a replication policy to a bucket
2. Verify objects are being replicated
3. Delete the policy by editing the value of `replicationPolicy` to be `""`
4. Verify objects aren't replicated anymore

- [ ] Doc added/updated
- [ ] Tests added
