### PR TITLE
Added TopologySpreadConstraints to the backingstore pod for better performance

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 
 	"cloud.google.com/go/storage"
-	semver "github.com/coreos/go-semver/semver"
 	"github.com/marstr/randname"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bundle"
@@ -42,12 +41,11 @@ import (
 )
 
 const (
-	ibmEndpoint                           = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
-	ibmLocation                           = "%s-standard"
-	ibmCosBucketCred                      = "ibm-cloud-cos-creds"
-	topologyConstraintsEnabledKubeVersion = "1.26.0"
-	minutesToWaitForDefaultBSCreation     = 10
-	credentialsKey                        = "credentials"
+	ibmEndpoint                       = "https://s3.direct.%s.cloud-object-storage.appdomain.cloud"
+	ibmLocation                       = "%s-standard"
+	ibmCosBucketCred                  = "ibm-cloud-cos-creds"
+	minutesToWaitForDefaultBSCreation = 10
+	credentialsKey                    = "credentials"
 )
 
 type gcpAuthJSON struct {
@@ -285,7 +283,7 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 	disableDefaultTopologyConstraints, found := r.NooBaa.ObjectMeta.Annotations[nbv1.SkipTopologyConstraints]
 	if podSpec.TopologySpreadConstraints != nil {
 		r.Logger.Debugf("deployment %s TopologySpreadConstraints already exists, leaving as is", r.DeploymentEndpoint.Name)
-	} else if !r.hasNodeInclusionPolicyInPodTopologySpread() {
+	} else if !util.HasNodeInclusionPolicyInPodTopologySpread() {
 		r.Logger.Debugf("deployment %s TopologySpreadConstraints cannot be set because feature gate NodeInclusionPolicyInPodTopologySpread is not supported on this cluster version",
 			r.DeploymentEndpoint.Name)
 	} else if found && disableDefaultTopologyConstraints == "true" {
@@ -434,23 +432,6 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 		}
 	}
 	return nil
-}
-
-func (r *Reconciler) hasNodeInclusionPolicyInPodTopologySpread() bool {
-	kubeVersion, err := util.GetKubeVersion()
-	if err != nil {
-		r.Logger.Printf("❌ Failed to get kube version %s", err)
-		return false
-	}
-	enabledKubeVersion, err := semver.NewVersion(topologyConstraintsEnabledKubeVersion)
-	if err != nil {
-		util.Panic(err)
-		return false
-	}
-	if kubeVersion.LessThan(*enabledKubeVersion) {
-		return false
-	}
-	return true
 }
 
 func (r *Reconciler) setDesiredRootMasterKeyMounts(podSpec *corev1.PodSpec, container *corev1.Container) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -77,6 +77,8 @@ const (
 	gigabyte             = 1024 * 1024 * 1024
 	petabyte             = gigabyte * 1024 * 1024
 	obcMaxSizeUpperLimit = petabyte * 1023
+
+	topologyConstraintsEnabledKubeVersion = "1.26.0"
 )
 
 // OAuth2Endpoints holds OAuth2 endpoints information.
@@ -2198,4 +2200,22 @@ func IsDevEnv() bool {
 		return true
 	}
 	return false
+}
+
+// HasNodeInclusionPolicyInPodTopologySpread checks if the cluster supports the spread topology policy
+func HasNodeInclusionPolicyInPodTopologySpread() bool {
+	kubeVersion, err := GetKubeVersion()
+	if err != nil {
+		fmt.Printf("❌ Failed to get kube version %s", err)
+		return false
+	}
+	enabledKubeVersion, err := semver.NewVersion(topologyConstraintsEnabledKubeVersion)
+	if err != nil {
+		Panic(err)
+		return false
+	}
+	if kubeVersion.LessThan(*enabledKubeVersion) {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
### Explain the changes
1. Currently, when we create a pv backingstore then the backingstore pod got scheduled on the random basis on any node. This is not good as if any node goes down all the backingstore pod on that node will be down. To increase the performance we have added topology spread constraints to the backingstore pod so they get scheduled on spread basis.

### Issues: Fixed #xxx / Gap #xxx
1. fix: https://bugzilla.redhat.com/show_bug.cgi?id=2294846

### Testing Instructions:
1. After installing noobaa, try creating new pv-backingstore and check if the pv backingstore pod got scheduled and spread across the multiple nodes. Each pod should be spread in different nodes with a maximum skew difference of 1.
