### PR TITLE
[Direct to 4.15] Set Noobaa status to rejected if failed to upgrade to postgresql-15

### DIFF
--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -435,12 +435,22 @@ func (r *Reconciler) Reconcile() (reconcile.Result, error) {
 			log.Warnf("⏳ Temporary Error: %s", err)
 		}
 	} else {
-		r.SetPhase(
-			nbv1.SystemPhaseReady,
-			"SystemPhaseReady",
-			"noobaa operator completed reconcile - system is ready",
-		)
-		log.Infof("✅ Done")
+		// Postgres upgrade failure workaround
+		// if the system reconciliation has no other error, but the postgres image is still postresql-12 image, set the status to Rejected
+		psql12Image, ok := os.LookupEnv("NOOBAA_PSQL_12_IMAGE")
+		if ok && r.NooBaaPostgresDB.Spec.Template.Spec.Containers[0].Image == psql12Image {
+			r.SetPhase(nbv1.SystemPhaseRejected,
+				"PostgresImageVersion",
+				"Noobaa is using Postgresql-12 which indicates a failure to upgrade to Postgresql-15. Please contact support.")
+			log.Errorf("❌ Postgres image version is set to postgresql-12. Indicates a failure to upgrade to Postgresql-15. Please contact support.")
+		} else {
+			r.SetPhase(
+				nbv1.SystemPhaseReady,
+				"SystemPhaseReady",
+				"noobaa operator completed reconcile - system is ready",
+			)
+			log.Infof("✅ Done")
+		}
 	}
 
 	err = r.UpdateStatus()


### PR DESCRIPTION
### Explain the changes
1. If the noobaa db image is `NOOBAA_PSQL_12_IMAGE` when completing reconciliation, set the noobaa CR to `Rejected`

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2299836

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
