### PR TITLE
cnpg - use olm webhook certs

### DIFF
--- a/pkg/cnpg/cnpg.go
+++ b/pkg/cnpg/cnpg.go
@@ -358,6 +358,13 @@ func modifyResources(cnpgRes *CnpgResources) {
 		}
 	}
 
+	// modify the web hook secret
+	for i := range depl.Spec.Template.Spec.Volumes {
+		if depl.Spec.Template.Spec.Volumes[i].Name == "webhook-certificates" {
+			depl.Spec.Template.Spec.Volumes[i].Secret.SecretName = "webhook-cert-secret"
+		}
+	}
+
 	modifyCnpgRbac(cnpgRes)
 
 	// update the service account namespace
@@ -365,6 +372,8 @@ func modifyResources(cnpgRes *CnpgResources) {
 
 	// update the configmap namespace
 	cnpgRes.ConfigMap.Namespace = options.Namespace
+	cnpgRes.ConfigMap.Name = "cnpg-controller-manager-config"
+	cnpgRes.ConfigMap.Data["WebhookCertDir"] = "/run/secrets/cnpg.io/webhook";
 
 	// update the namespace in the  mutating webhooks
 	for i := range cnpgRes.MutatingWebhookConfiguration.Webhooks {


### PR DESCRIPTION
### Explain the changes
1. cnpg needs the WebhookCertDir so to use webhook certs provided by olm.

### Issues: Fixed #xxx / Gap #xxx
cnpg pod fails with

{"level":"error","ts":"2025-02-28T10:46:18.352087216Z",
"logger":"setup",
"msg":"unable to setup PKI infrastructure",
"error":"mutatingwebhookconfigurations.admissionregistration.k8s.io \"cnpg-mutating-webhook-configuration\" is forbidden: 
	User \"system:serviceaccount:openshift-storage:cnpg-manager\" cannot get resource \"mutatingwebhookconfigurations\" in API group \"admissionregistration.k8s.io\" at the cluster scope",
"stacktrace":
	"github.com/cloudnative-pg/machinery/pkg/log.(*logger).Error\n\t/remote-source/deps/gomod/pkg/mod/github.com/cloudnative-pg/machinery@v0.0.0-20250102082645-95c37fe624d0/pkg/log/log.go:125\n
	github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/controller.ensurePKI\n\t/remote-source/app/internal/cmd/manager/controller/controller.go:386\n
	github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/controller.RunController\n\t/remote-source/app/internal/cmd/manager/controller/controller.go:210\n
	github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/controller.NewCmd.func1\n\t
		/remote-source/app/internal/cmd/manager/controller/cmd.go:43\n
	github.com/spf13/cobra.(*Command).execute\n\t
		/remote-source/deps/gomod/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985\n
	github.com/spf13/cobra.(*Command).ExecuteC\n\t
		/remote-source/deps/gomod/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117\n
	github.com/spf13/cobra.(*Command).Execute\n\t
		/remote-source/deps/gomod/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041\n
	main.main\n\t
		/remote-source/app/cmd/manager/main.go:68\nruntime.main\n\t/usr/lib/golang/src/runtime/proc.go:272"}
		
In odf/olm, we shouldn't go into controller.ensurePKI().
This means that webhook certs dir was not configured.

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
