### PR TITLE
[5.15] SCC Fix

### DIFF
--- a/deploy/scc_db.yaml
+++ b/deploy/scc_db.yaml
@@ -10,8 +10,6 @@ allowHostPID: false
 allowHostPorts: false
 allowPrivilegedContainer: false
 readOnlyRootFilesystem: false
-requiredDropCapabilities:
-  - ALL
 fsGroup:
   type: RunAsAny
 runAsUser:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -6403,7 +6403,7 @@ supplementalGroups:
 readOnlyRootFilesystem: true
 `
 
-const Sha256_deploy_scc_db_yaml = "de2274e71f8c6e83c0288623941a75d4dabc8c13a9fb9d0c2648b8fda3968b70"
+const Sha256_deploy_scc_db_yaml = "8a54368eed78778d1e3f0af542979cfd4de16249a18ab50ca9fc07f54ac17fc7"
 
 const File_deploy_scc_db_yaml = `apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -6417,8 +6417,6 @@ allowHostPID: false
 allowHostPorts: false
 allowPrivilegedContainer: false
 readOnlyRootFilesystem: false
-requiredDropCapabilities:
-  - ALL
 fsGroup:
   type: RunAsAny
 runAsUser:


### PR DESCRIPTION
### Explain the changes
In the master branch and 5.16, because we do no longer have an init container, we no longer require a lot of privileges to operate. The same is **not** true for versions before and including 5.15.

I tried multiple combinations of:
```
AUDIT_WRITE
CHOWN
DAC_OVERRIDE
FOWNER
FSETID
KILL
MKNOD
NET_BIND_SERVICE
SETFCAP
SETGID
SETPCAP
SETUID
SYS_CHROOT
```
capabilities but nothing really worked hence adding back the dropped default privileges. Will seek exception for this container (and I think we did do that initially for 5.14).

### Issues: Fixed #xxx / Gap #xxx
1. Broke 4.15.3 RC build - fixing that

### Testing Instructions:
1. Created a fresh openshift-cluster from cluster bot.
2. Used CLI built from this patch and ran `nb install ...`.
3. Waited for the system to be stable.
4. Ran `aws s3 ls` against the deployment.
5. Created obc and then S3 ops against that bucket using admin credentials.


The above testing was done to ensure that system is indeed functional at least in 5.15.

- [ ] Doc added/updated
- [ ] Tests added
