### PR TITLE
NOOBAA_LOG_COLOR  - Add check env var is not null

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -1173,8 +1173,8 @@ func (r *Reconciler) needUpdate(pod *corev1.Pod) bool {
 		configMapValue := r.CoreAppConfig.Data[name]
 		noobaaLogEnvVar := util.GetEnvVariable(&c.Env, name)
 
-		if configMapValue != noobaaLogEnvVar.Value {
-			r.Logger.Warnf("%s Env variable change detected: (%v) on the config map (%v)", name, noobaaLogEnvVar.Value, configMapValue)
+		if (noobaaLogEnvVar == nil && configMapValue != "") || (noobaaLogEnvVar != nil && configMapValue != noobaaLogEnvVar.Value) {
+			r.Logger.Warnf("%s Env variable change detected: (%v) on the config map (%v)", name, noobaaLogEnvVar, configMapValue)
 			return true
 		}
 	}


### PR DESCRIPTION
### Explain the changes
1.  When we upgrade between versions with NOOBAA_LOG_COLOR from one with none. it's possible that the pod won't have this env var and will return null, in this case we will get segmentation fault
2. fixed to check if null; if so, don't check the value.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
