### PR TITLE
Adding disable_cookies annotation to S3 route

### DIFF
--- a/deploy/internal/route-s3.yaml
+++ b/deploy/internal/route-s3.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/disable_cookies: 'true'
   labels:
     app: noobaa
   name: s3

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4666,11 +4666,13 @@ spec:
   wildcardPolicy: None
 `
 
-const Sha256_deploy_internal_route_s3_yaml = "16050267fd5cb0a34ff7b4d849a601d2583da1a11394a94f38c4f066c1613f34"
+const Sha256_deploy_internal_route_s3_yaml = "51a2eeee88436d97847f2911a4d05077885dd94bc69c537ad67417bc823a8e20"
 
 const File_deploy_internal_route_s3_yaml = `apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/disable_cookies: 'true'
   labels:
     app: noobaa
   name: s3


### PR DESCRIPTION
### Explain the changes
1. Disable the cookies when using s3 routes as some s3 clients like Cyberduck don't handle them correctly. 

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #1327

### Testing Instructions:
1. install a noobaa system on top of OCP cluster
2. try to connect to the system with default access keys using Cyberduck
3. see that you can connect and list the buckets and not get issues about bad signature

- [ ] Doc added/updated
- [ ] Tests added
