### PR TITLE
Adapting operator to new bucket list API change

### DIFF
--- a/pkg/bucket/bucket.go
+++ b/pkg/bucket/bucket.go
@@ -239,7 +239,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 func RunList(cmd *cobra.Command, args []string) {
 	log := util.Logger()
 	nbClient := system.GetNBClient()
-	list, err := nbClient.ListBucketsAPI()
+	list, err := nbClient.ListBucketsAPI(nb.ListBucketsParams{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -19,7 +19,7 @@ type Client interface {
 	SetNamespaceStoreInfo(NamespaceStoreInfo) error
 
 	ListAccountsAPI(ListAccountsParams) (ListAccountsReply, error)
-	ListBucketsAPI() (ListBucketsReply, error)
+	ListBucketsAPI(ListBucketsParams) (ListBucketsReply, error)
 	ListHostsAPI(ListHostsParams) (ListHostsReply, error)
 
 	CreateAuthAPI(CreateAuthParams) (CreateAuthReply, error)
@@ -146,8 +146,8 @@ func (c *RPCClient) ListAccountsAPI(params ListAccountsParams) (ListAccountsRepl
 }
 
 // ListBucketsAPI calls bucket_api.list_buckets()
-func (c *RPCClient) ListBucketsAPI() (ListBucketsReply, error) {
-	req := &RPCMessage{API: "bucket_api", Method: "list_buckets"}
+func (c *RPCClient) ListBucketsAPI(params ListBucketsParams) (ListBucketsReply, error) {
+	req := &RPCMessage{API: "bucket_api", Method: "list_buckets", Params: params}
 	res := &struct {
 		RPCMessage `json:",inline"`
 		Reply      ListBucketsReply `json:"reply"`

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -283,6 +283,12 @@ type ListAccountsReply struct {
 	Accounts []*AccountInfo `json:"accounts"`
 }
 
+// ListBcuketsParams is the params to account_api.list_buckets()
+type ListBucketsParams struct {
+	ContinuationToken *string `json:"continuation_token,omitempty"`
+	MaxBuckets *int `json:"max_buckets,omitempty"`
+}
+
 // ListBucketsReply is the reply of bucket_api.list_buckets()
 type ListBucketsReply struct {
 	Buckets []struct {


### PR DESCRIPTION
### Explain the changes
1. After changing the api for list buckets, we need to update operator to support it as well otherwise nb api will fail listing the buckets
2. Adding the new params to the API
3. updating the list bucket nb cli command to support the new params

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-822

### Testing Instructions:
1. run the scenario in the bug: noobaa-cli bucket list
2. make sure you see the buckets and no schema errors appear

- [ ] Doc added/updated
- [ ] Tests added
