### PR TITLE
CA Paths Fixes

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -48,12 +48,6 @@ const (
 
 	// SystemName is a constant as we want just a single system per namespace
 	SystemName = "noobaa"
-
-	// ServiceServingCertCAFile points to OCP default root CA list
-	ServiceServingCertCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
-
-	// InjectedBundleCertCAFile points to OCP root CA to be added to the default root CA list
-	InjectedBundleCertCAFile = "/etc/ocp-injected-ca-bundle/ca-bundle.crt"
 )
 
 // Namespace is the target namespace for locating the noobaa system

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -49,8 +49,11 @@ const (
 	// SystemName is a constant as we want just a single system per namespace
 	SystemName = "noobaa"
 
-	// ServiceServingCertCAFile points to OCP root CA to be added to the default root CA list
+	// ServiceServingCertCAFile points to OCP default root CA list
 	ServiceServingCertCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+
+	// InjectedBundleCertCAFile points to OCP root CA to be added to the default root CA list
+	InjectedBundleCertCAFile = "/etc/ocp-injected-ca-bundle/ca-bundle.crt"
 )
 
 // Namespace is the target namespace for locating the noobaa system

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -547,7 +547,8 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 			if r.NooBaa.Spec.CoreResources != nil {
 				c.Resources = *r.NooBaa.Spec.CoreResources
 			}
-			if util.KubeCheckQuiet(r.CaBundleConf) {
+			// we want to check that the cm exists and also that it has data in it
+			if util.KubeCheckQuiet(r.CaBundleConf) && len(r.CaBundleConf.Data) > 0 {
 				configMapVolumeMounts := []corev1.VolumeMount{{
 					Name:      r.CaBundleConf.Name,
 					MountPath: "/etc/ocp-injected-ca-bundle",
@@ -630,7 +631,8 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 					Limits:   logResourceList,
 				}
 			}
-			if util.KubeCheckQuiet(r.CaBundleConf) {
+			// we want to check that the cm exists and also that it has data in it
+			if util.KubeCheckQuiet(r.CaBundleConf) && len(r.CaBundleConf.Data) > 0 {
 				configMapVolumeMounts := []corev1.VolumeMount{{
 					Name:      r.CaBundleConf.Name,
 					MountPath: "/etc/ocp-injected-ca-bundle",
@@ -673,7 +675,8 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 
 	r.CoreApp.Spec.Template.Annotations["noobaa.io/configmap-hash"] = r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"]
 
-	if util.KubeCheckQuiet(r.CaBundleConf) {
+	// we want to check that the cm exists and also that it has data in it
+	if util.KubeCheckQuiet(r.CaBundleConf) && len(r.CaBundleConf.Data) > 0 {
 		configMapVolumes := []corev1.Volume{{
 			Name: r.CaBundleConf.Name,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -550,7 +550,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 			if util.KubeCheckQuiet(r.CaBundleConf) {
 				configMapVolumeMounts := []corev1.VolumeMount{{
 					Name:      r.CaBundleConf.Name,
-					MountPath: "/etc/ocp-injected-ca-bundle.crt",
+					MountPath: "/etc/ocp-injected-ca-bundle",
 					ReadOnly:  true,
 				}}
 				util.MergeVolumeMountList(&c.VolumeMounts, &configMapVolumeMounts)
@@ -633,7 +633,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 			if util.KubeCheckQuiet(r.CaBundleConf) {
 				configMapVolumeMounts := []corev1.VolumeMount{{
 					Name:      r.CaBundleConf.Name,
-					MountPath: "/etc/ocp-injected-ca-bundle.crt",
+					MountPath: "/etc/ocp-injected-ca-bundle",
 					ReadOnly:  true,
 				}}
 				util.MergeVolumeMountList(&c.VolumeMounts, &configMapVolumeMounts)

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -491,7 +491,8 @@ func (r *Reconciler) setDesiredEndpointMounts(podSpec *corev1.PodSpec, container
 	podSpec.Volumes = r.DefaultDeploymentEndpoint.Volumes
 	container.VolumeMounts = r.DefaultDeploymentEndpoint.Containers[0].VolumeMounts
 
-	if util.KubeCheckQuiet(r.CaBundleConf) {
+	// we want to check that the cm exists and also that it has data in it
+	if util.KubeCheckQuiet(r.CaBundleConf) && len(r.CaBundleConf.Data) > 0 {
 		configMapVolumes := []corev1.Volume{{
 			Name: r.CaBundleConf.Name,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -509,7 +509,7 @@ func (r *Reconciler) setDesiredEndpointMounts(podSpec *corev1.PodSpec, container
 		util.MergeVolumeList(&podSpec.Volumes, &configMapVolumes)
 		configMapVolumeMounts := []corev1.VolumeMount{{
 			Name:      r.CaBundleConf.Name,
-			MountPath: "/etc/ocp-injected-ca-bundle.crt",
+			MountPath: "/etc/ocp-injected-ca-bundle",
 			ReadOnly:  true,
 		}}
 		util.MergeVolumeMountList(&container.VolumeMounts, &configMapVolumeMounts)

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -404,9 +404,9 @@ func (r *Reconciler) Reconcile() (reconcile.Result, error) {
 		}
 	}
 
-	err = util.CombineCaBundle(options.ServiceServingCertCAFile)
+	err = util.CombineCaBundle(util.ServiceServingCertCAFile)
 	if err == nil {
-		r.ApplyCAsToPods = options.InjectedBundleCertCAFile
+		r.ApplyCAsToPods = util.InjectedBundleCertCAFile
 	} else if !os.IsNotExist(err) {
 		log.Errorf("❌ NooBaa %q failed to add root CAs to system default", r.NooBaa.Name)
 		res.RequeueAfter = 3 * time.Second

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -404,9 +404,9 @@ func (r *Reconciler) Reconcile() (reconcile.Result, error) {
 		}
 	}
 
-	err = util.AddToRootCAs(options.ServiceServingCertCAFile)
+	err = util.CombineCaBundle(options.ServiceServingCertCAFile)
 	if err == nil {
-		r.ApplyCAsToPods = options.ServiceServingCertCAFile
+		r.ApplyCAsToPods = options.InjectedBundleCertCAFile
 	} else if !os.IsNotExist(err) {
 		log.Errorf("❌ NooBaa %q failed to add root CAs to system default", r.NooBaa.Name)
 		res.RequeueAfter = 3 * time.Second

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -68,7 +68,7 @@ type Reconciler struct {
 	OperatorVersion          string
 	OAuthEndpoints           *util.OAuth2Endpoints
 	PostgresConnectionString string
-	ApplyCAsToPods           string
+	ApplyCAsToPods           string // the CA will be applied to the core and endpoint pods
 
 	NooBaa                    *nbv1.NooBaa
 	ServiceAccount            *corev1.ServiceAccount

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -282,7 +282,7 @@ func NewReconciler(
 	r.RouteS3.Name = r.ServiceS3.Name
 	r.RouteSts.Name = r.ServiceSts.Name
 	r.DeploymentEndpoint.Name = r.Request.Name + "-endpoint"
-	r.CaBundleConf.Name = r.Request.Name + "-ca-inject"
+	r.CaBundleConf.Name = "ocp-injected-ca-bundle"
 	r.KedaScaled.Name = r.Request.Name
 	r.AdapterHPA.Name = r.Request.Name + "-hpav2"
 	r.BucketLoggingPVC.Name = r.Request.Name + "-bucket-logging-pvc"

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -406,7 +406,8 @@ func (r *Reconciler) Reconcile() (reconcile.Result, error) {
 
 	err = util.CombineCaBundle(util.ServiceServingCertCAFile)
 	if err == nil {
-		r.ApplyCAsToPods = util.InjectedBundleCertCAFile
+		// r.ApplyCAsToPods = util.InjectedBundleCertCAFile
+		r.ApplyCAsToPods = util.ServiceServingCertCAFile // back as it was
 	} else if !os.IsNotExist(err) {
 		log.Errorf("❌ NooBaa %q failed to add root CAs to system default", r.NooBaa.Name)
 		res.RequeueAfter = 3 * time.Second

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -143,8 +143,8 @@ var (
 	}
 )
 
-// AddToRootCAs adds a local cert file to Our GlobalCARefreshingTransport
-func AddToRootCAs(localCertFile string) error {
+// CombineCaBundle combines a local cert file to Our GlobalCARefreshingTransport
+func CombineCaBundle(localCertFile string) error {
 	rootCAs, _ := x509.SystemCertPool()
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
@@ -169,7 +169,7 @@ func AddToRootCAs(localCertFile string) error {
 		}
 
 		// Trust the augmented cert pool in our client
-		log.Infof("Successfuly appended %q to RootCAs", certFile)
+		log.Infof("Successfully appended %q to RootCAs", certFile)
 	}
 	GlobalCARefreshingTransport.TLSClientConfig.RootCAs = rootCAs
 	return nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -84,6 +84,12 @@ const (
 
 	topologyConstraintsEnabledKubeVersion = "1.26.0"
 	trueStr                               = "true"
+
+	// ServiceServingCertCAFile points to OCP default root CA list
+	ServiceServingCertCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+
+	// InjectedBundleCertCAFile points to OCP root CA to be added to the default root CA list
+	InjectedBundleCertCAFile = "/etc/ocp-injected-ca-bundle/ca-bundle.crt"
 )
 
 // OAuth2Endpoints holds OAuth2 endpoints information.
@@ -151,7 +157,7 @@ func CombineCaBundle(localCertFile string) error {
 	}
 
 	var certFiles = []string{
-		"/etc/ocp-injected-ca-bundle/ca-bundle.crt",
+		InjectedBundleCertCAFile,
 		localCertFile,
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -151,7 +151,7 @@ func AddToRootCAs(localCertFile string) error {
 	}
 
 	var certFiles = []string{
-		"/etc/ocp-injected-ca-bundle.crt",
+		"/etc/ocp-injected-ca-bundle/ca-bundle.crt",
 		localCertFile,
 	}
 


### PR DESCRIPTION
### Explain the changes
1. In `pkg/utilutil.go` - Change the `/etc/ocp-injected-ca-bundle.crt` to `/etc/ocp-injected-ca-bundle/ca-bundle.crt`.
2. In `pkg/system/reconciler.go` - Rename `r.CaBundleConf.Name` from `r.Request.Name + "-ca-inject"` to `"ocp-injected-ca-bundle"` to align with the rename of `configmap-ca-inject.yaml` from `noobaa-ca-inject` to `ocp-injected-ca-bundle` in PR #1328.
3. In `pkg/system/phase2_creating.go` and `pkg/system/phase4_configuring.go` - the core and the endpoint change the mount path from `/etc/ocp-injected-ca-bundle.crt` (with file extension) to a directory (remove the extension).
4. Rename `AddToRootCAs` to `CombineCaBundle`, add the const `InjectedBundleCertCAFile` which is `/etc/ocp-injected-ca-bundle/ca-bundle.crt`, and assign `r.ApplyCAsToPods` to be the new constant (will be `NODE_EXTRA_CA_CERTS` eventually).
5. Change the condition of checking only the existence of the config map of the CA (`configmap-ca-inject`) to check this and also that we have data in it.
The reason is that when we test the OLM (in the CI), we have the OLM and then we have the operator so the config map as it is created by the OLM, but in the first step it is empty.
When manually looking at the config map in a real cluster there is data, that probably comes from additional needed configuration in the cluster (which is not in the scope of the test).
6. Add a comment about `ApplyCAsToPods` so it would be clear that it is relevant to the endpoint and core pods.
7. in `CombineCaBundle` use const instead of hard-coded string (to avoid circular dependency had to move the consts from `options` to `util` file).
8. (this change might be temporary - need to decide) Change the `ApplyCAsToPods` to `ServiceServingCertCAFile` (previous `InjectedBundleCertCAFile` in comment).


### Issues:
1.  Currently, when I tried to deploy with the cluster-bot I saw that `NODE_EXTRA_CA_CERTS` is empty, while it used to be 
`NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`.

GAPs:
1. Tests end-to-end with certificates.

### Testing Instructions:
#### Basic Manual Tests (more details in the [comment below](https://github.com/noobaa/noobaa-operator/pull/1570#issuecomment-2748516358))
Check the value of `NODE_EXTRA_CA_CERTS`:
1. I used the cluster-bot with `launch 4.17 aws`
2. Installed ODF operator and MCG standalone according to the docs [here](https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.17/html/deploying_and_managing_openshift_data_foundation_using_red_hat_openstack_platform/deploy-standalone-multicloud-object-gateway#deploy-standalone-multicloud-object-gateway).
3. Check the env `NODE_EXTRA_CA_CERTS`:
  - `oc exec statefulset/noobaa-core -c core -n openshift-storage -- printenv | grep NODE_EXTRA_CA_CERTS` (was empty)
  - `oc exec noobaa-endpoint-<characters> -n openshift-storage -- env | grep NODE_EXTRA_CA_CERTS` (was empty)
4. same steps with `launch 4.14 aws` in the cluster-bot (the version was chosen as a version before the changes of PR #1328) we could see `NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` (both on core and endpoint).
5. After the change we would see (both on core and endpoint pods): 
  - `NODE_EXTRA_CA_CERTS=/etc/ocp-injected-ca-bundle/ca-bundle.crt`
  - `NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` (with the commit mentioned in change number 8).

- [ ] Doc added/updated
- [ ] Tests added
