### PR TITLE
bucket notifications - need connect files also in endpoint for put bucket notif

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -608,6 +608,26 @@ func (r *Reconciler) setDesiredEndpointMounts(podSpec *corev1.PodSpec, container
 			}
 		}
 	}
+
+	for _, notifSecret := range r.NooBaa.Spec.BucketNotifications.Connections {
+		secretVolumeMounts := []corev1.VolumeMount{{
+			Name:      notifSecret.Name,
+			MountPath: "/etc/notif_connect/" + notifSecret.Name,
+			ReadOnly:  true,
+		}}
+		util.MergeVolumeMountList(&container.VolumeMounts, &secretVolumeMounts)
+
+		secretVolumes := []corev1.Volume{{
+			Name: notifSecret.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: notifSecret.Name,
+				},
+			},
+		}}
+		util.MergeVolumeList(&podSpec.Volumes, &secretVolumes)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Explain the changes
1. Since PR https://github.com/noobaa/noobaa-core/pull/8667 the endpoint validate the new notifications conf before applying the change to DB. This means we need the connect files also in endpoint.

### Issues: Fixed #xxx / Gap #xxx
1. put bucket notifications stopped working in containerized after above PR was merged.

### Testing Instructions:
1. Simple put bucket notification scenario.

- [ ] Doc added/updated
- [ ] Tests added
