### PR TITLE
Bucket Notification - connect filename simplification

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -568,7 +568,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 				for _, notifSecret := range r.NooBaa.Spec.BucketNotifications.Connections {
 					secretVolumeMounts := []corev1.VolumeMount{{
 						Name:      notifSecret.Name,
-						MountPath: "/etc/notif_connect/" + notifSecret.Name,
+						MountPath: "/etc/notif_connect/",
 						ReadOnly:  true,
 					}}
 					util.MergeVolumeMountList(&c.VolumeMounts, &secretVolumeMounts)


### PR DESCRIPTION
### Explain the changes
1. Simplify connect file mount path.

### Issues: Fixed #xxx / Gap #xxx
1. All connect files are now in one directory instead of each connect file in its own directory.
