### PR TITLE
Implemented data import from the old DB to the cluster on upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/coreos/go-semver v0.3.1
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/gemalto/kmip-go v0.0.10
+	github.com/go-test/deep v1.1.0
 	github.com/google/uuid v1.6.0
 	github.com/kedacore/keda/v2 v2.7.0
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221122204822-d1a8c34382f1
@@ -84,7 +85,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
-	github.com/go-test/deep v1.1.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -465,13 +465,23 @@ type NooBaaDBStatus struct {
 type DBClusterStatus string
 
 const (
-	// DBClusterStatusNone means the DB is not created
-	DBClusterStatusNone      DBClusterStatus = "None"
-	DBClusterStatusCreating  DBClusterStatus = "Creating"
-	DBClusterStatusUpdating  DBClusterStatus = "Updating"
+	// DBClusterStatusNone means there is no DB cluster configured
+	DBClusterStatusNone DBClusterStatus = "None"
+
+	// DBClusterStatusCreating means a new DB cluster is being created
+	DBClusterStatusCreating DBClusterStatus = "Creating"
+
+	// DBClusterStatusUpdating means the DB cluster is being updated
+	DBClusterStatusUpdating DBClusterStatus = "Updating"
+
+	// DBClusterStatusImporting means a new DB cluster is being created and data is being imported from the previous DB
 	DBClusterStatusImporting DBClusterStatus = "Importing"
-	DBClusterStatusReady     DBClusterStatus = "Ready"
-	DBClusterStatusFailed    DBClusterStatus = "Failed"
+
+	// DBClusterStatusReady means the DB cluster is ready
+	DBClusterStatusReady DBClusterStatus = "Ready"
+
+	// DBClusterStatusFailed means the DB cluster reconciliation encountered an error
+	DBClusterStatusFailed DBClusterStatus = "Failed"
 )
 
 // These are the valid conditions types and statuses:

--- a/pkg/cnpg/cnpg.go
+++ b/pkg/cnpg/cnpg.go
@@ -103,6 +103,31 @@ func RunInstall(cmd *cobra.Command, args []string) {
 	util.KubeCreateSkipExisting(cnpgRes.WebhooksService)
 }
 
+// RunInstall runs the CloudNativePG operator installation
+func RunUpgrade(cmd *cobra.Command, args []string) {
+
+	cnpgRes, err := LoadCnpgResources()
+	if err != nil {
+		util.Panic(err)
+	}
+
+	for _, crd := range cnpgRes.CRDs {
+		util.KubeApply(crd)
+	}
+	util.KubeApply(cnpgRes.ServiceAccount)
+	util.KubeApply(cnpgRes.CnpgManagerRoleBinding)
+	util.KubeApply(cnpgRes.CnpgManagerClusterRoleBinding)
+	util.KubeApply(cnpgRes.CnpgWebhooksClusterRoleBinding)
+	util.KubeApply(cnpgRes.CnpgWebhooksClusterRole)
+	util.KubeApply(cnpgRes.ConfigMap)
+	util.KubeApply(cnpgRes.MutatingWebhookConfiguration)
+	util.KubeApply(cnpgRes.ValidatingWebhookConfiguration)
+	util.KubeApply(cnpgRes.CnpgOperatorDeployment)
+	util.KubeApply(cnpgRes.CnpgManagerClusterRole)
+	util.KubeApply(cnpgRes.CnpgManagerRole)
+	util.KubeApply(cnpgRes.WebhooksService)
+}
+
 // CmdUninstall returns a CLI command
 func CmdUninstall() *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -149,6 +149,8 @@ func RunUpgrade(cmd *cobra.Command, args []string) {
 	log.Printf("System versions prior to upgrade:\n")
 	system.RunSystemVersionsStatus(cmd, args)
 	log.Printf("Namespace: %s\n", options.Namespace)
+	log.Printf("CNPG upgrade:")
+	cnpg.RunUpgrade(cmd, args)
 	log.Printf("CRD upgrade:")
 	crd.RunUpgrade(cmd, args)
 	log.Printf("\nOperator upgrade:")

--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -6,12 +6,14 @@ import (
 	"slices"
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/go-test/deep"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/cnpg"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -19,21 +21,25 @@ const (
 	pgImageCatalogSuffix = "-db-pg-image-catalog"
 )
 
+// ReconcileCNPGCluster reconciles the CNPG cluster
+// There are several cases to handle:
+// 1. Reconciling a fresh install - No CNPG cluster and no previous DB to import from
+//   - In this case we need to create a new empty CNPG cluster
+//   - Create a new CNPG image catalog
+//   - Create a new CNPG cluster
+//
+// 2. Reconciling an upgrade from a version with a standalone DB - No CNPG cluster and DB statefulset exists
+//   - In this case we need to create a new CNPG cluster and import the DB from the previous statefulset
+//   - Import is done by providing externalCluster details in the CNPG cluster spec (https://cloudnative-pg.io/documentation/1.25/database_import/#the-microservice-type)
+//   - After Import is completed, cleanup the old DB resources. For now we only scale down the standalone DB pod to 0 replicas
+//   - All other pods (core, endpoints) should be stopped before starting the import
+//
+// 3. Reconciling an existing CNPG cluster with no standalone DB - CNPG cluster exists and DB statefulset does not exist
+//   - If the major version is the same, check if the DB image is changed and update the ImageCatalog
+//   - If the major version is different, handle Major version upgrade (future feature. Not implemented yet)
 func (r *Reconciler) ReconcileCNPGCluster() error {
 
-	// there are several cases to handle:
-	// 1. Reconciling a fresh install - No CNPG cluster and no previous DB to import from
-	//    - In this case we need to create a new empty CNPG cluster
-	// 	    - Create a new CNPG image catalog
-	// 	    - Create a new CNPG cluster
-	// 2. Reconciling an upgrade from a version with a standalone DB - No CNPG cluster and DB statefulset exists
-	//    - In this case we need to create a new CNPG cluster and import the DB from the previous statefulset
-	//    - Import is done by providing externalCluster details in the CNPG cluster spec (https://cloudnative-pg.io/documentation/1.25/database_import/#the-microservice-type)
-	//    - After Import is completed, cleanup the old DB resources.
-	//    - All other pods (core, endpoints) should be stopped before starting the import
-	// 3. Reconciling an existing CNPG cluster with no standalone DB - CNPG cluster exists and DB statefulset does not exist
-	//    - If major version is the same, check if the DB image is changed and update the ImageCatalog
-	//    - If major version is different, handle Major version upgrade (future feature)
+	r.cnpgLog("reconciling CNPG cluster")
 
 	// init the DB status if not set
 	if r.NooBaa.Status.DBStatus == nil {
@@ -42,17 +48,44 @@ func (r *Reconciler) ReconcileCNPGCluster() error {
 		}
 	}
 
+	// reconcile the DB image in the image catalog
 	if err := r.reconcileCNPGImageCatalog(); err != nil {
-		r.Logger.Errorf("got error reconciling image catalog. error: %v", err)
+		r.cnpgLogError("got error reconciling image catalog. error: %v", err)
 		return err
 	}
 
-	if err := r.reconcileCluster(); err != nil {
-		r.Logger.Errorf("got error reconciling cluster. error: %v", err)
+	// reconcile the DB cluster CR and apply changes
+	err := r.reconcileDBCluster()
+	if err != nil {
+		r.cnpgLogError("got error reconciling cluster. error: %v", err)
 		return err
 	}
 
-	if !isClusterReady(r.CNPGCluster) {
+	if isClusterReady(r.CNPGCluster) {
+		r.cnpgLog("cnpg cluster is ready")
+		r.NooBaa.Status.DBStatus.DBClusterStatus = nbv1.DBClusterStatusReady
+
+		standaloneDBPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      r.NooBaaPostgresDB.Name + "-0",
+				Namespace: r.NooBaaPostgresDB.Namespace,
+			},
+		}
+
+		if util.KubeCheck(standaloneDBPod) {
+			// stop the standalone DB pod. For now it is only scaled down to 0 replicas, to keep it around as backup
+			r.cnpgLog("Scaling down the standalone DB pod")
+			if err := r.ReconcileObject(r.NooBaaPostgresDB, func() error {
+				zeroReplicas := int32(0)
+				r.NooBaaPostgresDB.Spec.Replicas = &zeroReplicas
+				return nil
+			}); err != nil {
+				r.cnpgLogError("got error scaling down the standalone DB pod. error: %v", err)
+				return err
+			}
+		}
+
+	} else {
 		return fmt.Errorf("cnpg cluster is not ready")
 	}
 
@@ -73,21 +106,21 @@ func (r *Reconciler) reconcileCNPGImageCatalog() error {
 		})
 
 		if imageIndex == -1 {
-			r.Logger.Infof("no image entry found for major version %q. updating image %q", desiredMajorVersion, desiredDbImage)
+			r.cnpgLog("no image entry found for major version %q. updating image %q", desiredMajorVersion, desiredDbImage)
 			r.CNPGImageCatalog.Spec.Images = append(r.CNPGImageCatalog.Spec.Images, cnpgv1.CatalogImage{
 				Major: desiredMajorVersion,
 				Image: desiredDbImage,
 			})
 		} else if r.CNPGImageCatalog.Spec.Images[imageIndex].Image != desiredDbImage {
 			// handle minor version change
-			r.Logger.Infof("image entry for major version %q found and is different from the desired image. updating image from %q to %q",
+			r.cnpgLog("image entry for major version %q found and is different from the desired image. updating image from %q to %q",
 				desiredMajorVersion, r.CNPGImageCatalog.Spec.Images[imageIndex].Image, desiredDbImage)
 			r.CNPGImageCatalog.Spec.Images[imageIndex].Image = desiredDbImage
 		}
 
 		return nil
 	}); err != nil {
-		r.Logger.Errorf("got error reconciling image catalog. error: %v", err)
+		r.cnpgLogError("got error reconciling image catalog. error: %v", err)
 		return err
 	}
 
@@ -98,25 +131,90 @@ func (r *Reconciler) reconcileCNPGImageCatalog() error {
 	return nil
 }
 
-func (r *Reconciler) reconcileCluster() error {
+func (r *Reconciler) reconcileDBCluster() error {
 
 	// get the existing cluster
 	util.KubeCheck(r.CNPGCluster)
 
-	existingClusterSpec := r.CNPGCluster.Spec.DeepCopy()
-
 	dbSpec := r.NooBaa.Spec.DBSpec
 
-	desiredMajorVersion := getDesiredMajorVersion(dbSpec)
+	existingClusterSpec := r.CNPGCluster.Spec.DeepCopy()
 
-	// set app=noobaa label on the cluster to be propagated to the DB pods
-	r.CNPGCluster.Spec.InheritedMetadata = &cnpgv1.EmbeddedObjectMetadata{
-		Labels: map[string]string{
-			"app": "noobaa",
-		},
+	// set the desired cluster spec except for the bootstrap configuration which should only be set for the CR creation
+	if err := r.reconcileClusterSpec(dbSpec); err != nil {
+		r.cnpgLogError("got error setting desired cluster spec. error: %v", err)
+		return err
 	}
 
+	// Apply changes to the cluster resources. create or update the modified cluster
+	if r.CNPGCluster.UID == "" {
+		// Cluster resource was not created yet. Create it and handle import if needed
+
+		if err := r.reconcileClusterImport(); err != nil {
+			r.cnpgLogError("got error setting up cluster import. error: %v", err)
+			return err
+		}
+
+		// create the cluster
+		r.cnpgLog("creating new cluster")
+		r.Own(r.CNPGCluster)
+		if err := r.Client.Create(r.Ctx, r.CNPGCluster); err != nil {
+			r.cnpgLogError("got error creating the cluster resources in kubernetes api server. error: %v", err)
+			return err
+		}
+
+		// update the DB status
+		if r.CNPGCluster.Spec.Bootstrap.InitDB.Import == nil {
+			r.NooBaa.Status.DBStatus.DBClusterStatus = nbv1.DBClusterStatusCreating
+		} else {
+			r.NooBaa.Status.DBStatus.DBClusterStatus = nbv1.DBClusterStatusImporting
+		}
+
+	} else {
+		// Handle Cluster CRD changes
+
+		// check if the cluster is changed
+		if r.wasClusterSpecChanged(existingClusterSpec) {
+			diff := deep.Equal(*existingClusterSpec, r.CNPGCluster.Spec)
+			r.cnpgLog("cluster spec is changed, updating cluster. diff: %v", diff)
+
+			currentDBClusterStatus := r.NooBaa.Status.DBStatus.DBClusterStatus
+			// avoid updating a cluster that is being created or imported.
+			// We might want to consider allowing this somehow for supportability (through annotation or something)
+			if currentDBClusterStatus == nbv1.DBClusterStatusCreating || currentDBClusterStatus == nbv1.DBClusterStatusImporting {
+				r.cnpgLog("the cluster spec was changed but the cluster creation or import is still in progress, skipping update")
+				return fmt.Errorf("cluster creation or import is still in progress, skipping update")
+			}
+
+			r.cnpgLog("cluster spec is changed, updating cluster")
+			if err := r.Client.Update(r.Ctx, r.CNPGCluster); err != nil {
+				r.cnpgLogError("got error updating cluster. error: %v", err)
+				return err
+			}
+			// update the DB status
+			r.NooBaa.Status.DBStatus.DBClusterStatus = nbv1.DBClusterStatusUpdating
+		}
+
+		// The cluster spec is unchanged, no need to update
+		return nil
+	}
+
+	return nil
+}
+
+func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
+
+	// set app=noobaa label on the cluster to be propagated to the DB pods
+	if r.CNPGCluster.Spec.InheritedMetadata == nil {
+		r.CNPGCluster.Spec.InheritedMetadata = &cnpgv1.EmbeddedObjectMetadata{}
+	}
+	if r.CNPGCluster.Spec.InheritedMetadata.Labels == nil {
+		r.CNPGCluster.Spec.InheritedMetadata.Labels = map[string]string{}
+	}
+	r.CNPGCluster.Spec.InheritedMetadata.Labels["app"] = "noobaa"
+
 	// update the image catalog ref
+	desiredMajorVersion := getDesiredMajorVersion(dbSpec)
 	r.CNPGCluster.Spec.ImageCatalogRef = &cnpgv1.ImageCatalogRef{
 		TypedLocalObjectReference: corev1.TypedLocalObjectReference{
 			Kind:     "ImageCatalog",
@@ -135,52 +233,115 @@ func (r *Reconciler) reconcileCluster() error {
 	}
 
 	// update db volume resources
-	desiredStorageConfiguration, err := getDesiredStorageConfiguration(dbSpec)
+	// update the storage configuration
+	err := setDesiredStorageConf(&r.CNPGCluster.Spec.StorageConfiguration, dbSpec)
 	if err != nil {
-		r.Logger.Errorf("got error getting desired storage configuration for cnpg cluster. error: %v", err)
+		r.cnpgLogError("got error getting desired storage configuration for cnpg cluster. error: %v", err)
 		return err
 	}
-	r.CNPGCluster.Spec.StorageConfiguration = desiredStorageConfiguration
 
 	// TODO: consider specifying a separate WAL storage configuration in Spec.WalStorage
 	// currently, the same storage will be used for both DB and WAL
 
-	// TODO: handle import of existing DB in bootstrap section
-	// define bootstrap section
-	r.CNPGCluster.Spec.Bootstrap = &cnpgv1.BootstrapConfiguration{
-		InitDB: &cnpgv1.BootstrapInitDB{
-			Database: "nbcore",
-			Owner:    "noobaa",
-		},
+	return nil
+
+}
+
+func (r *Reconciler) reconcileClusterImport() error {
+
+	// The bootstrap configuration should only be set for the CR creation.
+
+	// set default bootstrap configuration
+	if r.CNPGCluster.Spec.Bootstrap == nil {
+		r.CNPGCluster.Spec.Bootstrap = &cnpgv1.BootstrapConfiguration{
+			InitDB: &cnpgv1.BootstrapInitDB{
+				Database: "nbcore",
+				Owner:    "noobaa",
+			},
+		}
 	}
 
-	// check if the cluster is changed
-	if reflect.DeepEqual(*existingClusterSpec, r.CNPGCluster.Spec) {
-		// The cluster spec is unchanged, no need to update
+	// We first want to check if a standalone DB statefulset exists, and trigger import if so
+	util.KubeCheck(r.NooBaaPostgresDB)
+	if r.NooBaaPostgresDB.UID != "" {
+		r.cnpgLog("standalone DB statefulset found, setting up import")
+
+		// stop core and endpoints pods and wait for them to be terminated
+		numRunningPods, err := r.stopNoobaaPodsAndGetNumRunningPods()
+		if err != nil {
+			r.cnpgLogError("got error stopping noobaa-core and noobaa-endpoint pods. error: %v", err)
+			return err
+		}
+		if numRunningPods > 0 {
+			r.cnpgLog("waiting for noobaa-core and noobaa-endpoint pods to be terminated")
+			return fmt.Errorf("waiting for noobaa-core and noobaa-endpoint pods to be terminated")
+		}
+
+		externalClusterName := r.NooBaaPostgresDB.Name
+		//setup once the pods are terminated, set import in the bootstrap configuration and continue to create the cluster
+		r.CNPGCluster.Spec.Bootstrap.InitDB.Import = &cnpgv1.Import{
+			Source: cnpgv1.ImportSource{
+				ExternalCluster: externalClusterName,
+			},
+			// microservice type - import only the nbcore database
+			Type: cnpgv1.MicroserviceSnapshotType,
+			Databases: []string{
+				"nbcore",
+			},
+		}
+
+		// provide the external cluster connection parameters
+		r.CNPGCluster.Spec.ExternalClusters = []cnpgv1.ExternalCluster{
+			{
+				Name: externalClusterName,
+				ConnectionParameters: map[string]string{
+					"host":   r.NooBaaPostgresDB.Name + "-0." + r.NooBaaPostgresDB.Spec.ServiceName + "." + r.NooBaaPostgresDB.Namespace + ".svc",
+					"user":   "noobaa",
+					"dbname": "nbcore",
+				},
+				Password: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: r.SecretDB.Name,
+					},
+					Key: "password",
+				},
+			},
+		}
+		return nil
+	} else {
+		// No existing DB statefulset, set bootstrap to init with a new DB
+		r.cnpgLog("no existing DB statefulset found, configuring the cluster to bootstrap a new nbcore DB")
 		return nil
 	}
 
-	// create or update the modified cluster
-	if r.CNPGCluster.UID == "" {
-		r.Logger.Infof("creating new cluster")
-		r.Own(r.CNPGCluster)
-		if err := r.Client.Create(r.Ctx, r.CNPGCluster); err != nil {
-			r.Logger.Errorf("got error creating cluster. error: %v", err)
-			return err
-		}
-		// update the DB status
-		r.NooBaa.Status.DBStatus.DBClusterStatus = nbv1.DBClusterStatusCreating
-	} else {
-		r.Logger.Infof("cluster spec is changed, updating cluster")
-		if err := r.Client.Update(r.Ctx, r.CNPGCluster); err != nil {
-			r.Logger.Errorf("got error updating cluster. error: %v", err)
-			return err
-		}
-		// update the DB status
-		r.NooBaa.Status.DBStatus.DBClusterStatus = nbv1.DBClusterStatusUpdating
-	}
+}
 
-	return nil
+func (r *Reconciler) stopNoobaaPodsAndGetNumRunningPods() (int, error) {
+	// stop core\endpoints pods
+	zeroReplicas := int32(0)
+	if err := r.ReconcileObject(r.CoreApp, func() error {
+		r.CoreApp.Spec.Replicas = &zeroReplicas
+		return nil
+	}); err != nil {
+		r.cnpgLogError("got error stopping noobaa-core pods. error: %v", err)
+		return -1, err
+	}
+	if err := r.ReconcileObject(r.DeploymentEndpoint, func() error {
+		r.DeploymentEndpoint.Spec.Replicas = &zeroReplicas
+		return nil
+	}); err != nil {
+		r.cnpgLogError("got error stopping noobaa-endpoints pods. error: %v", err)
+		return -1, err
+	}
+	corePodsList := &corev1.PodList{}
+	if !util.KubeList(corePodsList, client.InNamespace(options.Namespace), client.MatchingLabels{"noobaa-core": "noobaa"}) {
+		return -1, fmt.Errorf("got error listing noobaa-core pods")
+	}
+	endpointPodsList := &corev1.PodList{}
+	if !util.KubeList(endpointPodsList, client.InNamespace(options.Namespace), client.MatchingLabels{"noobaa-s3": "noobaa"}) {
+		return -1, fmt.Errorf("got error listing noobaa-endpoints pods")
+	}
+	return len(corePodsList.Items) + len(endpointPodsList.Items), nil
 }
 
 func getDesiredMajorVersion(dbSpec *nbv1.NooBaaDBSpec) int {
@@ -207,25 +368,27 @@ func getDesiredInstances(dbSpec *nbv1.NooBaaDBSpec) int {
 	return desiredInstances
 }
 
-func getDesiredStorageConfiguration(dbSpec *nbv1.NooBaaDBSpec) (cnpgv1.StorageConfiguration, error) {
-	desiredStorageConfiguration := cnpgv1.StorageConfiguration{}
+func setDesiredStorageConf(storageConfiguration *cnpgv1.StorageConfiguration, dbSpec *nbv1.NooBaaDBSpec) error {
+	if storageConfiguration == nil {
+		return fmt.Errorf("storage configuration is nil")
+	}
 	if dbSpec.DBStorageClass != nil {
-		desiredStorageConfiguration.StorageClass = dbSpec.DBStorageClass
+		storageConfiguration.StorageClass = dbSpec.DBStorageClass
 	} else {
 		storageClassName, err := findLocalStorageClass()
 		if err != nil {
-			return cnpgv1.StorageConfiguration{}, err
+			return err
 		}
-		desiredStorageConfiguration.StorageClass = &storageClassName
+		storageConfiguration.StorageClass = &storageClassName
 	}
 
 	if dbSpec.DBMinVolumeSize != "" {
-		desiredStorageConfiguration.Size = dbSpec.DBMinVolumeSize
+		storageConfiguration.Size = dbSpec.DBMinVolumeSize
 	} else {
-		desiredStorageConfiguration.Size = options.DefaultDBVolumeSize
+		storageConfiguration.Size = options.DefaultDBVolumeSize
 	}
 
-	return desiredStorageConfiguration, nil
+	return nil
 }
 
 func isClusterReady(cluster *cnpgv1.Cluster) bool {
@@ -254,4 +417,25 @@ func (r *Reconciler) getEnvFromClusterSecretKey(key string) *corev1.EnvVarSource
 			Key: key,
 		},
 	}
+}
+
+func (r *Reconciler) cnpgLog(format string, args ...interface{}) {
+	r.Logger.Infof("cnpg:: "+format, args...)
+}
+
+func (r *Reconciler) cnpgLogError(format string, args ...interface{}) {
+	r.Logger.Errorf("cnpg:: "+format, args...)
+}
+
+// wasClusterSpecChanged checks if any of the cluster spec fields that matter for us were changed.
+// This need to be updated if we change more fields in the cluster spec.
+// For some reason reflect.DeepEqual always returns false when comparing the entire spec.
+func (r *Reconciler) wasClusterSpecChanged(existingClusterSpec *cnpgv1.ClusterSpec) bool {
+
+	return !reflect.DeepEqual(existingClusterSpec.InheritedMetadata, r.CNPGCluster.Spec.InheritedMetadata) ||
+		!reflect.DeepEqual(existingClusterSpec.ImageCatalogRef, r.CNPGCluster.Spec.ImageCatalogRef) ||
+		existingClusterSpec.Instances != r.CNPGCluster.Spec.Instances ||
+		!reflect.DeepEqual(existingClusterSpec.Resources, r.CNPGCluster.Spec.Resources) ||
+		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.StorageClass, r.CNPGCluster.Spec.StorageConfiguration.StorageClass) ||
+		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.Size, r.CNPGCluster.Spec.StorageConfiguration.Size)
 }

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -277,6 +277,17 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 		podSpec.ImagePullSecrets =
 			[]corev1.LocalObjectReference{*r.NooBaa.Spec.ImagePullSecret}
 	}
+
+	if r.DeploymentEndpoint.Spec.Replicas != nil && *r.DeploymentEndpoint.Spec.Replicas == 0 {
+		// replicas can be set to 0 if the cluster went through data import to DB cluster
+		// restore back to the minimum number of replicas
+		minReplicas := int32(1)
+		if endpointsSpec != nil {
+			minReplicas = max(minReplicas, endpointsSpec.MinCount)
+		}
+		r.DeploymentEndpoint.Spec.Replicas = &minReplicas
+	}
+
 	rootUIDGid := int64(0)
 	podSpec.SecurityContext.RunAsUser = &rootUIDGid
 	podSpec.SecurityContext.RunAsGroup = &rootUIDGid


### PR DESCRIPTION
### Explain the changes
- When upgrading from a deployment with an existing DB, provide the DB details in the cluster CR, to perform data import.
- Upgrade flow is as follows:
  - If DB sts exist:
    - Stop core\endpoints pods
    - Create a cnpg cluster with import details in the CR
    - The cnpg operator will start the first instance and deploy an import job to import the data. After the import is completed, the second instance will started.
    - Wait for cluster to complete import and become Ready
    - Once ready scale down the noobaa-db-pg sts to 0 replicas.
    - The reconciliation will wait for the cluster to be ready, and a temp error is returned until it is.
- The old sts is not deleted, to have it around for backup. In future versions we should cleanup all the leftovers.
- Updated `noobaa upgrade` command in noobaa cli, to install the necessary cnpg resources.

### Gaps
- CNPG operator performs the import by performing a pg_dump onto the data volume of the instance and then restoring the dump to the new DB. If the existing DB is too large, we can get into an out-of-space situation. To handle this, we should check the percentage of used space in the existing DB and, above a certain threshold, provision a larger volume for the new cluster. 

### Testing Instructions:
1. Install noobaa from an older version.
2. after installed, run `noobaa upgrade` with a latest build of the CLI. this should install missing cnpg resources and update the noobaa CR to perform import

- [ ] Doc added/updated
- [ ] Tests added
