### PR TITLE
Noobaa/Operator: Display error message

### DIFF
--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -425,6 +425,11 @@ func RunDelete(cmd *cobra.Command, args []string) {
 	bucketClass.Name = args[0]
 	bucketClass.Namespace = options.Namespace
 
+	if !util.KubeCheck(bucketClass) {
+		log.Fatalf(`❌ Could not delete, BucketClass %q in namespace %q does not exist`,
+			bucketClass.Name, bucketClass.Namespace)
+	}
+
 	if !util.KubeDelete(bucketClass) {
 		log.Fatalf(`❌ Could not delete BucketClass %q in namespace %q`,
 			bucketClass.Name, bucketClass.Namespace)

--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -147,7 +147,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 		log.Fatalf(`❌ NSFS account config must include both UID and GID as positive integers`)
 	}
 
-	if bucketClassName == "" && ( gid > -1 || uid > -1 || distinguishedName != "" ) {
+	if bucketClassName == "" && (gid > -1 || uid > -1 || distinguishedName != "") {
 		log.Fatalf(`❌ NSFS account config cannot be set without an NSFS bucketclass`)
 	}
 
@@ -330,6 +330,10 @@ func RunDelete(cmd *cobra.Command, args []string) {
 	obc := o.(*nbv1.ObjectBucketClaim)
 	obc.Name = args[0]
 	obc.Namespace = appNamespace
+
+	if !util.KubeCheck(obc) {
+		log.Fatalf(`❌ Could not delete. OBC %q in namespace %q does not exist`, obc.Name, obc.Namespace)
+	}
 
 	if !util.KubeDelete(obc) {
 		log.Fatalf(`❌ Could not delete OBC %q in namespace %q`,

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -965,13 +965,11 @@ function delete_backingstore_path {
 
 function delete_namespacestore_path {
     local object_bucket namespace_store
-    test_noobaa obc delete ${obc[2]}
-    test_noobaa bucketclass delete ${bucketclass[2]}
     local namespacestore=($(test_noobaa silence namespacestore list | grep -v "NAME" | awk '{print $1}'))
     local bucketclass=($(test_noobaa silence bucketclass list | grep -v "NAME" | awk '{print $1}'))
     local obc=()
     local all_obc=($(test_noobaa silence obc list | grep -v "BUCKET-NAME" | awk '{print $2":"$5}'))
-    
+
     # get obcs that their bucketclass is in bucketclass array
     for object_bucket in ${all_obc[@]}
     do


### PR DESCRIPTION
While deleting OBC or Bucketclass which does not exist, we should display an error message and should not silently give success.
https://issues.redhat.com/browse/DFBUGS-201
As part of this I have also modified test_cli_functions.sh
Test under "delete_namespacestore_path" function was failing because we do not have a bucket which we are trying to delete. It was passing silently. In this function we are fetching the list of bucketclass and obc freshly and deleting those objects. I think that should cover the cases.