### PR TITLE
Fixing SCC issues for bucket logging

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         noobaa.io/configmap-hash: ""
     spec:
-      serviceAccountName: noobaa
+      serviceAccountName: noobaa-core
       volumes:
         - name: logs
           emptyDir: {}
@@ -42,6 +42,11 @@ spec:
                   path: token
                   # For testing purposes change the audience to api
                   audience: openshift
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
         #----------------#
         # CORE CONTAINER #

--- a/deploy/role_binding_core.yaml
+++ b/deploy/role_binding_core.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: noobaa-core-role-binding
+  namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: noobaa-core-role
+subjects:
+- kind: ServiceAccount
+  name: noobaa-core
+  namespace: openshift-storage

--- a/deploy/role_core.yaml
+++ b/deploy/role_core.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: noobaa-core-role
+rules:
+- apiGroups:
+  - noobaa.io
+  resources:
+  - '*'
+  - noobaas
+  - backingstores
+  - bucketclasses
+  - noobaas/finalizers
+  - backingstores/finalizers
+  - bucketclasses/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - noobaa-db
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/scc_endpoint.yaml
+++ b/deploy/scc_endpoint.yaml
@@ -23,7 +23,7 @@ requiredDropCapabilities:
 runAsUser:
   type: RunAsAny
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs
 supplementalGroups:
   type: RunAsAny
 volumes:

--- a/deploy/service_account_core.yaml
+++ b/deploy/service_account_core.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: noobaa-core
+

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4900,7 +4900,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "0e7e90edc6c96f93cbdbdcc6aa6b64f05a98a88b181d94780d9a97fb2fcecd07"
+const Sha256_deploy_internal_statefulset_core_yaml = "7ef8bd78b51d915e4da983c90120eefcadb7b3f40087098887e834480f829dc8"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4925,7 +4925,7 @@ spec:
       annotations:
         noobaa.io/configmap-hash: ""
     spec:
-      serviceAccountName: noobaa
+      serviceAccountName: noobaa-core
       volumes:
         - name: logs
           emptyDir: {}
@@ -4946,6 +4946,11 @@ spec:
                   path: token
                   # For testing purposes change the audience to api
                   audience: openshift
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
         #----------------#
         # CORE CONTAINER #
@@ -6249,6 +6254,23 @@ subjects:
   name: custom-metrics-prometheus-adapter
 `
 
+const Sha256_deploy_role_binding_core_yaml = "8e6063e6056d180419063b17d364596a554140bcdb93c521e031f940e9377bb3"
+
+const File_deploy_role_binding_core_yaml = `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: noobaa-core-role-binding
+  namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: noobaa-core-role
+subjects:
+- kind: ServiceAccount
+  name: noobaa-core
+  namespace: openshift-storage
+`
+
 const Sha256_deploy_role_binding_db_yaml = "3a4872fcde50e692ae52bbd208a8e1d115c574431c25a9644a7c820ae13c7748"
 
 const File_deploy_role_binding_db_yaml = `apiVersion: rbac.authorization.k8s.io/v1
@@ -6311,6 +6333,57 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: custom-metrics-prometheus-adapter
+`
+
+const Sha256_deploy_role_core_yaml = "93a1dce5d48364080923b2b8d78ed661d60375ada2bb0b2bde9857ca3960e874"
+
+const File_deploy_role_core_yaml = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: noobaa-core-role
+rules:
+- apiGroups:
+  - noobaa.io
+  resources:
+  - '*'
+  - noobaas
+  - backingstores
+  - bucketclasses
+  - noobaas/finalizers
+  - backingstores/finalizers
+  - bucketclasses/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - noobaa-db
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 `
 
 const Sha256_deploy_role_db_yaml = "bc7eeca1125dfcdb491ab8eb69e3dcbce9f004a467b88489f85678b3c6872cce"
@@ -6485,7 +6558,7 @@ supplementalGroups:
   type: RunAsAny
 `
 
-const Sha256_deploy_scc_endpoint_yaml = "f9407c9f1fd1876eabbaad4cf910a05e57db33a2d590b2e2efad22bd1e3f8876"
+const Sha256_deploy_scc_endpoint_yaml = "b540b01b4e31dde0c5ff93c116f7873350a186c8985a35e21388091b63b221c7"
 
 const File_deploy_scc_endpoint_yaml = `apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -6512,7 +6585,7 @@ requiredDropCapabilities:
 runAsUser:
   type: RunAsAny
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs
 supplementalGroups:
   type: RunAsAny
 volumes:
@@ -6532,6 +6605,15 @@ metadata:
   name: noobaa
   annotations:
     serviceaccounts.openshift.io/oauth-redirectreference.noobaa-mgmt: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"noobaa-mgmt"}}'
+`
+
+const Sha256_deploy_service_account_core_yaml = "7e8f1d49bdba0969a33e8acc676cc5e2d50af9f4c94112b6de07548f3f704c24"
+
+const File_deploy_service_account_core_yaml = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: noobaa-core
+
 `
 
 const Sha256_deploy_service_account_db_yaml = "fcbccd7518ee5a426b071a3acc85d22142e27c5628b61ce4292cc393d2ecac31"

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -274,6 +274,11 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 			ServiceAccountName: opConf.SAEndpoint.Name,
 			Rules:              opConf.RoleEndpoint.Rules,
 		})
+	csv.Spec.InstallStrategy.StrategySpec.Permissions = append(csv.Spec.InstallStrategy.StrategySpec.Permissions,
+		operv1.StrategyDeploymentPermissions{
+			ServiceAccountName: opConf.SACore.Name,
+			Rules:              opConf.RoleCore.Rules,
+		})
 	csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = []operv1.StrategyDeploymentSpec{}
 	csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = append(csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs,
 		operv1.StrategyDeploymentSpec{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -350,12 +350,15 @@ type Conf struct {
 	NS                   *corev1.Namespace
 	SA                   *corev1.ServiceAccount
 	SAEndpoint           *corev1.ServiceAccount
+	SACore               *corev1.ServiceAccount
 	SAUI                 *corev1.ServiceAccount
 	Role                 *rbacv1.Role
 	RoleEndpoint         *rbacv1.Role
+	RoleCore             *rbacv1.Role
 	RoleUI               *rbacv1.ClusterRole
 	RoleBinding          *rbacv1.RoleBinding
 	RoleBindingEndpoint  *rbacv1.RoleBinding
+	RoleBindingCore      *rbacv1.RoleBinding
 	ClusterRole          *rbacv1.ClusterRole
 	ClusterRoleBinding   *rbacv1.ClusterRoleBinding
 	Deployment           *appsv1.Deployment
@@ -371,12 +374,15 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.NS = util.KubeObject(bundle.File_deploy_namespace_yaml).(*corev1.Namespace)
 	c.SA = util.KubeObject(bundle.File_deploy_service_account_yaml).(*corev1.ServiceAccount)
 	c.SAEndpoint = util.KubeObject(bundle.File_deploy_service_account_endpoint_yaml).(*corev1.ServiceAccount)
+	c.SACore = util.KubeObject(bundle.File_deploy_service_account_core_yaml).(*corev1.ServiceAccount)
 	c.SAUI = util.KubeObject(bundle.File_deploy_service_account_ui_yaml).(*corev1.ServiceAccount)
 	c.Role = util.KubeObject(bundle.File_deploy_role_yaml).(*rbacv1.Role)
 	c.RoleEndpoint = util.KubeObject(bundle.File_deploy_role_endpoint_yaml).(*rbacv1.Role)
+	c.RoleCore = util.KubeObject(bundle.File_deploy_role_core_yaml).(*rbacv1.Role)
 	c.RoleUI = util.KubeObject(bundle.File_deploy_role_ui_yaml).(*rbacv1.ClusterRole)
 	c.RoleBinding = util.KubeObject(bundle.File_deploy_role_binding_yaml).(*rbacv1.RoleBinding)
 	c.RoleBindingEndpoint = util.KubeObject(bundle.File_deploy_role_binding_endpoint_yaml).(*rbacv1.RoleBinding)
+	c.RoleBindingCore = util.KubeObject(bundle.File_deploy_role_binding_core_yaml).(*rbacv1.RoleBinding)
 	c.ClusterRole = util.KubeObject(bundle.File_deploy_cluster_role_yaml).(*rbacv1.ClusterRole)
 	c.ClusterRoleBinding = util.KubeObject(bundle.File_deploy_cluster_role_binding_yaml).(*rbacv1.ClusterRoleBinding)
 	c.Deployment = util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
@@ -384,10 +390,13 @@ func LoadOperatorConf(cmd *cobra.Command) *Conf {
 	c.NS.Name = options.Namespace
 	c.SA.Namespace = options.Namespace
 	c.SAEndpoint.Namespace = options.Namespace
+	c.SACore.Namespace = options.Namespace
 	c.Role.Namespace = options.Namespace
 	c.RoleEndpoint.Namespace = options.Namespace
+	c.RoleCore.Namespace = options.Namespace
 	c.RoleBinding.Namespace = options.Namespace
 	c.RoleBindingEndpoint.Namespace = options.Namespace
+	c.RoleBindingCore.Namespace = options.Namespace
 	c.ClusterRole.Namespace = options.Namespace
 	c.Deployment.Namespace = options.Namespace
 


### PR DESCRIPTION
### Explain the changes
1. Added SA/Role/Rolebinding for noobaa-core pod. As I don't think any additional SSC caps over noobaa-db used this SCC
2. Fixed noobaa-endpoint SCC to use MustRunAs instead RunAsAny to avoid inner namespace s3linux labeling - which blocks access between endpoints and core and between endpoints.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
