### PR TITLE
Add support for AllNamespaces install mode

### DIFF
--- a/deploy/olm/noobaa-operator.clusterserviceversion.yaml
+++ b/deploy/olm/noobaa-operator.clusterserviceversion.yaml
@@ -60,7 +60,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   install:
     strategy: deployment


### PR DESCRIPTION
### Explain the changes
1.  OCS client operator is deployed in all namespace install mode
2. OCS client operator depends on NooBaa operator
3. For OLM to be able to get NooBaa operator as a dependency of OCS client operator, noobaa operator need to mark itself as supporting all namespace install mode

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
