### PR TITLE
[Direct To 5.15] add InitCotnainers to DB sts if not exist

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -301,6 +301,10 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 		},
 	)
 
+	if podSpec.InitContainers == nil {
+		podSpec.InitContainers = NooBaaDBTemplate.Spec.Template.Spec.InitContainers
+	}
+
 	for i := range podSpec.InitContainers {
 		c := &podSpec.InitContainers[i]
 		if c.Name == "initialize-database" {


### PR DESCRIPTION
### Explain the changes
* this change is done directly on 5.15. The code in the master (5.16 and up) removes the need for an init container. 

* upgrade of postgres 12 to 15 assumes there is an init container to the DB sts.
* in some cases, it is possible that the DB is running without an init container.
* If no init container exists, the operator will crash when attempting to access the init containers array.
* The fix adds an init container to the pod spec from the DB statefulset template (statefulset-postgres-db.yaml)

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2281839

### Testing Instructions:
1. install noobaa
2. stop the operator
3. remove the init container from DB sts
4. start the operator. it should now add the init container back.


- [ ] Doc added/updated
- [ ] Tests added
