### PR TITLE
Handle low volume space for DB import 

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1214,8 +1214,9 @@ spec:
                     type: object
                   dbMinVolumeSize:
                     description: |-
-                      DBMinVolumeSize (optional) overrides the default PVC resource requirements for the database volume.
-                      The actual requested PVC might be larger if the DB requires more space.
+                      DBMinVolumeSize (optional) The initial size of the database volume.The actual size might be larger.
+                      Increasing the size of the volume is supported if the underlying storage class supports volume expansion.
+                      The new size should be larger than actualVolumeSize in dbStatus for the volume to be resized.
                     type: string
                   dbResources:
                     description: DBResources (optional) overrides the default resource
@@ -1975,6 +1976,10 @@ spec:
               dbStatus:
                 description: DBStatus is the status of the postgres cluster
                 properties:
+                  actualVolumeSize:
+                    description: ActualVolumeSize is the actual size of the postgres
+                      cluster volume. This can be different than the requested size
+                    type: string
                   currentPgMajorVersion:
                     description: CurrentPgMajorVersion is the major version of the
                       postgres cluster

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -31,6 +31,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  resourceNames:
+  - noobaa-db-pg-0
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -327,8 +327,9 @@ type NooBaaDBSpec struct {
 	// +optional
 	DBResources *corev1.ResourceRequirements `json:"dbResources,omitempty"`
 
-	// DBMinVolumeSize (optional) overrides the default PVC resource requirements for the database volume.
-	// The actual requested PVC might be larger if the DB requires more space.
+	// DBMinVolumeSize (optional) The initial size of the database volume.The actual size might be larger.
+	// Increasing the size of the volume is supported if the underlying storage class supports volume expansion.
+	// The new size should be larger than actualVolumeSize in dbStatus for the volume to be resized.
 	// +optional
 	DBMinVolumeSize string `json:"dbMinVolumeSize,omitempty"`
 
@@ -464,6 +465,9 @@ type NooBaaDBStatus struct {
 
 	// CurrentPgMajorVersion is the major version of the postgres cluster
 	CurrentPgMajorVersion int `json:"currentPgMajorVersion,omitempty"`
+
+	// ActualVolumeSize is the actual size of the postgres cluster volume. This can be different than the requested size
+	ActualVolumeSize string `json:"actualVolumeSize,omitempty"`
 }
 
 type DBClusterStatus string

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1423,7 +1423,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "3416255059a8149d163f9db9d4c3501612458a1d5a52cf3094581cfafff8404f"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "aed8cc731e6c6a182d75aa975ed8e7849d229eae6c823c4b3d5b3ae50d74f127"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -2641,8 +2641,9 @@ spec:
                     type: object
                   dbMinVolumeSize:
                     description: |-
-                      DBMinVolumeSize (optional) overrides the default PVC resource requirements for the database volume.
-                      The actual requested PVC might be larger if the DB requires more space.
+                      DBMinVolumeSize (optional) The initial size of the database volume.The actual size might be larger.
+                      Increasing the size of the volume is supported if the underlying storage class supports volume expansion.
+                      The new size should be larger than actualVolumeSize in dbStatus for the volume to be resized.
                     type: string
                   dbResources:
                     description: DBResources (optional) overrides the default resource
@@ -3402,6 +3403,10 @@ spec:
               dbStatus:
                 description: DBStatus is the status of the postgres cluster
                 properties:
+                  actualVolumeSize:
+                    description: ActualVolumeSize is the actual size of the postgres
+                      cluster volume. This can be different than the requested size
+                    type: string
                   currentPgMajorVersion:
                     description: CurrentPgMajorVersion is the major version of the
                       postgres cluster
@@ -6194,7 +6199,7 @@ spec:
         #     name: socket
 `
 
-const Sha256_deploy_role_yaml = "657d632a42e9ed89ad6c0b2d909517346ab32ab0f8f208d5c9178fa8ad28681d"
+const Sha256_deploy_role_yaml = "6d98627f4b3c9834710856edf01c6ed71fcefe1e78b15189343423ecc524e18d"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -6228,6 +6233,14 @@ rules:
   - serviceaccounts
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  resourceNames:
+  - noobaa-db-pg-0
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
### Explain the changes
- Check for the used space before initiating DB import to a new cluster.
  - If the used space is over 33 percent, request double the size for the PV
- Implemented new util function `ExecCommandInPod` to execute a command inside a pod
  - Using `ExecCommandInPod` running `df` in the old DB pod to get used percentage
  - Added permission to the noobaa-operator role to execute commands in `noobaa-db-pg-0` pod
- Also handling updates of storage size to support PVC expansion (for supporting storage-classes)


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
