### PR TITLE
Add support for AllNamespaces install mode

### DIFF
--- a/deploy/olm/noobaa-operator.clusterserviceversion.yaml
+++ b/deploy/olm/noobaa-operator.clusterserviceversion.yaml
@@ -60,7 +60,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   install:
     strategy: deployment

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5907,7 +5907,7 @@ s3 ls s3://first.bucket
 ` + "`" + `` + "`" + `` + "`" + `
 `
 
-const Sha256_deploy_olm_noobaa_operator_clusterserviceversion_yaml = "900ed615837a7f63510de5bff4bd8ffdcc02bea8cec0cf231d21e32812f78ed7"
+const Sha256_deploy_olm_noobaa_operator_clusterserviceversion_yaml = "3b11ab7cce6a4dfc36ad13f75b37821c8e200aec4cf21007208948e74ce9cc44"
 
 const File_deploy_olm_noobaa_operator_clusterserviceversion_yaml = `apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
@@ -5971,7 +5971,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   install:
     strategy: deployment


### PR DESCRIPTION
### Explain the changes
1. Update Noobaa operator CSV to install on all Namespaces
2. OCS client operator has a dependency on Noobaa operator, but noobaa operator doesn't allow to install on all namespaces.This patch fixes the above

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2314211

### Testing Instructions:
1. Noobaa operator should get installed on all namespaces

- [ ] Doc added/updated
- [ ] Tests added
