### PR TITLE
Implement operator support for pool ownership

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -177,3 +177,5 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: CONFIG_JS_RESTRICT_RESOURCE_DELETION
+              value: "false"

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4900,7 +4900,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "7ef8bd78b51d915e4da983c90120eefcadb7b3f40087098887e834480f829dc8"
+const Sha256_deploy_internal_statefulset_core_yaml = "99c00569849a8e406ba6228de686a53cc73eaac308bc6bed7849bb5a8040d469"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5081,6 +5081,8 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: CONFIG_JS_RESTRICT_RESOURCE_DELETION
+              value: "false"
 `
 
 const Sha256_deploy_internal_statefulset_postgres_db_yaml = "37a6c36928ba426ca04fd89e1eb2685e10d1a5f65c63ebb40c68a4f5c37645de"

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -450,6 +450,11 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	r.CoreApp.Spec.Selector.MatchLabels["noobaa-core"] = r.Request.Name
 	r.CoreApp.Spec.ServiceName = r.ServiceMgmt.Name
 
+	//check if provider mode is enabled and signal the core
+	if annotationValue, _ := util.GetAnnotationValue(r.NooBaa.Annotations, "MulticloudObjectGatewayProviderMode"); annotationValue == "true" {
+		util.GetEnvVariable(&r.CoreApp.Spec.Template.Spec.Containers[0].Env, "CONFIG_JS_RESTRICT_RESOURCE_DELETION").Value = "true"
+	}
+
 	podSpec := &r.CoreApp.Spec.Template.Spec
 	podSpec.ServiceAccountName = "noobaa"
 	coreImageChanged := false

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1424,6 +1424,15 @@ func GetEnvVariable(env *[]corev1.EnvVar, name string) *corev1.EnvVar {
 	return nil
 }
 
+// GetAnnotationValue searches for an annotation within a map of strings and returns if it exists and what its value
+func GetAnnotationValue(annotations map[string]string, name string) (string, bool) {
+	if annotations != nil {
+		val, exists := annotations[name]
+		return val, exists
+	}
+	return "", false
+}
+
 // ReflectEnvVariable will add, update or remove an env variable base on the existence and value of an
 // env variable with the same name on the container running this function.
 func ReflectEnvVariable(env *[]corev1.EnvVar, name string) {


### PR DESCRIPTION
### Explain the changes
1.  part of the change required in [Implement OCS and MCG operator support for pool ownership](https://issues.redhat.com/browse/RHSTOR-6123) adds an indication to the core that the cluster is set to provider mode upon deployment.

### Issues: Fixed #xxx / Gap #xxx
1. This implementation supports [RHSTOR-5187 - Support Provider & Consumer mode](https://issues.redhat.com/browse/RHSTOR-5187)

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
