### PR TITLE
Added annotation to CSV capabilities="Seamless Upgrades"

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -249,6 +249,7 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 	csv.Annotations["operators.openshift.io/infrastructure-features"] = "ֿ'[\"disconnected\"]'"
 	// annotation for OpenShift AWS STS cluster
 	csv.Annotations["features.operators.openshift.io/token-auth-aws"] = "true"
+	csv.Annotations["capabilities"] = "Seamless Upgrades"
 	csv.Spec.Version.Version = semver.MustParse(version.Version)
 	csv.Spec.Description = bundle.File_deploy_olm_description_md
 	csv.Spec.Icon[0].Data = bundle.File_deploy_olm_noobaa_icon_base64


### PR DESCRIPTION
### Explain the changes
1. The capabilities annotation indicates the maturity level of the operator in the OLM
2. more details here: https://sdk.operatorframework.io/docs/overview/operator-capabilities/#level-2---seamless-upgrades


### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2303820

### Testing Instructions:
1. generate noobaa CSV. e.g.:
      ```
      make gen-odf-package csv-name="noobaa-operator.csv" core-image="noobaa/noobaa-core:5.10.0" db-image="centos/postgresql:12" operator-image="noobaa/noobaa-operator:5.10.0" obc-crd="none" psql-12-image="ttt"
      ```
2. check that the generated CSV has the `capabilities` annotation with `Seamless Upgrades` values

- [ ] Doc added/updated
- [ ] Tests added
