### PR TITLE
Add AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY to noobaa-account secret

### DIFF
--- a/pkg/noobaaaccount/reconciler.go
+++ b/pkg/noobaaaccount/reconciler.go
@@ -369,7 +369,11 @@ func (r *Reconciler) CreateNooBaaAccount() error {
 			if err != nil {
 				return fmt.Errorf("cannot create an auth token for remote operator, error: %v", err)
 			}
+			accessKeys := accountInfo.AccessKeys[0]
 			r.Secret.StringData["auth_token"] = res.Token
+			r.Secret.StringData["AWS_ACCESS_KEY_ID"] = string(accessKeys.AccessKey)
+			r.Secret.StringData["AWS_SECRET_ACCESS_KEY"] = string(accessKeys.SecretKey)
+
 		}
 	} else {
 		var accessKeys nb.S3AccessKeys


### PR DESCRIPTION
### Explain the changes
1. Currently the noobaa account  secret created for storageconsumer doesnot have 
AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY.
2. This is required for noobaa object browser to be able to connect to remote s3 endpoint via proxy

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/RHSTOR-6903

### Testing Instructions:
1.  Create a noobaa account with this annotation `remote-client-noobaa: "true" `
2. Check the noobaa account secret created
3. It should have auth_token mgmt_url and AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY.

- [ ] Doc added/updated
- [ ] Tests added
