### PR TITLE
Added a CLI sub-command in noobaa diagnostics to print proxy details

### DIFF
--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -24,6 +24,7 @@ func Cmd() *cobra.Command {
 		CmdCollect(),
 		CmdDbDump(),
 		CmdAnalyze(),
+		CmdReport(),
 	)
 	return cmd
 }
@@ -64,6 +65,17 @@ func CmdAnalyze() *cobra.Command {
 		CmdAnalyzeNamespaceStore(),
 		CmdAnalyzeResources(),
 	)
+	return cmd
+}
+
+// CmdReport returns a CLI command
+func CmdReport() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report",
+		Short: "Run reports of the status and setup",
+		Run:   RunReport,
+		Args:  cobra.NoArgs,
+	}
 	return cmd
 }
 

--- a/pkg/diagnostics/report.go
+++ b/pkg/diagnostics/report.go
@@ -1,0 +1,43 @@
+package diagnostics
+
+import (
+	"fmt"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/bundle"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// RunReport runs a CLI command
+func RunReport(cmd *cobra.Command, args []string) {
+
+	// retrieving the status of proxy environment variables
+	proxyStatus()
+
+	// TODO: Add support for additional features
+}
+
+// proxyStatus returns the status of the environment variables: HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
+func proxyStatus() {
+	log := util.Logger()
+
+	log.Print("⏳ Retrieving proxy environment variable details...\n")
+	coreApp := util.KubeObject(bundle.File_deploy_internal_statefulset_core_yaml).(*appsv1.StatefulSet)
+	coreApp.Namespace = options.Namespace
+	if !util.KubeCheck(coreApp) {
+		log.Fatalf(`❌ Could not get core StatefulSet %q in Namespace %q`,
+			coreApp.Name, coreApp.Namespace)
+	}
+
+	fmt.Print("\nProxy Environment Variables Check:\n----------------------------------\n")
+	for _, proxyName := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+		envVar := util.GetEnvVariable(&coreApp.Spec.Template.Spec.Containers[0].Env, proxyName)
+		if envVar != nil && envVar.Value != "" {
+			fmt.Printf("	✅ %-12s : %s\n", envVar.Name, envVar.Value)
+		} else {
+			fmt.Printf("	❌ %-12s : not set or empty.\n", proxyName)
+		}
+	}
+}


### PR DESCRIPTION
### Explain the changes
1. The CLI command checks and logs the values of essential environment variables related to proxy configuration (HTTP_PROXY, HTTPS_PROXY, NO_PROXY). It performs the following actions:

    Checks: Verifies if these proxy environment variables are set and not empty.

This implementation currently focuses on proxy environment variables but is designed with future expansion in mind. Additional checks and diagnostics will be introduced in the future.

![Screenshot from 2024-09-17 17-48-53](https://github.com/user-attachments/assets/815ac1bb-3982-4bff-8bc1-4be0aaf8fad2)



### Issues: Fixed #xxx / Gap #xxx
1. BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2302136

### Testing Instructions:
1. Try running noobaa cli  command `noobaa diagnostics report` to check the proxy status. 

**Note:** Use the command `kubectl set env deployment/noobaa-operator -c noobaa-operator HTTP_PROXY=localhost:8080` to update the proxy vars.
