### PR TITLE
Update AWS Regions with New Region

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1159,6 +1159,8 @@ func GetAWSRegion() (string, error) {
 		"ap-southeast-3": "ap-southeast-3",
 		"ap-southeast-4": "ap-southeast-4",
 		"ap-southeast-5": "ap-southeast-5",
+		// Currently in AWS table there is no region ap-southeast-6
+		"ap-southeast-7": "ap-southeast-7",
 		"ap-south-1":     "ap-south-1",
 		"ap-south-2":     "ap-south-2",
 		"me-south-1":     "me-south-1",
@@ -1168,6 +1170,7 @@ func GetAWSRegion() (string, error) {
 		"us-gov-east-1":  "us-gov-east-1",
 		"af-south-1":     "af-south-1",
 		"il-central-1":   "il-central-1",
+		"mx-central-1":   "mx-central-1",
 	}
 	var awsRegion string
 	infrastructure := &configv1.Infrastructure{


### PR DESCRIPTION
### Explain the changes
1. Update AWS regions with:
- `ap-southeast-7` (see [here](https://aws.amazon.com/blogs/aws/announcing-the-new-aws-asia-pacific-thailand-region/)).
- `mx-central-1` (see [here](https://aws.amazon.com/blogs/aws/now-open-aws-mexico-central-region/)).

### Issues: Fixed [DFBUGS-1550](https://issues.redhat.com/browse/DFBUGS-1550)
1. Currently we don't have the region `ap-southeast-7` and `mx-central-1` that were added lately.
2. In the issue it was only about `ap-southeast-7` that was added in 07/01/2025, but a week later was also added `mx-central-1`.

### Testing Instructions:
1. none.

- [ ] Doc added/updated
- [ ] Tests added