### PR TITLE
gen_odf - quote with single quote

### DIFF
--- a/build/gen-odf-package.sh
+++ b/build/gen-odf-package.sh
@@ -22,8 +22,8 @@ cmd="./build/_output/bin/noobaa-operator-local olm catalog -n openshift-storage 
 --dir ${MANIFESTS} \
 --odf \
 --csv-name ${CSV_NAME} \
---skip-range "${SKIP_RANGE}" \
---replaces "${REPLACES}" \
+--skip-range '${SKIP_RANGE}' \
+--replaces '${REPLACES}' \
 --noobaa-image ${CORE_IMAGE} \
 --db-image ${DB_IMAGE} \
 --psql-12-image ${PSQL_12_IMAGE} \


### PR DESCRIPTION
### Explain the changes
1. Use different quotes for entire cmd and single commands inside it to support env vars with space.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
REPLACES="has space" OBC_CRD=none MANIFESTS=MA CSV_NAME=CS CORE_IMAGE=CO PSQL_12_IMAGE=PS DB_IMAGE=DB OPERATOR_IMAGE=OP COSI_SIDECAR_IMAGE=CO ./build/gen-odf-package.sh 
--obc-crd=none

- [ ] Doc added/updated
- [ ] Tests added
