### PR TITLE
Added a flag DisableRoutes to manage openshift routes in noobaa

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1580,6 +1580,11 @@ spec:
                   type to ClusterIP instead of LoadBalancer
                 nullable: true
                 type: boolean
+              disableRoutes:
+                description: DisableRoutes (optional) disables the reconciliation
+                  of openshift route resources in the cluster
+                nullable: true
+                type: boolean
               endpoints:
                 description: |-
                   Endpoints (optional) sets configuration info for the noobaa endpoint

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -202,6 +202,11 @@ type NooBaaSpec struct {
 	// +optional
 	DisableLoadBalancerService bool `json:"disableLoadBalancerService,omitempty"`
 
+	// DisableRoutes (optional) disables the reconciliation of openshift route resources in the cluster
+	// +nullable
+	// +optional
+	DisableRoutes bool `json:"disableRoutes,omitempty"`
+
 	// Deprecated: DefaultBackingStoreSpec is not supported anymore, use ManualDefaultBackingStore instead.
 	// +optional
 	DefaultBackingStoreSpec *BackingStoreSpec `json:"defaultBackingStoreSpec,omitempty"`

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1423,7 +1423,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "aed8cc731e6c6a182d75aa975ed8e7849d229eae6c823c4b3d5b3ae50d74f127"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "1637077ca2e0d584cd4203469f809b215af45ee4ba5358a283bbd7a5bf1b573e"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -3005,6 +3005,11 @@ spec:
               disableLoadBalancerService:
                 description: DisableLoadBalancerService (optional) sets the service
                   type to ClusterIP instead of LoadBalancer
+                nullable: true
+                type: boolean
+              disableRoutes:
+                description: DisableRoutes (optional) disables the reconciliation
+                  of openshift route resources in the cluster
                 nullable: true
                 type: boolean
               endpoints:

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -141,6 +141,9 @@ var DevEnv = false
 // DisableLoadBalancerService is used for setting the service type to ClusterIP instead of LoadBalancer
 var DisableLoadBalancerService = false
 
+// DisableRoutes is used to disable the reconciliation of openshift route resources
+var DisableRoutes = false
+
 // CosiDriverPath is the cosi socket fs path
 var CosiDriverPath = "/var/lib/cosi/cosi.sock"
 
@@ -305,6 +308,10 @@ func init() {
 	FlagSet.BoolVar(
 		&DisableLoadBalancerService, "disable-load-balancer",
 		false, "Set the service type to ClusterIP instead of LoadBalancer",
+	)
+	FlagSet.BoolVar(
+		&DisableRoutes, "disable-routes",
+		false, "disable the reconciliation of openshift route resources",
 	)
 	FlagSet.StringVar(
 		&CosiDriverPath, "cosi-driver-path",

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -61,14 +61,20 @@ func (r *Reconciler) ReconcilePhaseCreating() error {
 	if err := r.ReconcileObject(r.ServiceS3, r.SetDesiredServiceS3); err != nil {
 		return err
 	}
-	if err := r.ReconcileObjectOptional(r.RouteS3, r.SetDesiredRouteS3); err != nil {
-		return err
+	// reconcile noobaa-s3 route only if routes are enabled
+	if !r.NooBaa.Spec.DisableRoutes {
+		if err := r.ReconcileObjectOptional(r.RouteS3, r.SetDesiredRouteS3); err != nil {
+			return err
+		}
 	}
 	if err := r.ReconcileObject(r.ServiceSts, r.SetDesiredServiceSts); err != nil {
 		return err
 	}
-	if err := r.ReconcileObjectOptional(r.RouteSts, nil); err != nil {
-		return err
+	// reconcile noobaa-sts route only if routes are enabled
+	if !r.NooBaa.Spec.DisableRoutes {
+		if err := r.ReconcileObjectOptional(r.RouteSts, nil); err != nil {
+			return err
+		}
 	}
 	// the credentials that are created by cloud-credentials-operator sometimes take time
 	// to be valid (requests sometimes returns InvalidAccessKeyId for 1-2 minutes)
@@ -173,8 +179,11 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 		return err
 	}
 
-	if err := r.ReconcileObjectOptional(r.RouteMgmt, nil); err != nil {
-		return err
+	// reconcile noobaa-mgmt route only if routes are enabled
+	if !r.NooBaa.Spec.DisableRoutes {
+		if err := r.ReconcileObjectOptional(r.RouteMgmt, nil); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -151,6 +151,7 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 	dbType := options.DBType
 	sys.Spec.DBType = nbv1.DBTypes(dbType)
 	sys.Spec.DisableLoadBalancerService = options.DisableLoadBalancerService
+	sys.Spec.DisableRoutes = options.DisableRoutes
 	sys.Spec.ManualDefaultBackingStore = options.ManualDefaultBackingStore
 	sys.Spec.LoadBalancerSourceSubnets.S3 = options.S3LoadBalancerSourceSubnets
 	sys.Spec.LoadBalancerSourceSubnets.STS = options.STSLoadBalancerSourceSubnets


### PR DESCRIPTION
### Explain the changes
1. Added logic to disable the creation of routes based on the `DisableRoutes` flag. If the flag is set to true, the route creation is skipped, ensuring that routes are only created when necessary, based on the flag value. This allows more control over whether routes are deployed in the cluster.

### Issues: Fixed #xxx / Gap #xxx
1.  JIRA: https://issues.redhat.com/browse/RHSTOR-7195

### Testing Instructions:
1. Manual testing instructions:

-  Need ocp cluster as routes supported by openshift (use cluster-bot).
-  Install ODF and create storage system.
-  Update the operator image (latest including the changes) everywhere in the below csv:
`$ oc edit csv mcg-operator.v4.18.1-rhodf` (please use image from quay/docker)
-  Update the noobaa CRD using below command:
`$ oc apply -f noobaa-operator/deploy/crds/noobaa.io_noobaas.yaml`
-  Edit noobaa instance and add `disableRoute: true` into `Spec`:
`$ oc edit noobaa noobaa`
-  Try deleting routes present, they should not be reconciled after setting `disableRoute: true`:
`$ oc get routes`
