### PR TITLE
Fix for mount permissions on the agents PV

### DIFF
--- a/deploy/internal/pod-agent.yaml
+++ b/deploy/internal/pod-agent.yaml
@@ -35,6 +35,11 @@ spec:
       securityContext:
         runAsNonRoot: true
         allowPrivilegeEscalation: false
+  securityContext:
+    runAsUser: 10001
+    runAsGroup: 0
+    fsGroup: 0
+    fsGroupChangePolicy: "OnRootMismatch"
   volumes:
     - name: tmp-logs-vol
       emptyDir: {}

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -41,6 +41,9 @@ spec:
                   key: password
                   name: noobaa-db
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           ports:
             - containerPort: 5432
           resources:
@@ -64,7 +67,6 @@ spec:
         runAsGroup: 0
         fsGroup: 0
         fsGroupChangePolicy: "OnRootMismatch"
-        allowPrivilegeEscalation: false
   volumeClaimTemplates:
     - metadata:
         name: db

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4286,7 +4286,7 @@ metadata:
 data: {}
 `
 
-const Sha256_deploy_internal_pod_agent_yaml = "471be013b7cb20d0e00d6715edea3bf439e7a348f07661716326ca3356e648ee"
+const Sha256_deploy_internal_pod_agent_yaml = "a02ebca336c7db9e4b84a13459e30664fd8fd2a8ea238e188685caea52a281fd"
 
 const File_deploy_internal_pod_agent_yaml = `apiVersion: v1
 kind: Pod
@@ -4325,6 +4325,11 @@ spec:
       securityContext:
         runAsNonRoot: true
         allowPrivilegeEscalation: false
+  securityContext:
+    runAsUser: 10001
+    runAsGroup: 0
+    fsGroup: 0
+    fsGroupChangePolicy: "OnRootMismatch"
   volumes:
     - name: tmp-logs-vol
       emptyDir: {}
@@ -5036,7 +5041,7 @@ spec:
                   resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "efd4562dd6ce535624a56426dc921c584c5a761c8c2540d4823f9e410fcd0347"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "37a6c36928ba426ca04fd89e1eb2685e10d1a5f65c63ebb40c68a4f5c37645de"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5081,6 +5086,9 @@ spec:
                   key: password
                   name: noobaa-db
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           ports:
             - containerPort: 5432
           resources:
@@ -5104,7 +5112,6 @@ spec:
         runAsGroup: 0
         fsGroup: 0
         fsGroupChangePolicy: "OnRootMismatch"
-        allowPrivilegeEscalation: false
   volumeClaimTemplates:
     - metadata:
         name: db


### PR DESCRIPTION
### Explain the changes
* Fix for mount permissions
  * For some reason, the changes in #1340 caused the PV to be mounted without write permissions for GID 0 and be owned by root user. 
  * Added fsGroup 0 to the agent pod. This adds `w` permission to the mount for the owning GID 0 and provides write access to the agent process.
* Also moved `allowPrivilegeEscalation` in the DB sts to the container security context
  * This setting can only be set in the container security context, not the pod security context. (see [here](https://medium.com/pareture/k8s-podsecuritycontext-vs-containersecuritycontext-4ca682670f7b))

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2278120

### Testing Instructions:
1. Create a pv pool on an openshift cluster
2. Make sure it runs successfully 
3. The issue is not reproducible on minikube\rancher, since the pv is mounted there with `777`

- [ ] Doc added/updated
- [ ] Tests added
