### PR TITLE
fixed lint error

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -229,7 +229,7 @@ func (r *Reconciler) SetDesiredSecretAdminAccountInfo() error {
 	if err != nil {
 		return fmt.Errorf("cannot read admin account info, error: %v", err)
 	}
-	if account.AccessKeys == nil || len(account.AccessKeys) <= 0 {
+	if len(account.AccessKeys) <= 0 {
 		return fmt.Errorf("admin account has no access keys yet")
 	}
 
@@ -417,11 +417,11 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 
 			if r.NooBaa.Spec.BucketNotifications.Enabled {
 				envVar := corev1.EnvVar{
-					Name: "NOTIFICATION_LOG_DIR",
+					Name:  "NOTIFICATION_LOG_DIR",
 					Value: "/var/logs/notifications",
 				}
 
-				util.MergeEnvArrays(&c.Env, &[]corev1.EnvVar{envVar});
+				util.MergeEnvArrays(&c.Env, &[]corev1.EnvVar{envVar})
 			}
 
 			c.SecurityContext = &corev1.SecurityContext{


### PR DESCRIPTION
### Explain the changes
1. This PR fixes a lint failure with The latest golangci-lint
2. fixes error 
   ```
   should omit nil check; len() for nil slices is defined as zero (gosimple)
   ```

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
