### PR TITLE
Nsfs : Default resources on hci odf

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1645,10 +1645,10 @@ spec:
                 type: object
               manualDefaultBackingStore:
                 description: |-
-                  ManualDefaultBackingStore (optional - default value is false) if true the default backingstore will
-                  not be reconciled by the operator and it should be manually handled by the user. It will allow the
-                  user to  delete DefaultBackingStore, user needs to delete associated buckets and update the admin
-                  account with new BackingStore in order to delete the DefaultBackingStore
+                  ManualDefaultBackingStore (optional - default value is false) if true the default backingstore/namespacestore
+                  will not be reconciled by the operator and it should be manually handled by the user. It will allow the
+                  user to  delete DefaultBackingStore/DefaultNamespaceStore, user needs to delete associated buckets and
+                  update the admin account with new BackingStore/NamespaceStore in order to delete the DefaultBackingStore/DefaultNamespaceStore
                 nullable: true
                 type: boolean
               pvPoolDefaultStorageClass:

--- a/deploy/internal/nsfs-pvc-cr.yaml
+++ b/deploy/internal/nsfs-pvc-cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: noobaa-default-nsfs-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -202,10 +202,10 @@ type NooBaaSpec struct {
 	// +optional
 	DefaultBackingStoreSpec *BackingStoreSpec `json:"defaultBackingStoreSpec,omitempty"`
 
-	// ManualDefaultBackingStore (optional - default value is false) if true the default backingstore will
-	// not be reconciled by the operator and it should be manually handled by the user. It will allow the
-	// user to  delete DefaultBackingStore, user needs to delete associated buckets and update the admin
-	// account with new BackingStore in order to delete the DefaultBackingStore
+	// ManualDefaultBackingStore (optional - default value is false) if true the default backingstore/namespacestore
+	// will not be reconciled by the operator and it should be manually handled by the user. It will allow the
+	// user to  delete DefaultBackingStore/DefaultNamespaceStore, user needs to delete associated buckets and
+	// update the admin account with new BackingStore/NamespaceStore in order to delete the DefaultBackingStore/DefaultNamespaceStore
 	// +nullable
 	// +optional
 	ManualDefaultBackingStore bool `json:"manualDefaultBackingStore,omitempty"`

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1483,7 +1483,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "9fc4f547417125d6ad6246a27690a88fbbb054ffb7e318ed7cf9e21ca2c707ef"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "713f70e6340bd50db5bba1f4e552d2a7096625a8767fd708d092c91f0087f7d0"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -3132,10 +3132,10 @@ spec:
                 type: object
               manualDefaultBackingStore:
                 description: |-
-                  ManualDefaultBackingStore (optional - default value is false) if true the default backingstore will
-                  not be reconciled by the operator and it should be manually handled by the user. It will allow the
-                  user to  delete DefaultBackingStore, user needs to delete associated buckets and update the admin
-                  account with new BackingStore in order to delete the DefaultBackingStore
+                  ManualDefaultBackingStore (optional - default value is false) if true the default backingstore/namespacestore
+                  will not be reconciled by the operator and it should be manually handled by the user. It will allow the
+                  user to  delete DefaultBackingStore/DefaultNamespaceStore, user needs to delete associated buckets and
+                  update the admin account with new BackingStore/NamespaceStore in order to delete the DefaultBackingStore/DefaultNamespaceStore
                 nullable: true
                 type: boolean
               pvPoolDefaultStorageClass:
@@ -4300,6 +4300,20 @@ metadata:
   annotations:
     service.beta.openshift.io/inject-cabundle: 'true'
 data: {}
+`
+
+const Sha256_deploy_internal_nsfs_pvc_cr_yaml = "545eb71b68dc5bcdf86da7c1ce5d7303c750e223cb32c7e3fc1f22d57617926f"
+
+const File_deploy_internal_nsfs_pvc_cr_yaml = `apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: noobaa-default-nsfs-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi
 `
 
 const Sha256_deploy_internal_pod_agent_yaml = "a02ebca336c7db9e4b84a13459e30664fd8fd2a8ea238e188685caea52a281fd"

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -801,7 +801,6 @@ func (r *Reconciler) ReconcileIBMCredentials() error {
 	return nil
 }
 
-
 // SetDesiredAgentProfile updates the value of the AGENT_PROFILE env
 func (r *Reconciler) SetDesiredAgentProfile(profileString string) string {
 	agentProfile := map[string]interface{}{}

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -98,6 +98,8 @@ type Reconciler struct {
 	IBMCosBucketCreds         *corev1.Secret
 	DefaultBackingStore       *nbv1.BackingStore
 	DefaultBucketClass        *nbv1.BucketClass
+	DefaultNamespaceStore     *nbv1.NamespaceStore
+	DefaultNsfsPvc            *corev1.PersistentVolumeClaim
 	OBCStorageClass           *storagev1.StorageClass
 	PrometheusRule            *monitoringv1.PrometheusRule
 	ServiceMonitorMgmt        *monitoringv1.ServiceMonitor
@@ -162,6 +164,8 @@ func NewReconciler(
 		IBMCosBucketCreds:         util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		DefaultBackingStore:       util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_backingstore_cr_yaml).(*nbv1.BackingStore),
 		DefaultBucketClass:        util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_bucketclass_cr_yaml).(*nbv1.BucketClass),
+		DefaultNamespaceStore:     util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_namespacestore_cr_yaml).(*nbv1.NamespaceStore),
+		DefaultNsfsPvc:            util.KubeObject(bundle.File_deploy_internal_nsfs_pvc_cr_yaml).(*corev1.PersistentVolumeClaim),
 		OBCStorageClass:           util.KubeObject(bundle.File_deploy_obc_storage_class_yaml).(*storagev1.StorageClass),
 		PrometheusRule:            util.KubeObject(bundle.File_deploy_internal_prometheus_rules_yaml).(*monitoringv1.PrometheusRule),
 		ServiceMonitorMgmt:        util.KubeObject(bundle.File_deploy_internal_servicemonitor_mgmt_yaml).(*monitoringv1.ServiceMonitor),
@@ -207,6 +211,8 @@ func NewReconciler(
 	r.IBMCosBucketCreds.Namespace = r.Request.Namespace
 	r.DefaultBackingStore.Namespace = r.Request.Namespace
 	r.DefaultBucketClass.Namespace = r.Request.Namespace
+	r.DefaultNamespaceStore.Namespace = r.Request.Namespace
+	r.DefaultNsfsPvc.Namespace = r.Request.Namespace
 	r.PrometheusRule.Namespace = r.Request.Namespace
 	r.ServiceMonitorMgmt.Namespace = r.Request.Namespace
 	r.ServiceMonitorS3.Namespace = r.Request.Namespace
@@ -250,6 +256,8 @@ func NewReconciler(
 	r.IBMCosBucketCreds.Name = ibmCosBucketCred
 	r.DefaultBackingStore.Name = r.Request.Name + "-default-backing-store"
 	r.DefaultBucketClass.Name = r.Request.Name + "-default-bucket-class"
+	r.DefaultNamespaceStore.Name = r.Request.Name + "-default-namespace-store"
+	r.DefaultNsfsPvc.Name = r.Request.Name + "-default-nsfs-pvc"
 	r.PrometheusRule.Name = r.Request.Name + "-prometheus-rules"
 	r.ServiceMonitorMgmt.Name = r.ServiceMgmt.Name + "-service-monitor"
 	r.ServiceMonitorS3.Name = r.ServiceS3.Name + "-service-monitor"
@@ -316,6 +324,8 @@ func (r *Reconciler) CheckAll() {
 	util.KubeCheck(r.DefaultBucketClass)
 	util.KubeCheck(r.DeploymentEndpoint)
 	util.KubeCheckOptional(r.DefaultBackingStore)
+	util.KubeCheckOptional(r.DefaultNamespaceStore)
+	util.KubeCheckOptional(r.DefaultNsfsPvc)
 	util.KubeCheckOptional(r.AWSCloudCreds)
 	util.KubeCheckOptional(r.AzureCloudCreds)
 	util.KubeCheckOptional(r.AzureContainerCreds)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1031,6 +1031,16 @@ func IsAWSPlatform() bool {
 	return isAWS
 }
 
+// IsFusionHCIWithScale checks if the noobaa is deployed on HCI platform and
+// using Spectrum Scale storage.
+func IsFusionHCIWithScale() bool {
+	sc := &storagev1.StorageClass{
+		TypeMeta:   metav1.TypeMeta{Kind: "StorageClass"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ibm-spectrum-scale-csi-storageclass-version2"},
+	}
+	return KubeCheck(sc)
+}
+
 // IsSTSClusterBS returns true if it is running on an STS cluster
 func IsSTSClusterBS(bs *nbv1.BackingStore) bool {
 	if bs.Spec.Type == nbv1.StoreTypeAWSS3 {


### PR DESCRIPTION
    NSFS: Create default resource objects on Fusion HCI
    
    ODF MCG on Fusion HCI with Spectrum Scale CNSA should
    configure the default BucketClass, Namespacestore and
    default PVC to use NSFS.
    
    To set up NSFS on kubernetes, we need to create pvc
    and namespacestore which can be used to create nsfs
    bucket class. These nsfs buckets are used to create
    a user bucket by s3 client.
