### PR TITLE
[Direct to 5.15] Handle empty initContainers array in postgres upgrade flow

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -1520,6 +1520,11 @@ func (r *Reconciler) ReconcileSetDbImageAndInitCode(targetImage string, initScri
 		podSpec := &r.NooBaaPostgresDB.Spec.Template.Spec
 		podSpec.ServiceAccountName = "noobaa"
 		if addInit {
+			if podSpec.InitContainers == nil {
+				var NooBaaDBTemplate *appsv1.StatefulSet = util.KubeObject(bundle.File_deploy_internal_statefulset_postgres_db_yaml).(*appsv1.StatefulSet)
+				podSpec.InitContainers = NooBaaDBTemplate.Spec.Template.Spec.InitContainers
+				podSpec.InitContainers[0].Image = targetImage
+			}
 			upgradeContainer := podSpec.InitContainers[0]
 			upgradeContainer.Name = "upgrade-db"
 			upgradeContainer.Command = []string{"sh", "-x", initScript}


### PR DESCRIPTION
### Explain the changes
1. Adding the "missing" initContainer right before accessing `podSpec.InitContainers` array.
2. In the [previous fix](https://github.com/noobaa/noobaa-operator/pull/1367), the init container was added to the DB reconcile, which happens after the upgrade flow. 

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2281839

### Testing Instructions:
1. install noobaa 4.14
2. stop the operator
3. remove the init container from DB sts
4. start the operator
5. upgrade to 4.15
6. before the fix, the operator would crash. after the fix, it should continue with the upgrade as expected

- [ ] Doc added/updated
- [ ] Tests added
