### PR TITLE
Added a fix to update bucketLogVolumes and bucketLogVolumeMounts in noobaa core pod

### DIFF
--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -72,7 +72,7 @@ type Reconciler struct {
 	ServiceAccount            *corev1.ServiceAccount
 	CoreApp                   *appsv1.StatefulSet
 	CoreAppConfig             *corev1.ConfigMap
-	DefaultCoreApp            *corev1.Container
+	DefaultCoreApp            *corev1.PodSpec
 	PostgresDBConf            *corev1.ConfigMap
 	NooBaaPostgresDB          *appsv1.StatefulSet
 	ServiceMgmt               *corev1.Service
@@ -301,7 +301,7 @@ func NewReconciler(
 	r.BucketLoggingVolume = r.Request.Name + "-bucket-logging-volume"
 	r.BucketLoggingVolumeMount = "/var/logs/bucket-logs"
 
-	r.DefaultCoreApp = r.CoreApp.Spec.Template.Spec.Containers[0].DeepCopy()
+	r.DefaultCoreApp = r.CoreApp.Spec.Template.Spec.DeepCopy()
 	r.DefaultDeploymentEndpoint = r.DeploymentEndpoint.Spec.Template.Spec.DeepCopy()
 
 	return r


### PR DESCRIPTION
### Explain the changes
1. Currently, bucketLogVolumes and bucketLogVolumeMounts are not updating in noobaa core pod once set with bucketLogging. Added a fix to update both of them with bucketLogging.

### Issues: Fixed #xxx / Gap #xxx
1. fix: https://bugzilla.redhat.com/show_bug.cgi?id=2302842
2. Improvement: #1371 

### Testing Instructions:
1. Try updating bucketLoggingPVC in bucketLogging or removing bucketLogging and check if both volumes and volumeMounts got updated in noobaa core.
