### PR TITLE
Fix Bug BZ 2320939 | Update AWS Regions

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1153,6 +1153,7 @@ func GetAWSRegion() (string, error) {
 		"ap-southeast-2": "ap-southeast-2",
 		"ap-southeast-3": "ap-southeast-3",
 		"ap-southeast-4": "ap-southeast-4",
+		"ap-southeast-5": "ap-southeast-5",
 		"ap-south-1":     "ap-south-1",
 		"ap-south-2":     "ap-south-2",
 		"me-south-1":     "me-south-1",


### PR DESCRIPTION
### Explain the changes
1. Update AWS regions - add `ap-southeast-5` (it was added lately, see [here](https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-malaysia-region/)).

### Issues: Fixed [BZ 2320939](https://bugzilla.redhat.com/show_bug.cgi?id=2320939)
1. Update AWS regions.

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added
