### PR TITLE
Docs | STS | Update Docs (Noobaa Core Service Account Name Changed)

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         noobaa.io/configmap-hash: ""
     spec:
+        # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa-endpoint
       volumes:
         - name: mgmt-secret

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         noobaa.io/configmap-hash: ""
     spec:
+    # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa-core
       volumes:
         - name: logs

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,6 +13,7 @@ spec:
         app: noobaa
         noobaa-operator: deployment
     spec:
+        # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa
       securityContext:
         seccompProfile:

--- a/doc/dev_guide/create_aws_role.sh
+++ b/doc/dev_guide/create_aws_role.sh
@@ -15,8 +15,9 @@ ROLE_NAME="shira-28-11" # role name that you pick in your AWS account (replace s
 NAMESPACE="test1" # namespace name where noobaa will be running (replace test1 with your value)
 
 # noobaa variables
-SERVICE_ACCOUNT_NAME_1="noobaa" # The service account name of statefulset core and deployment operator
+SERVICE_ACCOUNT_NAME_1="noobaa" # The service account name of deployment operator
 SERVICE_ACCOUNT_NAME_2="noobaa-endpoint" # The service account name of deployment endpoint
+SERVICE_ACCOUNT_NAME_3="noobaa-core" # The service account name of statefulset core
 
 # AWS variables
 # Please make sure these values are not empty (AWS_ACCOUNT_ID, OIDC_PROVIDER)
@@ -47,8 +48,9 @@ read -r -d '' TRUST_RELATIONSHIP <<EOF
      "Condition": {
        "StringEquals": {
         "${OIDC_PROVIDER}:sub": [
-          "system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT_NAME_1}", 
-          "system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT_NAME_2}"
+          "system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT_NAME_1}",
+          "system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT_NAME_2}",
+          "system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT_NAME_3}"
           ]
        }
      }

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3820,7 +3820,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "0784d71f1a50b8b2f216adb957ea4ce90392e39981bd584dd5e98272327a99c2"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "21b206c9119e37c4ebba84d5c1e2b1d45b06c716b4def69db9ba9268ef75e1e1"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -3846,6 +3846,7 @@ spec:
       annotations:
         noobaa.io/configmap-hash: ""
     spec:
+        # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa-endpoint
       volumes:
         - name: mgmt-secret
@@ -4880,7 +4881,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "447d0c9d6831eb9074e8648609614268430b4d0f89d618a4c9a250053f858290"
+const Sha256_deploy_internal_statefulset_core_yaml = "50e5b11d8e0a2f2bb8a6db8d154b34b6569e160fa7ad2b1fb154001b36c8a152"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -4905,6 +4906,7 @@ spec:
       annotations:
         noobaa.io/configmap-hash: ""
     spec:
+    # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa-core
       volumes:
         - name: logs
@@ -5955,7 +5957,7 @@ spec:
   sourceNamespace: default
 `
 
-const Sha256_deploy_operator_yaml = "f1d3f744af5e55b5476c085c10425f93837cf0bdf39d206f3857d3c5e9bc6c78"
+const Sha256_deploy_operator_yaml = "5399fbfcd1c421acd978f2762d6f8c5048d68fb3c5acc79a595d62cd035a3bc0"
 
 const File_deploy_operator_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -5972,6 +5974,7 @@ spec:
         app: noobaa
         noobaa-operator: deployment
     spec:
+        # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa
       securityContext:
         seccompProfile:


### PR DESCRIPTION
### Explain the changes
1. In PR #1391 the service account name of `statefulset-core.yaml` was changed from "noobaa" to 'noobaa-core" (see [here](https://github.com/noobaa/noobaa-operator/pull/1391/files#diff-d3a8aafe07a48415e712a53978cd91e809e3f05496824cdea7f2948e2b2fd951L24)), hence we update the existing docs  related to AWS STS.
2. Added a comment near the service account name, in case someone would change it so it would know that there additional actions and impact on users of existing deployed AWS STS clusters for this change.
3. Added a section in the troubleshooting for such case, or for partial trust policy (that doesn't have the new service account).

### Issues:
1. Was raised as a part of [BZ 2322124](https://bugzilla.redhat.com/show_bug.cgi?id=2322124).
2. GAP - worth improving the of the variables name in the doc script (as mention in the [comment below](https://github.com/noobaa/noobaa-operator/pull/1466#discussion_r1820372039)).

### Testing Instructions:
1. none

- [X] Doc added/updated
- [ ] Tests added
