### PR TITLE
Checking for pvc only if BucketLoggingPVC is not nil

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -430,6 +430,8 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 		case "GUARANTEED_LOGS_PATH":
 			if r.NooBaa.Spec.BucketLogging.LoggingType == nbv1.BucketLoggingTypeGuaranteed {
 				c.Env[j].Value = r.BucketLoggingVolumeMount
+			} else {
+				c.Env[j].Value = ""
 			}
 		}
 	}

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -408,6 +408,8 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 				case "GUARANTEED_LOGS_PATH":
 					if r.NooBaa.Spec.BucketLogging.LoggingType == nbv1.BucketLoggingTypeGuaranteed {
 						c.Env[j].Value = r.BucketLoggingVolumeMount
+					} else {
+						c.Env[j].Value = ""
 					}
 				}
 			}

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -299,7 +299,7 @@ func NewReconciler(
 
 	// Set bucket logging volume mount name and path
 	r.BucketLoggingVolume = r.Request.Name + "-bucket-logging-volume"
-	r.BucketLoggingVolumeMount = "/etc/logs/bucket-logs"
+	r.BucketLoggingVolumeMount = "/var/logs/bucket-logs"
 
 	r.DefaultCoreApp = r.CoreApp.Spec.Template.Spec.Containers[0].DeepCopy()
 	r.DefaultDeploymentEndpoint = r.DeploymentEndpoint.Spec.Template.Spec.DeepCopy()


### PR DESCRIPTION
### Explain the changes
1.  Checking for bucket logging pvc only if BucketLoggingPVC is provided by the user. Currently, checks are failing if cephfs storage class is already present inside the cluster.

### Issues: Fixed #xxx / Gap #xxx
1. Improvement: #1368 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
