### PR TITLE
Also install setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ gen-olm: gen
 		. $(VENV)/bin/activate && \
 		pip3 install --upgrade pip && \
 		pip3 install operator-courier==2.1.11 && \
+		pip3 install setuptools && \
 		operator-courier --verbose verify --ui_validate_io $(OLM)
 	docker build -t $(CATALOG_IMAGE) -f build/catalog-source.Dockerfile .
 	@echo "✅ gen-olm"


### PR DESCRIPTION
Without setuptools, running operator-courier fails with:

```
Traceback (most recent call last):
  File "/Users/zregvart/work/croz/noobaa/noobaa-operator/build/_output/venv/bin/operator-courier", line 5, in <module>
    from operatorcourier.cli import main
  File "/Users/zregvart/work/croz/noobaa/noobaa-operator/build/_output/venv/lib/python3.13/site-packages/operatorcourier/cli.py", line 2, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
make: *** [gen-olm] Error 1
```

### Explain the changes
1. Adds installation of setuptools python package

### Issues: Fixed #xxx / Gap #xxx
1. n/a

### Testing Instructions:
1. run `make` on brand new python setup

- [ ] Doc added/updated
- [ ] Tests added
