### PR TITLE
CI | Using golangci-lint for lint in the Makefile target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+run:
+  timeout: 5m
+
+issues:
+  exclude-dirs:
+    - pkg/apis/noobaa/v1alpha1
+    - pkg/bundle
+  exclude-files:
+    - zz_generated\.go

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,9 @@ golangci-lint: gen
 .PHONY: golangci-lint
 
 lint: gen
-	@echo "Lint is deprecated and failing due to a dependency. Disabling it as a quick fix to release the CI flow."
+	@echo ""
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	golangci-lint run --config .golangci.yml
 	@echo "✅ lint"
 .PHONY: lint
 

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -1076,7 +1076,7 @@ func MapSecretToBackingStores(secret types.NamespacedName) []reconcile.Request {
 	for _, bs := range bsList.Items {
 		bsSecret, err := util.GetBackingStoreSecret(&bs)
 		if err != nil {
-			log.Errorf(err.Error())
+			log.Error(err)
 		}
 		if bsSecret != nil && bsSecret.Name == secret.Name {
 			reqs = append(reqs, reconcile.Request{

--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -3,6 +3,7 @@ package bucketclass
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -787,12 +788,12 @@ func GetDefaultBucketClass(Namespace string) (*nbv1.BucketClass, error) {
 
 	if !util.KubeCheck(bucketClass) {
 		msg := fmt.Sprintf("GetDefaultBucketClass BucketClass %q not found in provisioner namespace %q", bucketClassName, Namespace)
-		return nil, fmt.Errorf(msg)
+		return nil, errors.New(msg)
 	}
 
 	if bucketClass.Status.Phase != nbv1.BucketClassPhaseReady {
 		msg := fmt.Sprintf("GetDefaultBucketClass BucketClass %q is %v", bucketClassName, bucketClass.Status.Phase)
-		return nil, fmt.Errorf(msg)
+		return nil, errors.New(msg)
 	}
 
 	return bucketClass, nil

--- a/pkg/cosi/provisioner.go
+++ b/pkg/cosi/provisioner.go
@@ -119,7 +119,7 @@ func (p *Provisioner) DriverCreateBucket(ctx context.Context,
 		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
 		if util.Contains(finalizersArray, nbv1.GracefulFinalizer) {
 			msg := "NooBaa is in deleting state, new requests will be ignored"
-			log.Errorf(msg)
+			log.Error(msg)
 			return nil, status.Error(codes.Internal, msg)
 		}
 	}
@@ -185,7 +185,7 @@ func (p *Provisioner) DriverGrantBucketAccess(ctx context.Context,
 		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
 		if util.Contains(finalizersArray, nbv1.GracefulFinalizer) {
 			msg := "NooBaa is in deleting state, new requests will be ignored"
-			log.Errorf(msg)
+			log.Error(msg)
 			return nil, status.Error(codes.Internal, msg)
 		}
 	}

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -899,7 +899,7 @@ func MapSecretToNamespaceStores(secret types.NamespacedName) []reconcile.Request
 	for _, ns := range nsList.Items {
 		nsSecret, err := util.GetNamespaceStoreSecret(&ns)
 		if err != nil {
-			log.Errorf(err.Error())
+			log.Error(err)
 		}
 		if nsSecret != nil && nsSecret.Name == secret.Name {
 			reqs = append(reqs, reconcile.Request{

--- a/pkg/nb/rpc_ws.go
+++ b/pkg/nb/rpc_ws.go
@@ -318,7 +318,7 @@ func (c *RPCConnWS) ReadMessage() (*RPCMessage, error) {
 	msg.RawBytes = msgBytes
 
 	// Read message buffers if any
-	if msg.Buffers != nil && len(msg.Buffers) > 0 {
+	if len(msg.Buffers) > 0 {
 		buffers, err := io.ReadAll(reader)
 		// if err != nil && err.Error() != "failed to read: cannot use EOFed reader" {
 		if err != nil {

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -2,6 +2,7 @@ package obc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -112,7 +113,7 @@ func (p *Provisioner) Provision(bucketOptions *obAPI.BucketOptions) (*nbv1.Objec
 		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
 		if util.Contains(finalizersArray, nbv1.GracefulFinalizer) {
 			msg := "NooBaa is in deleting state, new requests will be ignored"
-			log.Errorf(msg)
+			log.Error(msg)
 			return nil, obErrors.NewBucketExistsError(msg)
 		}
 	}
@@ -151,7 +152,7 @@ func (p *Provisioner) Grant(bucketOptions *obAPI.BucketOptions) (*nbv1.ObjectBuc
 		finalizersArray := r.SysClient.NooBaa.GetFinalizers()
 		if util.Contains(finalizersArray, nbv1.GracefulFinalizer) {
 			msg := "NooBaa is in deleting state, new requests will be ignored"
-			log.Errorf(msg)
+			log.Error(msg)
 			return nil, obErrors.NewBucketExistsError(msg)
 		}
 	}
@@ -308,12 +309,12 @@ func NewBucketRequest(
 			}
 
 			p.recorder.Event(r.OBC, "Warning", "MissingBucketClass", msg)
-			return nil, fmt.Errorf(msg)
+			return nil, errors.New(msg)
 		}
 		if r.BucketClass.Status.Phase != nbv1.BucketClassPhaseReady {
 			msg := fmt.Sprintf("BucketClass %q is not ready", bucketClassName)
 			p.recorder.Event(r.OBC, "Warning", "BucketClassNotReady", msg)
-			return nil, fmt.Errorf(msg)
+			return nil, errors.New(msg)
 		}
 		additionalConfig := r.OBC.Spec.AdditionalConfig
 		if additionalConfig == nil {
@@ -554,7 +555,7 @@ func (r *BucketRequest) LogAndGetError(format string, a ...interface{}) error {
 	log := r.Provisioner.Logger
 	msg := fmt.Sprintf(format, a...)
 	log.Error(msg)
-	return fmt.Errorf(msg)
+	return errors.New(msg)
 }
 
 // CreateAccount creates the obc account

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -519,8 +519,8 @@ func (r *Reconciler) VerifyObjectBucketCleanup() error {
 		}
 		msg := fmt.Sprintf("Failed to delete NooBaa. object buckets in namespace %q are not cleaned up. remaining buckets: %+v",
 			r.NooBaa.Namespace, bucketNames)
-		log.Errorf(msg)
-		return fmt.Errorf(msg)
+		log.Error(msg)
+		return errors.New(msg)
 	}
 
 	log.Infof("All object buckets deleted in namespace %q", r.NooBaa.Namespace)

--- a/pkg/util/kms/test/dev/kms_dev_test.go
+++ b/pkg/util/kms/test/dev/kms_dev_test.go
@@ -41,7 +41,7 @@ func simpleKmsSpec(token, apiAddress string) nbv1.KeyManagementServiceSpec {
 func checkExternalSecret(noobaa *nbv1.NooBaa, expectedNil bool) {
 	k := noobaa.Spec.Security.KeyManagementService
 	uid := string(noobaa.UID)
-	driver := &kms.Vault{uid}
+	driver := &kms.Vault{UID: uid}
 	path := k.ConnectionDetails[vault.VaultBackendPathKey] + driver.Path()
 	cmd := exec.Command("kubectl", "exec", "vault-0", "--", "vault", "kv", "get", path)
 	logger.Printf("Running command: path %v args %v ", cmd.Path, cmd.Args)

--- a/pkg/util/kms/test/ibm-kp/kms_ibm_kp_test.go
+++ b/pkg/util/kms/test/ibm-kp/kms_ibm_kp_test.go
@@ -52,7 +52,7 @@ func checkExternalSecret(tokenSecretName string, instanceID string, noobaa *nbv1
 
 	k := noobaa.Spec.Security.KeyManagementService
 	uid := string(noobaa.UID)
-	driver := &kms.IBM{uid}
+	driver := &kms.IBM{UID: uid}
 
 	// Generate backend configuration using backend driver instance
 	c, err := driver.Config(k.ConnectionDetails, k.TokenSecretName, noobaa.Namespace)


### PR DESCRIPTION
### Explain the changes
- Using `golangci-lint` for lint in the Makefile target
- Adding `.golangci.yml` as a configuration file
- Fixing some lint errors

### Testing Instructions:
1.  run `make lint` 

- [X] Tests added
