### PR TITLE
Bug-fix for fetching region from AWS cluster obj in GetAWSRegion()

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -183,3 +183,11 @@ rules:
       - delete
       - update
       - create
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+    verbs:
+      - get
+      - list
+      - watch

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2,7 +2,7 @@ package bundle
 
 const Version = "5.18.0"
 
-const Sha256_deploy_cluster_role_yaml = "3f8118853db73926c4f9d14be84ac8f81833c3a7a94a52ecf1e9ebcf712eee93"
+const Sha256_deploy_cluster_role_yaml = "31fc622ff7fa66617be3895bddcb6cfdb97883b75b20bdb2bf04052bd14221a8"
 
 const File_deploy_cluster_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -189,6 +189,14 @@ rules:
       - delete
       - update
       - create
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+    verbs:
+      - get
+      - list
+      - watch
 `
 
 const Sha256_deploy_cluster_role_binding_yaml = "15c78355aefdceaf577bd96b4ae949ae424a3febdc8853be0917cf89a63941fc"


### PR DESCRIPTION
### Explain the changes
1. Root Cause: The problem arises when the AWS cluster region cannot be determined from node names, especially in cases where the node naming convention does not include the region or when the DHCP option modifies DNS settings, causing standard parsing methods to fail.

2. Solution: To resolve this, the solution first attempts to fetch the region directly from the cluster configuration, which is the most reliable source. If this fails, it falls back to parsing the region from the node name.

### Issues: Fixed #xxx / Gap #xxx
1. Bug: https://issues.redhat.com/browse/DFBUGS-747

### Testing Instructions:
1. Install noobaa operator on AWS cluster and check for default backingstore creation with DHCP option set and not set.
