### PR TITLE
Block NSS creation when  SignatureVersion v4 and endpoint non-secure

### DIFF
--- a/pkg/cli/cli_suite_test.go
+++ b/pkg/cli/cli_suite_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+var clientset *kubernetes.Clientset
+var logger *log.Logger
+
+func TestCLI(t *testing.T) {
+	// this variable will be defined in .github/workflows/run_some_test.yml
+	// indication of running in integration test environment
+	_, ok := os.LookupEnv("OPERATOR_IMAGE")
+	if !ok {
+		t.Skip() // Not an integration test, skip
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CLI Suite")
+}
+
+func connectToK8s() (*kubernetes.Clientset, error) {
+	clientset, err := kubernetes.NewForConfig(util.KubeConfig())
+	if err != nil {
+		logger.Printf("failed to create K8s clientset")
+		return nil, err
+	}
+
+	return clientset, nil
+}
+
+var _ = BeforeSuite(func(ctx context.Context) {
+	By("Connecting to K8S cluster")
+	logger = log.New(GinkgoWriter, "INFO: ", log.Lshortfile)
+
+	var err error
+	clientset, err = connectToK8s()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(clientset).ToNot(BeNil())
+}, NodeTimeout(60*time.Second))

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,11 +1,15 @@
 package cli
 
 import (
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/noobaa/noobaa-operator/v5/version"
 )
 
@@ -13,42 +17,68 @@ const (
 	CLIPath = "../../build/_output/bin/noobaa-operator-local"
 )
 
-func TestNoArgs(t *testing.T) {
-	out := RunCLI(t)
-	Expect(t, out,
-		`.*?`, `Install:`, `\s*\n`,
-		`.*?`, `Manage:`, `\s*\n`,
-		`.*?`, `Advanced:`, `\s*\n`,
-		`.*?`, `Use "noobaa <command> --help" for more information about a given command.`, `\s*\n`,
-		`.*?`)
-}
+var _ = Describe("CLI tests", func() {
 
-func TestVersion(t *testing.T) {
-	out := RunCLI(t, "version")
-	Expect(t, out,
-		`.*?`, `CLI version: `, version.Version,
-		`.*?`)
-}
+	os.Setenv("TEST_ENV", "true")
 
-func TestOptions(t *testing.T) {
-	out := RunCLI(t, "options")
-	Expect(t, out,
-		`.*?`, `The following options can be passed to any command:`,
-		`.*?`)
-}
+	Context("Noobaa CLI functions", func() {
+		It("CLI with no arguments", func() {
+			cmd := exec.Command(CLIPath)
+			out, err := cmd.CombinedOutput()
+			Expect(err).To(BeNil())
+			Expect(ExpectMessage(string(out),
+				`.*?`, `Install:`, `\s*\n`,
+				`.*?`, `Manage:`, `\s*\n`,
+				`.*?`, `Advanced:`, `\s*\n`,
+				`.*?`, `Use "noobaa <command> --help" for more information about a given command.`, `\s*\n`,
+				`.*?`)).To(BeTrue())
+		})
 
-func RunCLI(t *testing.T, args ...string) string {
-	cmd := exec.Command(CLIPath, args...) // #nosec
+		It("CLI with version", func() {
+			cmd := exec.Command(CLIPath, "version")
+			out, err := cmd.CombinedOutput()
+			Expect(err).To(BeNil())
+			Expect(ExpectMessage(string(out),
+				`.*?`, `CLI version: `, version.Version,
+				`.*?`)).To(BeTrue())
+		})
+
+		It("CLI with Options", func() {
+			cmd := exec.Command(CLIPath, "options")
+			out, err := cmd.CombinedOutput()
+			Expect(err).To(BeNil())
+			Expect(ExpectMessage(string(out),
+				`.*?`, `The following options can be passed to any command:`,
+				`.*?`)).To(BeTrue())
+		})
+	})
+
+	Context("Noobaa namspacestore CLI", func() {
+		It("S3Compatible namespacestore - signature-version validation", func() {
+			cmd := exec.Command(CLIPath, "namespacestore", "create", "s3-compatible", "s3compatible-nss", "--endpoint", "http://localhost.com",
+				"--access-key", "2EA1ZBLabcd123", "--secret-key", "XL2zyHTYElKuxTiCwTabcd1234",
+				"--target-bucket", "test-bucket", "--signature-version", "v4", "-n", "noobaa")
+			out, err := cmd.CombinedOutput()
+			Expect(err).NotTo(BeNil())
+			Expect(ExpectMessage(string(out),
+				`.*?`, `Non-secure endpoint works only with v2 signature-version. Please select signature version v2 for namespacestore`,
+				`.*?`)).To(BeTrue())
+		})
+	})
+})
+
+func RunCLI(args ...string) (string, error) {
+	cmd := exec.Command(CLIPath, args...)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Error(err)
-	}
-	return string(out)
+	return string(out), err
 }
 
-func Expect(t *testing.T, out string, re ...string) {
+func ExpectMessage(out string, re ...string) bool {
+	log := util.Logger()
 	fullRE := regexp.MustCompile("(?s)^" + strings.Join(re, "") + "$")
 	if !fullRE.MatchString(out) {
-		t.Fatalf("Expected output not matching regexp %q %q", fullRE, out)
+		log.Infof("Command output %s and regexp do not match", out)
+		return false
 	}
+	return true
 }


### PR DESCRIPTION
### Explain the changes
1. Block NSS creation when SignatureVersion v4 and endpoint non-secure and return with error.
2. Setting signature version v2 for non-secure endpoint to avoid body content sign in. With secure request body sigin is disabled by [default.](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3DisableBodySigning-property)

No change for Backingstore since uploadPart upload(Non-file stream) is not supported by backingstore. 

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-1035
NSS is in rejected state because the endpoint provided is non-secure and CLI is adding signature version to the endpoint request when try to access data this is creating issue in aws-sdk

related Github issue: https://github.com/aws/aws-sdk-js/issues/965

### Testing Instructions:
1. go test ./pkg/cli/

- [ ] Doc added/updated
- [X] Tests added
