### PR TITLE
Fix #432: Change db service to headless needed to get direct pod dns name on GKE

### DIFF
--- a/deploy/internal/service-db.yaml
+++ b/deploy/internal/service-db.yaml
@@ -8,7 +8,7 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: "noobaa-db-serving-cert"
     service.alpha.openshift.io/serving-cert-secret-name: "noobaa-db-serving-cert"
 spec:
-  type: ClusterIP
+  clusterIP: None # headless service
   selector:
     noobaa-db: SYSNAME
   ports:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4771,7 +4771,7 @@ type: Opaque
 data: {}
 `
 
-const Sha256_deploy_internal_service_db_yaml = "7bf9f8bd18c07c5d768392f2bdfcac7f3398c1137eecb0f48983f468234a5a96"
+const Sha256_deploy_internal_service_db_yaml = "ad9f76ccec1a38c07af34d0251e9e3f3d64bfad48ebaebbdfeef653af1e6eafc"
 
 const File_deploy_internal_service_db_yaml = `apiVersion: v1
 kind: Service
@@ -4783,7 +4783,7 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: "noobaa-db-serving-cert"
     service.alpha.openshift.io/serving-cert-secret-name: "noobaa-db-serving-cert"
 spec:
-  type: ClusterIP
+  clusterIP: None # headless service
   selector:
     noobaa-db: SYSNAME
   ports:


### PR DESCRIPTION
### Explain the changes
1. Without this on GKE we don't get the DNS name of the pod created `noobaa-db-pg-0.noobaa-db-pg.<namespace>.svc`
2. see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields
3. see https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
4. For some reason on Openshift this works also for non-headless service, but on GKE it won't generate the DNS for the pods unless it's headless (see with kubectl get endpointslices).

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #432

### Testing Instructions:
1. Deploy on GKE
