### PR TITLE
postgres setup enhancements

### DIFF
--- a/deploy/internal/configmap-postgres-db.yaml
+++ b/deploy/internal/configmap-postgres-db.yaml
@@ -24,3 +24,4 @@ data:
     min_wal_size = 2GB
     max_wal_size = 8GB
     shared_preload_libraries = 'pg_stat_statements'
+    pg_stat_statements.track = all

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -58,10 +58,15 @@ spec:
               mountPath: /var/lib/pgsql
             - name: noobaa-postgres-config-volume
               mountPath: /opt/app-root/src/postgresql-cfg
+            - name: shm
+              mountPath: /dev/shm
       volumes:
         - name: noobaa-postgres-config-volume
           configMap:
             name: noobaa-postgres-config
+        - name: shm
+          emptyDir:
+            medium: Memory
       securityContext:
         runAsUser: 10001
         runAsGroup: 0

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3834,7 +3834,7 @@ metadata:
 data: {}
 `
 
-const Sha256_deploy_internal_configmap_postgres_db_yaml = "afe8a865abf2b033229df9dcea392abc1cb27df965d5ff0181f6d931504dce4e"
+const Sha256_deploy_internal_configmap_postgres_db_yaml = "9e522258577e9b24d289e005e74c8125cffcd56652533fe30ee109c7fb4b95e0"
 
 const File_deploy_internal_configmap_postgres_db_yaml = `apiVersion: v1
 kind: ConfigMap
@@ -3862,6 +3862,7 @@ data:
     min_wal_size = 2GB
     max_wal_size = 8GB
     shared_preload_libraries = 'pg_stat_statements'
+    pg_stat_statements.track = all
 `
 
 const Sha256_deploy_internal_deployment_endpoint_yaml = "21b206c9119e37c4ebba84d5c1e2b1d45b06c716b4def69db9ba9268ef75e1e1"
@@ -5114,7 +5115,7 @@ spec:
                   resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "37a6c36928ba426ca04fd89e1eb2685e10d1a5f65c63ebb40c68a4f5c37645de"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "d0242805c8719ef45290746b42706fb69805cfd40be6258986454d256112fa7c"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5176,10 +5177,15 @@ spec:
               mountPath: /var/lib/pgsql
             - name: noobaa-postgres-config-volume
               mountPath: /opt/app-root/src/postgresql-cfg
+            - name: shm
+              mountPath: /dev/shm
       volumes:
         - name: noobaa-postgres-config-volume
           configMap:
             name: noobaa-postgres-config
+        - name: shm
+          emptyDir:
+            medium: Memory
       securityContext:
         runAsUser: 10001
         runAsGroup: 0


### PR DESCRIPTION
### Explain the changes
- mount a memory based volumen for `/dev/shm`
- extend `terminationGracePeriodSeconds` to 70 seconds
- configure `pg_stat_statements.track = all` to track all types of queries when enabled.

### Issues: Fixed #xxx / Gap #xxx
1.  https://issues.redhat.com/browse/DFBUGS-2458

### Testing Instructions:
1. after upgrade, check noobaa-db-pg statefulset and verify the following:  
  - There is a volume and volume mounts for `/dev/shm`
  - `terminationGracePeriodSeconds` is 70 
  - check that the configmap `noobaa-postgres-config` contains the line `pg_stat_statements.track = all`

- [ ] Doc added/updated
- [ ] Tests added
