### PR TITLE
Added cnpg-default-monitoring configmap to opeartor bundle

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -230,11 +230,17 @@ func RunCatalog(cmd *cobra.Command, args []string) {
 		}
 	})
 
-	// write cnpg crds to manifest dir
+	// write cnpg resources to manifest dir
 	if csvParams.IncludeCnpg {
+		// write crds
 		for _, c := range csvParams.CnpgResources.CRDs {
 			util.Panic(util.WriteYamlFile(versionDir+c.Name+".crd.yaml", c))
 		}
+
+		// write configmap cnpg-default-monitoring
+		cm := csvParams.CnpgResources.ConfigMap
+		cm.Namespace = ""
+		util.Panic(util.WriteYamlFile(versionDir+cm.Name+".configmap.yaml", cm))
 	}
 
 }


### PR DESCRIPTION
### Explain the changes
1. the configmap is required by cnpg operator to start the instances pods
2. write the CM yaml to the manifests dir when generating a bundle.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
