### PR TITLE
Support to update credentials manually to an account

### DIFF
--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -64,6 +64,7 @@ type Client interface {
 	DeleteBucketReplicationAPI(DeleteBucketReplicationParams) error
 
 	GenerateAccountKeysAPI(GenerateAccountKeysParams) error
+	UpdateAccountKeysAPI(UpdateAccountKeysParams) error
 	ResetPasswordAPI(ResetPasswordParams) error
 }
 
@@ -435,6 +436,12 @@ func (c *RPCClient) DeleteBucketReplicationAPI(params DeleteBucketReplicationPar
 // GenerateAccountKeysAPI calls account_api.generate_account_keys()
 func (c *RPCClient) GenerateAccountKeysAPI(params GenerateAccountKeysParams) error {
 	req := &RPCMessage{API: "account_api", Method: "generate_account_keys", Params: params}
+	return c.Call(req, nil)
+}
+
+// UpdateAccountKeysAPI calls account_api.update_account_keys()
+func (c *RPCClient) UpdateAccountKeysAPI(params UpdateAccountKeysParams) error {
+	req := &RPCMessage{API: "account_api", Method: "update_account_keys", Params: params}
 	return c.Call(req, nil)
 }
 

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -427,6 +427,12 @@ type GenerateAccountKeysParams struct {
 	Email string `json:"email"`
 }
 
+// UpdateAccountKeysParams is the params of account_api.update_account_keys()
+type UpdateAccountKeysParams struct {
+	Email      string       `json:"email"`
+	AccessKeys S3AccessKeys `json:"access_keys"`
+}
+
 // ResetPasswordParams is the params of account_api.reset_password()
 type ResetPasswordParams struct {
 	Email                string       `json:"email"`

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20240314"
+	ContainerImageTag = "master-20240520"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -90,6 +90,12 @@ type ValidationError struct {
 	Msg string
 }
 
+// AccessKeyRegexp validates access keys, which are 20 characters long and may include alphanumeric characters
+var AccessKeyRegexp, _ = regexp.Compile(`^[a-zA-Z0-9]{20}$`)
+
+// SecretKeyRegexp validates secret keys, which are 40 characters long and may include alphanumeric characters '+' and '/'
+var SecretKeyRegexp, _ = regexp.Compile(`^[a-zA-Z0-9+/]{40}$`)
+
 // IsValidationError check if err is of type ValidationError
 func IsValidationError(err error) bool {
 	_, ok := err.(ValidationError)


### PR DESCRIPTION
### Explain the changes
1. Added a CLI command to manually update account credentials (access key and secret key). Users can provide the access key and secret key as flags, or they will be prompted to enter them if the flags are not specified.
For example: `noobaa account credentials --access-key=<access-key> --secret-key=<secret-key>`

Additionally, validation checks have been implemented for both keys to ensure the command succeeds only with valid credentials.

### Testing Instructions:
1. `make test-cli-flow`

- [X] Tests added
