### PR TITLE
Fix printing of Identity

### DIFF
--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -14,7 +14,7 @@ const (
 	maskString  = "****"
 )
 
-// MaskedString is a string type for sensitive string, masked when formated
+// MaskedString is a string type for sensitive string, masked when formatted
 type MaskedString string
 
 func (MaskedString) String() string {
@@ -701,8 +701,8 @@ type AddExternalConnectionParams struct {
 	Name               string                    `json:"name"`
 	EndpointType       EndpointType              `json:"endpoint_type"`
 	Endpoint           string                    `json:"endpoint"`
-	Identity           string                    `json:"identity"`
-	Secret             string                    `json:"secret"`
+	Identity           MaskedString              `json:"identity"`
+	Secret             MaskedString              `json:"secret"`
 	AuthMethod         CloudAuthMethod           `json:"auth_method,omitempty"`
 	AWSSTSARN          string                    `json:"aws_sts_arn,omitempty"`
 	Region             string                    `json:"region,omitempty"`
@@ -714,8 +714,8 @@ type CheckExternalConnectionParams struct {
 	Name                   string                    `json:"name"`
 	EndpointType           EndpointType              `json:"endpoint_type"`
 	Endpoint               string                    `json:"endpoint"`
-	Identity               string                    `json:"identity"`
-	Secret                 string                    `json:"secret"`
+	Identity               MaskedString              `json:"identity"`
+	Secret                 MaskedString              `json:"secret"`
 	AuthMethod             CloudAuthMethod           `json:"auth_method,omitempty"`
 	AWSSTSARN              string                    `json:"aws_sts_arn,omitempty"`
 	IgnoreNameAlreadyExist bool                      `json:"ignore_name_already_exist,omitempty"`
@@ -735,8 +735,8 @@ type CheckExternalConnectionReply struct {
 // UpdateExternalConnectionParams is the params of account_api.update_external_connection()
 type UpdateExternalConnectionParams struct {
 	Name               string                    `json:"name"`
-	Identity           string                    `json:"identity"`
-	Secret             string                    `json:"secret"`
+	Identity           MaskedString              `json:"identity"`
+	Secret             MaskedString              `json:"secret"`
 	AzureLogAccessKeys *AzureLogAccessKeysParams `json:"azure_log_access_keys,omitempty"`
 	Region             string                    `json:"region,omitempty"`
 }


### PR DESCRIPTION
### Explain the changes
Fix printing of Identity

we should see in the logs:
```
time="2024-05-01T15:15:37Z" level=info msg="✈️  RPC: account.check_external_connection() Request: {Name:newbc EndpointType:AWS Endpoint:https://s3.amazonaws.com Identity:**** Secret:**** AuthMethod: AWSSTSARN: IgnoreNameAlreadyExist:false AzureLogAccessKeys:<nil> Region:}"
```

### Fixes: 
https://bugzilla.redhat.com/show_bug.cgi?id=2277186