### PR TITLE
Updated forceMD5Etag to boolean pointer type

### DIFF
--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -70,7 +70,7 @@ type BucketInfo struct {
 	BucketType   string `json:"bucket_type"`
 	Mode         string `json:"mode"`
 	Undeletable  string `json:"undeletable"`
-	ForceMd5Etag bool   `json:"force_md5_etag"`
+	ForceMd5Etag *bool  `json:"force_md5_etag,omitempty"`
 
 	BucketClaim  *BucketClaimInfo   `json:"bucket_claim,omitempty"`
 	Tiering      *TieringPolicyInfo `json:"tiering,omitempty"`
@@ -340,7 +340,7 @@ type CreateSystemReply struct {
 type CreateBucketParams struct {
 	Name         string               `json:"name"`
 	Tiering      string               `json:"tiering,omitempty"`
-	ForceMd5Etag bool                 `json:"force_md5_etag,omitempty"`
+	ForceMd5Etag *bool                `json:"force_md5_etag,omitempty"`
 	BucketClaim  *BucketClaimInfo     `json:"bucket_claim,omitempty"`
 	Namespace    *NamespaceBucketInfo `json:"namespace,omitempty"`
 	Quota        *QuotaConfig         `json:"quota,omitempty"`
@@ -411,7 +411,7 @@ type CreateAccountParams struct {
 	S3Access          bool                    `json:"s3_access"`
 	AllowBucketCreate bool                    `json:"allow_bucket_creation"`
 	DefaultResource   string                  `json:"default_resource,omitempty"`
-	ForceMd5Etag      bool                    `json:"force_md5_etag,omitempty"`
+	ForceMd5Etag      *bool                   `json:"force_md5_etag,omitempty"`
 	BucketClaimOwner  string                  `json:"bucket_claim_owner,omitempty"`
 	NsfsAccountConfig *nbv1.AccountNsfsConfig `json:"nsfs_account_config,omitempty"`
 }

--- a/pkg/noobaaaccount/noobaaaccount.go
+++ b/pkg/noobaaaccount/noobaaaccount.go
@@ -182,7 +182,10 @@ func RunCreate(cmd *cobra.Command, args []string) {
 	defaultResource, _ := cmd.Flags().GetString("default_resource")
 
 	nsfsAccountConfig, _ := cmd.Flags().GetBool("nsfs_account_config")
-	forceMd5Etag, _ := cmd.Flags().GetBool("force_md5_etag")
+	forceMd5EtagPtr, err := util.GetBoolFlagPtr(cmd, "force_md5_etag")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	newBucketsPath, _ := cmd.Flags().GetString("new_buckets_path")
 	nsfsOnly, _ := cmd.Flags().GetBool("nsfs_only")
@@ -198,7 +201,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 	noobaaAccount.Name = name
 	noobaaAccount.Namespace = options.Namespace
 	noobaaAccount.Spec.AllowBucketCreate = allowBucketCreate
-	noobaaAccount.Spec.ForceMd5Etag = &forceMd5Etag
+	noobaaAccount.Spec.ForceMd5Etag = forceMd5EtagPtr
 
 	if nsfsAccountConfig {
 		nsfsUID := util.GetFlagIntOrPrompt(cmd, "uid")
@@ -240,7 +243,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 
 	noobaaAccount.Spec.DefaultResource = defaultResource
 
-	err := util.KubeClient().Get(util.Context(), util.ObjectKey(noobaaAccount), noobaaAccount)
+	err = util.KubeClient().Get(util.Context(), util.ObjectKey(noobaaAccount), noobaaAccount)
 	if err == nil {
 		log.Fatalf(`❌ noobaaAccount %q already exists in namespace %q`, noobaaAccount.Name, noobaaAccount.Namespace)
 	}
@@ -272,10 +275,9 @@ func RunUpdate(cmd *cobra.Command, args []string) {
 	name := args[0]
 
 	newDefaultResource := util.GetFlagStringOrPrompt(cmd, "new_default_resource")
-	var forceMd5EtagPtr *bool = nil
-	if cmd.Flags().Changed("force_md5_etag") {
-		forceMd5Etag, _ := cmd.Flags().GetBool("force_md5_etag")
-		forceMd5EtagPtr = &forceMd5Etag
+	forceMd5EtagPtr, err := util.GetBoolFlagPtr(cmd, "force_md5_etag")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	o := util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_noobaaaccount_cr_yaml)

--- a/pkg/noobaaaccount/reconciler.go
+++ b/pkg/noobaaaccount/reconciler.go
@@ -338,7 +338,7 @@ func (r *Reconciler) CreateNooBaaAccount() error {
 		DefaultResource:   r.NooBaaAccount.Spec.DefaultResource,
 		HasLogin:          false,
 		S3Access:          true,
-		ForceMd5Etag:      *r.NooBaaAccount.Spec.ForceMd5Etag,
+		ForceMd5Etag:      r.NooBaaAccount.Spec.ForceMd5Etag,
 		AllowBucketCreate: r.NooBaaAccount.Spec.AllowBucketCreate,
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1238,6 +1238,19 @@ func GetFlagStringOrPromptPassword(cmd *cobra.Command, flag string) string {
 	return str
 }
 
+// GetBoolFlagPtr returns a pointer to the boolean flag value if set, or nil if not set
+func GetBoolFlagPtr(cmd *cobra.Command, flag string) (*bool, error) {
+	if cmd.Flags().Changed(flag) {
+		flagVal, err := cmd.Flags().GetBool(flag)
+		if err != nil {
+			return nil, err
+		}
+		return &flagVal, nil
+	}
+
+	return nil, nil
+}
+
 // PrintThisNoteWhenFinishedApplyingAndStartWaitLoop is a common log task
 func PrintThisNoteWhenFinishedApplyingAndStartWaitLoop() {
 	log := Logger()


### PR DESCRIPTION
### Explain the changes
1. Updated forceMd5Etag to a Boolean Pointer Type (*bool): The forceMd5Etag flag is now handled as a pointer to a boolean (*bool) to explicitly track whether the flag was provided by the user:

- If the flag was set, forceMd5Etag points to a true or false value. 
- If the flag was not set, forceMd5Etag remains nil, preventing unintended changes to the ForceMd5Etag field.

### Issues: Fixed #xxx / Gap #xxx
1. Improvement: #1215 
2. BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2312533

### Testing Instructions:
1. Try creating and updating the bucket using cli.
2. Try creating and updating the NoobaaAccount using cli and yaml both.
