### PR TITLE
noobaa/operator: Provide option to disable log colors

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -91,6 +91,11 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_LOG_LEVEL
+            - name: NOOBAA_LOG_COLOR
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_LOG_COLOR
             - name: MGMT_ADDR
             - name: SYSLOG_ADDR
             - name: BG_ADDR

--- a/deploy/internal/pod-agent.yaml
+++ b/deploy/internal/pod-agent.yaml
@@ -23,6 +23,7 @@ spec:
           value: KUBERNETES
         - name: AGENT_CONFIG
         - name: NOOBAA_LOG_LEVEL
+        - name: NOOBAA_LOG_COLOR
       command: ["/noobaa_init_files/noobaa_init.sh", "agent"]
       # Insert the relevant image for the agent
       ports:

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -95,6 +95,11 @@ spec:
                   key: NOOBAA_LOG_LEVEL
             - name: RESTRICT_RESOURCE_DELETION
               value: "false"
+            - name: NOOBAA_LOG_COLOR
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_LOG_COLOR
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_PORT

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -1169,13 +1169,14 @@ func (r *Reconciler) needUpdate(pod *corev1.Pod) bool {
 		}
 	}
 
-	var noobaaLogEnv = "NOOBAA_LOG_LEVEL"
-	var configMapLogLevel = r.CoreAppConfig.Data[noobaaLogEnv]
-	noobaaLogEnvVar := util.GetEnvVariable(&c.Env, noobaaLogEnv)
+	for _, name := range []string{"NOOBAA_LOG_LEVEL", "NOOBAA_LOG_COLOR"} {
+		configMapValue := r.CoreAppConfig.Data[name]
+		noobaaLogEnvVar := util.GetEnvVariable(&c.Env, name)
 
-	if (configMapLogLevel != noobaaLogEnvVar.Value) {
-		r.Logger.Warnf("NOOBAA_LOG_LEVEL Env variable change detected: (%v) on the config map (%v)", noobaaLogEnvVar.Value, configMapLogLevel)
+		if configMapValue != noobaaLogEnvVar.Value {
+			r.Logger.Warnf("%s Env variable change detected: (%v) on the config map (%v)", name, noobaaLogEnvVar.Value, configMapValue)
 			return true
+		}
 	}
 
 	if c.Image != r.NooBaa.Status.ActualImage {
@@ -1288,6 +1289,8 @@ func (r *Reconciler) updatePodTemplate() error {
 			}
 		case "NOOBAA_LOG_LEVEL":
 			c.Env[j].Value = r.CoreAppConfig.Data["NOOBAA_LOG_LEVEL"]
+		case "NOOBAA_LOG_COLOR":
+			c.Env[j].Value = r.CoreAppConfig.Data["NOOBAA_LOG_COLOR"]
 		}
 	}
 	util.ReflectEnvVariable(&c.Env, "HTTP_PROXY")

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3852,7 +3852,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "a3825f23a13320c35024a33662e714010814b78dc774712a54ac503db8ea5dde"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "0784d71f1a50b8b2f216adb957ea4ce90392e39981bd584dd5e98272327a99c2"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -3947,6 +3947,11 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_LOG_LEVEL
+            - name: NOOBAA_LOG_COLOR
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_LOG_COLOR
             - name: MGMT_ADDR
             - name: SYSLOG_ADDR
             - name: BG_ADDR
@@ -4330,7 +4335,7 @@ spec:
       storage: 30Gi
 `
 
-const Sha256_deploy_internal_pod_agent_yaml = "7e3cfc034b4fc19567cdc429abaeb7726f69c728f5be360c15cb1a1951443d5d"
+const Sha256_deploy_internal_pod_agent_yaml = "0d3d438a85024b605e1d1b3587c0bf9522f7e30f187fdd0f1d607337e3df90d1"
 
 const File_deploy_internal_pod_agent_yaml = `apiVersion: v1
 kind: Pod
@@ -4357,6 +4362,7 @@ spec:
           value: KUBERNETES
         - name: AGENT_CONFIG
         - name: NOOBAA_LOG_LEVEL
+        - name: NOOBAA_LOG_COLOR
       command: ["/noobaa_init_files/noobaa_init.sh", "agent"]
       # Insert the relevant image for the agent
       ports:
@@ -4906,7 +4912,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "54acebc824f333be8b8e1b922ea031f2af13dbaf8775a8a5ac80e2ec8537cfd1"
+const Sha256_deploy_internal_statefulset_core_yaml = "447d0c9d6831eb9074e8648609614268430b4d0f89d618a4c9a250053f858290"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5005,6 +5011,11 @@ spec:
                   key: NOOBAA_LOG_LEVEL
             - name: RESTRICT_RESOURCE_DELETION
               value: "false"
+            - name: NOOBAA_LOG_COLOR
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_LOG_COLOR
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_PORT

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -1252,6 +1252,7 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 		"NOOBAA_DISABLE_COMPRESSION": "false",
 		"DISABLE_DEV_RANDOM_SEED":    "true",
 		"NOOBAA_LOG_LEVEL":           "default_level",
+		"NOOBAA_LOG_COLOR":           "true",
 	}
 	for key, value := range DefaultConfigMapData {
 		if _, ok := r.CoreAppConfig.Data[key]; !ok {


### PR DESCRIPTION
### Explain the changes

This patch is in sync with the changes on noobaa-core side.
https://github.com/noobaa/noobaa-core/pull/8281

We need to make sure a user can enable/disable the log color generated by core, endpoint and backing store.

### Fixes:
- Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2297435
