### PR TITLE
Fixing AzureClientCertPath in kms for azure

### DIFF
--- a/pkg/util/kms/kms_azure.go
+++ b/pkg/util/kms/kms_azure.go
@@ -12,11 +12,10 @@ import (
 
 // Azure authentication config options
 const (
-	AzureVaultURL       = "AZURE_VAULT_URL"
-	AzureVaultClientID  = "AZURE_CLIENT_ID"
-	AzureVaultTenantID  = "AZURE_TENANT_ID"
-	ServiceName         = "KMS_SERVICE_NAME"
-	AzureClientCertPath = "AZURE_CERT_SECRET_NAME"
+	AzureVaultURL             = "AZURE_VAULT_URL"
+	AzureVaultClientID        = "AZURE_CLIENT_ID"
+	AzureVaultTenantID        = "AZURE_TENANT_ID"
+	AzureClientCertSecretName = "AZURE_CERT_SECRET_NAME"
 )
 
 // AzureVault is a azure kms driver
@@ -59,9 +58,9 @@ func (v *AzureVault) Name() string {
 	return "rootkeyb64-" + v.UID
 }
 
-// Path return vault's kv secret id
+// Path returns azure vault's kv secret id
 func (v *AzureVault) Path() string {
-	return RootSecretPath + "/rootkeyb64-" + v.UID
+	return "/rootkeyb64-" + v.UID
 }
 
 // GetContext returns context used for secret get operation
@@ -91,16 +90,16 @@ func createCertTempFile(config map[string]interface{}, namespace string) error {
 	secret := &corev1.Secret{}
 	secret.Namespace = namespace
 
-	if clientCertSecretName, ok := config[AzureClientCertPath]; ok {
+	if clientCertSecretName, ok := config[AzureClientCertSecretName]; ok {
 		secret.Name = clientCertSecretName.(string)
 		if !util.KubeCheckOptional(secret) {
 			return fmt.Errorf(`❌ Could not find secret %q in namespace %q`, secret.Name, secret.Namespace)
 		}
-		clientCertFileAddr, err := writeCrtsToFile(secret.Name, namespace, secret.Data["cert"], AzureClientCertPath)
+		clientCertFileAddr, err := writeCrtsToFile(secret.Name, namespace, secret.Data["CLIENT_CERT"], AzureClientCertSecretName)
 		if err != nil {
-			return fmt.Errorf("can not write crt %v to file %v", AzureClientCertPath, err)
+			return fmt.Errorf("can not write crt %v to file %v", AzureClientCertSecretName, err)
 		}
-		config[AzureClientCertPath] = clientCertFileAddr
+		config[azure.AzureClientCertPath] = clientCertFileAddr
 	}
 
 	return nil

--- a/pkg/util/kms/test/azure-vault/kms_azure_vault_test.go
+++ b/pkg/util/kms/test/azure-vault/kms_azure_vault_test.go
@@ -26,12 +26,11 @@ func getMiniNooBaa() *nbv1.NooBaa {
 func azureKMSSpec(azureVaultURL string) nbv1.KeyManagementServiceSpec {
 	k := nbv1.KeyManagementServiceSpec{}
 	k.ConnectionDetails = map[string]string{
-		kms.AzureVaultURL:       azureVaultURL,
-		kms.Provider:            azure.Name,
-		kms.AzureVaultClientID:  "e08b2886-f826-4746-8673-47044661d1a1",
-		kms.AzureClientCertPath: "azure-ocs-ffwc9o1j",
-		kms.AzureVaultTenantID:  "9cf78105-e3e9-4321-b88d-b001b66c762b",
-		kms.ServiceName:         "kms-conn-azure1",
+		kms.AzureVaultURL:             azureVaultURL,
+		kms.Provider:                  azure.Name,
+		kms.AzureVaultClientID:        "e08b2886-f826-4746-8673-47044661d1a1",
+		kms.AzureClientCertSecretName: "azure-ocs-ffwc9o1j",
+		kms.AzureVaultTenantID:        "9cf78105-e3e9-4321-b88d-b001b66c762b",
 	}
 
 	return k


### PR DESCRIPTION
Fixing AzureClientCertPath in kms for azure

The azure kms is expecting the secret to be present
at key azure.AzureClientCertPath. We were storing the
secret with wrong key which which was stopping azure kms
to read the secret the from expected key.

This patch handles the correction

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2275049