### PR TITLE
[Direct to 5.15] Added error handling and retries in postgres upgrade scripts

### DIFF
--- a/deploy/internal/configmap-postgres-initdb.yaml
+++ b/deploy/internal/configmap-postgres-initdb.yaml
@@ -54,7 +54,24 @@ data:
           fi
           echo "Info: Free space $USE% is below $THRESHOLD% threshold. Starting upgrade!"
           until pg_isready; do sleep 1; done;
+          # after pg_isready, sleep for 30 seconds, since /usr/bin/run-postgresql script will restart the postgres service
+          sleep 30
+          # make sure again that postgres is running and ready
+          until pg_isready; do sleep 1; done;
+          set +e
+          # dump the db. retry 3 times in case of failure
+          for i in {1..3}; do
             pg_dumpall -U postgres > /$HOME/data/dump.sql
+            if [ $? -eq 0 ]; then
+              break
+            elif [ $i -eq 3 ]; then
+              echo "Failed to dump the db"
+              exit 1
+            fi
+            sleep 10
+          done
+          until pg_isready; do sleep 1; done;
+          pg_dumpall -U postgres > /$HOME/data/dump.sql
           exit 0
 
   upgradedb.sh: |
@@ -77,7 +94,22 @@ data:
           sed -i -e 's/^\(postgres:[^:]\):[0-9]*:[0-9]*:/\1:10001:0:/' /etc/passwd
           su postgres -c "bash -x /usr/bin/run-postgresql" &
           until pg_isready; do sleep 1;echo "sleeping.."; done;
-          psql -U postgres < /$HOME/data/dump.sql
+          # after pg_isready, sleep for 30 seconds, since /usr/bin/run-postgresql script will restart the postgres service
+          sleep 30
+          # make sure again that postgres is running and ready
+          until pg_isready; do sleep 1;echo "sleeping.."; done;
+          # restore the dump. retry 3 times in case of failure
+          set +e
+          for i in {1..3}; do
+            psql -U postgres < /$HOME/data/dump.sql
+            if [ $? -eq 0 ]; then
+              break
+            elif [ $i -eq 3 ]; then
+              echo "Failed to restore the dump"
+              exit 1
+            fi
+            sleep 10
+          done
           rm /$HOME/data/dump.sql
           exit 0
 


### PR DESCRIPTION
### Explain the changes
* Postgres upgrade scripts are being run in an init container. since postgres server is required for dump and restore in different Postgres versions, it is being run in the background in the upgrade scripts using the container's script `/usr/bin/run-postgresql`.
* `run-postgresql` runs postgres twice, first time for initialization if needed, and second time to actually run the server with the given params.
* in some cases the upgrade script identifies postgres as ready in the initialization run, and starts the restore from dump. then if `run-postgresql` stops the server, the restore fails.
* To fix - added 30 sec sleep after pg_isready, to alow for the init phase to complete (usually it should take a few seconds)
* Also added error handling and retries in case there are any errors in the dump or restore phases.

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2280834

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
