### PR TITLE
Remove the root secret from pod env variables

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -117,7 +117,6 @@ spec:
             - name: ENDPOINT_GROUP_ID
             - name: LOCAL_MD_SERVER
             - name: LOCAL_N2N_AGENT
-            - name: NOOBAA_ROOT_SECRET
             - name: NODE_EXTRA_CA_CERTS
             - name: GUARANTEED_LOGS_PATH
             - name: CONTAINER_CPU_REQUEST

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -116,7 +116,6 @@ spec:
               value: postgres
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
-            - name: NOOBAA_ROOT_SECRET
             - name: NODE_EXTRA_CA_CERTS
             - name: AGENT_PROFILE
               value: VALUE_AGENT_PROFILE

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3970,7 +3970,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "21b206c9119e37c4ebba84d5c1e2b1d45b06c716b4def69db9ba9268ef75e1e1"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "e76dc7c81a02fb396263e61311b2bc0d765f32377d1b9d2ec3f435fced2fb0c3"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4091,7 +4091,6 @@ spec:
             - name: ENDPOINT_GROUP_ID
             - name: LOCAL_MD_SERVER
             - name: LOCAL_N2N_AGENT
-            - name: NOOBAA_ROOT_SECRET
             - name: NODE_EXTRA_CA_CERTS
             - name: GUARANTEED_LOGS_PATH
             - name: CONTAINER_CPU_REQUEST
@@ -5031,7 +5030,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "50e5b11d8e0a2f2bb8a6db8d154b34b6569e160fa7ad2b1fb154001b36c8a152"
+const Sha256_deploy_internal_statefulset_core_yaml = "14226b25028637a7176dbdb4a6fa6e90a9e63cddd5f39cbe0c044f433b0a4764"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5151,7 +5150,6 @@ spec:
               value: postgres
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
-            - name: NOOBAA_ROOT_SECRET
             - name: NODE_EXTRA_CA_CERTS
             - name: AGENT_PROFILE
               value: VALUE_AGENT_PROFILE

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -463,8 +463,6 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			if r.NooBaa.Spec.ExternalPgSSLUnauthorized {
 				c.Env[j].Value = "true"
 			}
-		case "NOOBAA_ROOT_SECRET":
-			c.Env[j].Value = r.SecretRootMasterKey
 		case "NODE_EXTRA_CA_CERTS":
 			c.Env[j].Value = r.ApplyCAsToPods
 		case "GUARANTEED_LOGS_PATH":

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -382,8 +382,6 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 					if r.JoinSecret == nil {
 						c.Env[j].Value = "true"
 					}
-				case "NOOBAA_ROOT_SECRET":
-					c.Env[j].Value = r.SecretRootMasterKey
 				case "VIRTUAL_HOSTS":
 					hosts := []string{}
 					for _, addr := range r.NooBaa.Status.Services.ServiceS3.InternalDNS {


### PR DESCRIPTION
### Explain the changes
1. As reported in [DFBUGS-1608](https://issues.redhat.com/browse/DFBUGS-1608), the NooBaa root secret would be unintentionally revealed in some cases. This PR aims to remediate the issue by removing legacy code that was used to pass the secret via env params, before it was changed to be passed via a file mount. ([core](https://github.com/noobaa/noobaa-core/pull/7218), [operator](https://github.com/noobaa/noobaa-operator/pull/1071))

### Issues: 
Fixed:
1. [DFBUGS-1608](https://issues.redhat.com/browse/DFBUGS-1608)

Gap:
1. Some dead code is still present on the core side 

### Testing Instructions:
1. Deploy NooBaa on an AWS IPI Thales configuration
4. Make sure `NOOBAA_ROOT_SECRET` does not show in the env variables of endpoint and core pods

- [ ] Doc added/updated
- [ ] Tests added
