### PR TITLE
Fix the VolumeMount path for bucket logging

### DIFF
--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -299,7 +299,7 @@ func NewReconciler(
 
 	// Set bucket logging volume mount name and path
 	r.BucketLoggingVolume = r.Request.Name + "-bucket-logging-volume"
-	r.BucketLoggingVolumeMount = "etc/logs/bucket-logs"
+	r.BucketLoggingVolumeMount = "/etc/logs/bucket-logs"
 
 	r.DefaultCoreApp = r.CoreApp.Spec.Template.Spec.Containers[0].DeepCopy()
 	r.DefaultDeploymentEndpoint = r.DeploymentEndpoint.Spec.Template.Spec.DeepCopy()


### PR DESCRIPTION
### Explain the changes
1. Changed the volume mount path from 'etc/logs/bucket-logs' to '/etc/logs/bucket-logs'.

### Issues: Fixed #xxx / Gap #xxx
1. Improvement #1371 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
