### PR TITLE
disable automatic mount of SA token for pv-pool pod

### DIFF
--- a/deploy/internal/pod-agent.yaml
+++ b/deploy/internal/pod-agent.yaml
@@ -35,6 +35,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         allowPrivilegeEscalation: false
+  automountServiceAccountToken: false
   securityContext:
     runAsUser: 10001
     runAsGroup: 0

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -1170,6 +1170,11 @@ func (r *Reconciler) needUpdate(pod *corev1.Pod) bool {
 		return true
 	}
 
+	// if automountServiceAccountToken setting is different than the podAgentTemplate, return true
+	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken != *r.PodAgentTemplate.Spec.AutomountServiceAccountToken {
+		return true
+	}
+
 	podSecrets := pod.Spec.ImagePullSecrets
 	noobaaSecret := r.NooBaa.Spec.ImagePullSecret
 	if noobaaSecret == nil {

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4326,7 +4326,7 @@ spec:
       storage: 30Gi
 `
 
-const Sha256_deploy_internal_pod_agent_yaml = "a02ebca336c7db9e4b84a13459e30664fd8fd2a8ea238e188685caea52a281fd"
+const Sha256_deploy_internal_pod_agent_yaml = "208a74bcb0238999af0f70fcb6a92389d7cf960b94b469a2b7cfd62d06b66d6f"
 
 const File_deploy_internal_pod_agent_yaml = `apiVersion: v1
 kind: Pod
@@ -4365,6 +4365,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         allowPrivilegeEscalation: false
+  automountServiceAccountToken: false
   securityContext:
     runAsUser: 10001
     runAsGroup: 0


### PR DESCRIPTION
### Explain the changes
1. Kubernetes automatically mounts a service account token for every pod by default. 
2. The best practice is to mount it only for pods that require access to the Kubernetes API. 
3. For now, disabling automount for pv-pool pods. We should consider it for all pods other than the operator.
4. see more info [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) 


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
