### PR TITLE
[Backport into 5.16] Disabling lint as a quick fix to release the CI flow. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,15 +177,7 @@ golangci-lint: gen
 .PHONY: golangci-lint
 
 lint: gen
-	GO111MODULE=off go get -u -a golang.org/x/lint/golint
-	GO111MODULE=off go install -a golang.org/x/lint/golint
-	GO111MODULE=off go run golang.org/x/lint/golint \
-		-set_exit_status=1 \
-		$$(go list ./... | cut -d'/' -f5- | sed 's/^\(.*\)$$/\.\/\1\//' | grep -v ./pkg/apis/noobaa/v1alpha1/ | grep -v ./pkg/bundle/)
-	@echo
-	GO111MODULE=off go run golang.org/x/lint/golint \
-		-set_exit_status=1 \
-		$$(echo ./pkg/apis/noobaa/v1alpha1/* | tr ' ' '\n' | grep -v '/zz_generated')
+	@echo "Lint is deprecated and failing due to a dependency. Disabling it as a quick fix to release the CI flow."
 	@echo "✅ lint"
 .PHONY: lint
 


### PR DESCRIPTION
### Explain the changes
Lint is deprecated and failing due to a dependency. 
Disabling it as a quick fix to release the CI flow.

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit c0948d3d7f548124f25b68bdd3f2aec7c247bf9f)
