### PR TITLE
nsfs - add mounted nsr name to env. DFBUGS-153

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -617,6 +617,15 @@ func (r *Reconciler) setDesiredEndpointMounts(podSpec *corev1.PodSpec, container
 					SubPath:   subPath,
 				})
 			}
+
+			//this is a way to let containers explicitly know
+			//that an nsr should be mounted on them
+			envVar := corev1.EnvVar{
+				Name: "NSFS_NSR_" + nsStore.Name,
+				Value: "mounted",
+			}
+
+			util.MergeEnvArrays(&container.Env, &[]corev1.EnvVar{envVar});
 		}
 	}
 


### PR DESCRIPTION
### Explain the changes
1. Add an env variable for each nsfs nsr mount.
This way endpoints have a way to tell whether an nsr (that they get from system store) should be mounted or not.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Reduce config.NAMESPACE_MONITOR_DELAY to 1000ms.
2. Create nsfs nsr
3. nsr should not be rejected (by endpoints existing before its creation).

- [ ] Doc added/updated
- [ ] Tests added
