### PR TITLE
Add workflow to build custom CNPG operator image

### DIFF
--- a/.github/workflows/build-cnpg.yml
+++ b/.github/workflows/build-cnpg.yml
@@ -1,0 +1,31 @@
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The tag or branch that will be used as the base image for the CNPG Operator (default: v1.25.0 )"
+        required: false
+        default: "v1.25.0"
+
+jobs:
+  build-cnpg:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout CNPG Repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'cloudnative-pg/cloudnative-pg'
+          ref: ${{ github.event.inputs.tag }}
+          path: 'cloudnative-pg'
+
+      - name: Build CNPG Image
+        run: |
+          cd cloudnative-pg
+          find . -name .git -a -type d -prune -o -type f -exec sed -i -e 's|postgresql.cnpg.io|postgresql.cnpg.noobaa.io|g' -e 's|postgresql-cnpg-io|postgresql-cnpg-noobaa-io|g' {} +
+          make CONTROLLER_IMG=quay.io/noobaa/cloudnative-pg-noobaa:${{ github.event.inputs.tag }} docker-build
+
+      - name: Login to Quay.io Registry
+        run: echo ${{ secrets.GHACTIONQUAYTOKEN }} | docker login quay.io -u ${{ secrets.GHACTIONQUAYNAME }} --password-stdin
+
+      - name: Push CNPG Image to Quay
+        run: docker push quay.io/noobaa/cloudnative-pg-noobaa:${{ github.event.inputs.tag }}

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -87,6 +87,7 @@ jobs:
           db-image=centos/postgresql-15-centos7 \
           psql-12-image=centos/postgresql-12-centos7 \
           obc-crd="owned" \
+          cnpg-image=quay.io/noobaa/cloudnative-pg-noobaa:v1.25.0 \
           BUNDLE_IMAGE=quay.io/${{ steps.prep.outputs.operatorbundletags }}
 
       - name: Login to Quay.io Registry


### PR DESCRIPTION
### Explain the changes
Add GitHub workflow that builds a customized version of CloudNative PostgreSQL (CNPG) operator. The workflow:
- Allows selection of CNPG version tag (default v1.25.0)
- Modifies API group references from postgresql.cnpg.io to postgresql.cnpg.noobaa.io
- Builds and pushes a custom Docker image to Quay.io repository
- Uses manual trigger via workflow_dispatch

This enables NooBaa to maintain a customized version of the CNPG operator with necessary API group modifications.


### Testing Instructions:
1. Manually dispatch the workflow

- [ ] Doc added/updated
- [ ] Tests added
