### PR TITLE
Added support to join external noobaa system from hosted clusters

### DIFF
--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -190,21 +190,24 @@ func (r *Reconciler) CheckJoinSecret() error {
 		return util.NewPersistentError("InvalidJoinSecert",
 			"JoinSecret is missing mgmt_addr")
 	}
-	if r.JoinSecret.StringData["bg_addr"] == "" {
-		return util.NewPersistentError("InvalidJoinSecert",
-			"JoinSecret is missing bg_addr")
-	}
-	if r.JoinSecret.StringData["md_addr"] == "" {
-		return util.NewPersistentError("InvalidJoinSecert",
-			"JoinSecret is missing md_addr")
-	}
-	if r.JoinSecret.StringData["hosted_agents_addr"] == "" {
-		return util.NewPersistentError("InvalidJoinSecert",
-			"JoinSecret is missing hosted_agents_addr")
-	}
 	if r.JoinSecret.StringData["auth_token"] == "" {
 		return util.NewPersistentError("InvalidJoinSecert",
 			"JoinSecret is missing auth_token")
+	}
+
+	if exists := util.IsAnnotationPresent(r.NooBaa.GetAnnotations(), "remote-client-noobaa"); !exists {
+		if r.JoinSecret.StringData["bg_addr"] == "" {
+			return util.NewPersistentError("InvalidJoinSecert",
+				"JoinSecret is missing bg_addr")
+		}
+		if r.JoinSecret.StringData["md_addr"] == "" {
+			return util.NewPersistentError("InvalidJoinSecert",
+				"JoinSecret is missing md_addr")
+		}
+		if r.JoinSecret.StringData["hosted_agents_addr"] == "" {
+			return util.NewPersistentError("InvalidJoinSecert",
+				"JoinSecret is missing hosted_agents_addr")
+		}
 	}
 	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2190,3 +2190,13 @@ func IsDevEnv() bool {
 	}
 	return false
 }
+
+// IsAnnotationPresent checks if an annotation is
+// is present in the Annotations map
+func IsAnnotationPresent(annotations map[string]string, name string) bool {
+	if annotations == nil {
+		return false
+	}
+	_, exists := annotations[name]
+	return exists
+}


### PR DESCRIPTION
### Explain the changes
Part of : [RHSTOR-5187](https://issues.redhat.com//browse/RHSTOR-5187)
1. Edited Join Secret check to differentiate between `remote endpoints` behaviour and `remote noobaa operator` via a annonation `remote-client-noobaa:true`
2. Create a `auth_token` secret for noobaa accounts having an annotation `remote-operator`
3. Delete the auth_token secret when noobaa account is deleted

### Issues: Fixed #xxx / Gap #xxx
1.

### Testing Instructions:
1. This change works on a the provider-client model of OCS. 
2. When a new client cluster joins with ocs provider cluster, it creates a Noobaa account CR in the provider cluster
4. An auth token is created for each noobaa remote operator account and is supplied to the client cluster
5. ocs-client operator creates a join secret containing `auth_token` and `mgmt_addr` obtained from the provider noobaa cluster
6. ocs-client opertor creates a Noobaa CR with a secret referring to the join secret created.
7. Noobaa operator then reconciles the client Noobaa CR
8. New OBCs can be created in the client cluster
Ref: https://github.com/red-hat-storage/ocs-operator/pull/2680 
https://github.com/red-hat-storage/ocs-client-operator/pull/176

- [ ] Doc added/updated
- [ ] Tests added
