### PR TITLE
[5.15] Bumping version from 5.15.4 to 5.15.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ out-of-cluster.
 ```shell
 $ noobaa version
 
-INFO[0000] CLI version: 5.15.4
-INFO[0000] noobaa-image: noobaa/noobaa-core:5.15.4
-INFO[0000] operator-image: noobaa/noobaa-operator:5.15.4
+INFO[0000] CLI version: 5.15.6
+INFO[0000] noobaa-image: noobaa/noobaa-core:5.15.6
+INFO[0000] operator-image: noobaa/noobaa-operator:5.15.6
 
 ```
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1,6 +1,6 @@
 package bundle
 
-const Version = "5.15.4"
+const Version = "5.15.6"
 
 const Sha256_deploy_cluster_role_yaml = "3f8118853db73926c4f9d14be84ac8f81833c3a7a94a52ecf1e9ebcf712eee93"
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 const (
 	// Version is the noobaa-operator version (semver)
-	Version = "5.15.4"
+	Version = "5.15.6"
 )


### PR DESCRIPTION
### Explain the changes
[5.15] Bumping version from 5.15.4 to 5.15.6

- We are skipping 5.15.5 as it was used for a quick respin on the downstream, with no code changes in NooBaa.

