### PR TITLE
Fixing reconcile for mounted root-key secret noobaa-root-master-key-volume

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -1028,10 +1028,12 @@ func (r *Reconciler) keyRotate() error {
 // ReconcileSecretMap sets the root master key for rotating key / map
 func (r *Reconciler) ReconcileSecretMap(data map[string]string) error {
 	if data == nil {
-		return fmt.Errorf("System Reconciler ReconcileSecretMap data is nil")
+		return fmt.Errorf("system Reconciler ReconcileSecretMap data is nil")
 	}
-	r.SecretRootMasterMap.StringData = data
-	if err := r.ReconcileObject(r.SecretRootMasterMap, nil); err != nil {
+	if err := r.ReconcileObject(r.SecretRootMasterMap, func() error {
+		r.SecretRootMasterMap.StringData = data
+		return nil
+	}); err != nil {
 		return err
 	}
 	return nil
@@ -1040,7 +1042,7 @@ func (r *Reconciler) ReconcileSecretMap(data map[string]string) error {
 // ReconcileSecretString sets the root master key for single string secret
 func (r *Reconciler) ReconcileSecretString(data string) error {
 	if len(data) == 0 {
-		return fmt.Errorf("System Reconciler ReconcileSecreString data len is zero")
+		return fmt.Errorf("system Reconciler ReconcileSecretString data len is zero")
 	}
 	r.SecretRootMasterKey = data
 	return nil


### PR DESCRIPTION
### Explain the changes
1. When the secret had already been created, our internal secret which was used as a mount to our pods, was failing to be updated. Changing the reconcile function to apply the updated data to the secret fix this issue.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
