### PR TITLE
Remove hardcoded namespace from rolebinding

### DIFF
--- a/deploy/role_binding_core.yaml
+++ b/deploy/role_binding_core.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: noobaa-core
-  namespace: openshift-storage
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: noobaa-core
-  namespace: openshift-storage

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -6310,13 +6310,12 @@ subjects:
   name: custom-metrics-prometheus-adapter
 `
 
-const Sha256_deploy_role_binding_core_yaml = "99b90a402f770a4c3e7b1bb36c4e9175341f1697ff68a8ff3b121b43ef4d69d5"
+const Sha256_deploy_role_binding_core_yaml = "23dd0d60002ea999cc9f7e10fb3a8000e2c19f8a3ee27971f443acd06f698729"
 
 const File_deploy_role_binding_core_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: noobaa-core
-  namespace: openshift-storage
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -6324,7 +6323,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: noobaa-core
-  namespace: openshift-storage
 `
 
 const Sha256_deploy_role_binding_db_yaml = "3a4872fcde50e692ae52bbd208a8e1d115c574431c25a9644a7c820ae13c7748"


### PR DESCRIPTION
### Explain the changes
The PR removes hardcoded namespace from rolebinding. Without this, core pod loses its elevated privileges ultimately failing to perform internally some kubectl operations (eg. required to get connection details).

- [ ] Doc added/updated
- [ ] Tests added
