### PR TITLE
Fix provider env var panic

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -93,6 +93,8 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_LOG_LEVEL
+            - name: RESTRICT_RESOURCE_DELETION
+              value: "false"
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_PORT
@@ -175,5 +177,3 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
-            - name: CONFIG_JS_RESTRICT_RESOURCE_DELETION
-              value: "false"

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4906,7 +4906,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "f35f833d6ce6dd078ff3f5159fd8ae6ca095fc6adf4f4d171d88c526ac145136"
+const Sha256_deploy_internal_statefulset_core_yaml = "54acebc824f333be8b8e1b922ea031f2af13dbaf8775a8a5ac80e2ec8537cfd1"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5003,6 +5003,8 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_LOG_LEVEL
+            - name: RESTRICT_RESOURCE_DELETION
+              value: "false"
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_PORT
@@ -5085,8 +5087,6 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
-            - name: CONFIG_JS_RESTRICT_RESOURCE_DELETION
-              value: "false"
 `
 
 const Sha256_deploy_internal_statefulset_postgres_db_yaml = "37a6c36928ba426ca04fd89e1eb2685e10d1a5f65c63ebb40c68a4f5c37645de"


### PR DESCRIPTION
### Explain the changes
1. moved the check for the env var to the appropriate location
2. changed env var location in yaml file and made it optional

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2301889
2. change introduced as part of [epic](https://issues.redhat.com/browse/RHSTOR-5187) were causing clusters deployed in provider mode to fail deployment, operator crashed while trying to change env var value which was not found.

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
