### PR TITLE
Enable DB pods monitoring by default

### DIFF
--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -642,6 +642,9 @@ const (
 
 	// SkipTopologyConstraints is Annotation name for disabling default topology Constraints
 	SkipTopologyConstraints = "noobaa.io/skip_topology_spread_constraints"
+
+	// DisableDBDefaultMonitoring is Annotation name for disabling default db monitoring
+	DisableDBDefaultMonitoring = "noobaa.io/disable_db_default_monitoring"
 )
 
 // DBTypes is a string enum type for specify the types of DB that are supported.

--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -254,6 +254,13 @@ func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
 		r.CNPGCluster.Spec.Affinity.Tolerations = r.NooBaa.Spec.Tolerations
 	}
 
+	// by default enable monitoring of the DB instances. if the annotation is "true", disable monitoring
+	disableMonStr := r.NooBaa.ObjectMeta.Annotations[nbv1.DisableDBDefaultMonitoring]
+	if r.CNPGCluster.Spec.Monitoring == nil {
+		r.CNPGCluster.Spec.Monitoring = &cnpgv1.MonitoringConfiguration{}
+	}
+	r.CNPGCluster.Spec.Monitoring.EnablePodMonitor = disableMonStr != "true"
+
 	r.setPostgresConfig()
 
 	// TODO: consider specifying a separate WAL storage configuration in Spec.WalStorage
@@ -549,5 +556,6 @@ func (r *Reconciler) wasClusterSpecChanged(existingClusterSpec *cnpgv1.ClusterSp
 		!reflect.DeepEqual(existingClusterSpec.Resources, r.CNPGCluster.Spec.Resources) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.StorageClass, r.CNPGCluster.Spec.StorageConfiguration.StorageClass) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.Size, r.CNPGCluster.Spec.StorageConfiguration.Size) ||
+		!reflect.DeepEqual(existingClusterSpec.Monitoring, r.CNPGCluster.Spec.Monitoring) ||
 		!reflect.DeepEqual(existingClusterSpec.PostgresConfiguration.Parameters, r.CNPGCluster.Spec.PostgresConfiguration.Parameters)
 }


### PR DESCRIPTION
### Explain the changes
- By default, enable the DB cluster monitoring in Prometheus
- A PodMonitor resource is created to scrape the DB pods
- The default metrics are defined in the config-map `cnpg-default-monitoring`
- The monitoring can be disabled by annotating noobaa CR with `noobaa.io/disable_db_default_monitoring=true`

- [ ] Doc added/updated
- [ ] Tests added
