### PR TITLE
Authentication for metrics and version endpoint

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -97,6 +97,16 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_LOG_COLOR
+            - name: NOOBAA_METRICS_AUTH_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_METRICS_AUTH_ENABLED
+            - name: NOOBAA_VERSION_AUTH_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_VERSION_AUTH_ENABLED
             - name: MGMT_ADDR
             - name: SYSLOG_ADDR
             - name: BG_ADDR

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -101,6 +101,16 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_LOG_COLOR
+            - name: NOOBAA_METRICS_AUTH_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_METRICS_AUTH_ENABLED
+            - name: NOOBAA_VERSION_AUTH_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_VERSION_AUTH_ENABLED
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_PORT

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3980,7 +3980,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "6e69c76e3a5beeb55b30f045a30492cef835295e351360f464942962be4cdbc3"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "8cd3ac9930997965ab9fef72cbbe8bda1474f848ee8bfe2ee9af8fc6ea58dd69"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4081,6 +4081,16 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_LOG_COLOR
+            - name: NOOBAA_METRICS_AUTH_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_METRICS_AUTH_ENABLED
+            - name: NOOBAA_VERSION_AUTH_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_VERSION_AUTH_ENABLED
             - name: MGMT_ADDR
             - name: SYSLOG_ADDR
             - name: BG_ADDR
@@ -5044,7 +5054,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "ac5e3c4caf9983c154a706f808f02cfd2bea064729d90bba3d5ad42547b8d100"
+const Sha256_deploy_internal_statefulset_core_yaml = "477895e38effe338eeec7c35c1e051ea361db0b21946f03dcdbe46b08dc79f03"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5149,6 +5159,16 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_LOG_COLOR
+            - name: NOOBAA_METRICS_AUTH_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_METRICS_AUTH_ENABLED
+            - name: NOOBAA_VERSION_AUTH_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_VERSION_AUTH_ENABLED
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_PORT

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -1413,10 +1413,12 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 	// When adding a new env var, make sure to add it to the sts/deployment as well
 	// see "NOOBAA_DISABLE_COMPRESSION" as an example
 	DefaultConfigMapData := map[string]string{
-		"NOOBAA_DISABLE_COMPRESSION": "false",
-		"DISABLE_DEV_RANDOM_SEED":    "true",
-		"NOOBAA_LOG_LEVEL":           "default_level",
-		"NOOBAA_LOG_COLOR":           "true",
+		"NOOBAA_DISABLE_COMPRESSION":  "false",
+		"DISABLE_DEV_RANDOM_SEED":     "true",
+		"NOOBAA_LOG_LEVEL":            "default_level",
+		"NOOBAA_LOG_COLOR":            "true",
+		"NOOBAA_METRICS_AUTH_ENABLED": "true",
+		"NOOBAA_VERSION_AUTH_ENABLED": "true",
 	}
 	for key, value := range DefaultConfigMapData {
 		if _, ok := r.CoreAppConfig.Data[key]; !ok {

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -125,6 +125,7 @@ type Reconciler struct {
 	ExternalPgSecret          *corev1.Secret
 	ExternalPgSSLSecret       *corev1.Secret
 	BucketNotificationsPVC    *corev1.PersistentVolumeClaim
+	SecretMetricsAuth         *corev1.Secret
 
 	// CNPG resources
 	CNPGImageCatalog *cnpgv1.ImageCatalog
@@ -194,6 +195,8 @@ func NewReconciler(
 
 		CNPGImageCatalog: cnpg.GetCnpgImageCatalogObj(req.Namespace, req.Name+pgImageCatalogSuffix),
 		CNPGCluster:      cnpg.GetCnpgClusterObj(req.Namespace, req.Name+pgClusterSuffix),
+
+		SecretMetricsAuth: util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 	}
 
 	// Set Namespace
@@ -242,6 +245,7 @@ func NewReconciler(
 	r.AdapterHPA.Namespace = r.Request.Namespace
 	r.BucketLoggingPVC.Namespace = r.Request.Namespace
 	r.BucketNotificationsPVC.Namespace = r.Request.Namespace
+	r.SecretMetricsAuth.Namespace = r.Request.Namespace
 
 	// Set Names
 	r.NooBaa.Name = r.Request.Name
@@ -287,6 +291,7 @@ func NewReconciler(
 	r.AdapterHPA.Name = r.Request.Name + "-hpav2"
 	r.BucketLoggingPVC.Name = r.Request.Name + "-bucket-logging-pvc"
 	r.BucketNotificationsPVC.Name = r.Request.Name + "-bucket-notifications-pvc"
+	r.SecretMetricsAuth.Name = r.Request.Name + "-metrics-auth-secret"
 
 	// Set the target service for routes.
 	r.RouteMgmt.Spec.To.Name = r.ServiceMgmt.Name


### PR DESCRIPTION
### Explain the changes
1. Call CreateAuthAPI rpc with a role `metrics` to get the JWT token in the configuration phase, And the response token will be saved as secret(metrics-auth-secret)
2. JWT is signed using the existing signature key JWT_SECRET that used to sign other admin and operator credentials.
3. Secret will be used for authorization for both noobaa management and s3 ServiceMonitor.

### Issues: Fixed #xxx / Gap #xxx
1. [RHSTOR-7202](https://issues.redhat.com/browse/RHSTOR-7202)
[DFBUGS-1802](https://issues.redhat.com/browse/DFBUGS-1802)

### Testing Instructions:
**containerized deployment**
1. The customer should be able to access the bearer token from the secret `metrics-auth-secret`, secret can be used for accessing noobaa management and endpoint metrics/version.   

```
JWT_TOKEN=$(oc get secret/{token-secret-name} -n {namespace} -o jsonpath={.data.metrics_token} | base64 -d)    
curl -k -H "Authorization: Bearer ${JWT_TOKEN "https://{endpoint-loadbalancer-ingress-ip}:{endpoint-port}
curl -k -H "Authorization: Bearer ${JWT_TOKEN}" https://$(oc -n {namespace} get route noobaa-mgmt -o jsonpath='{.status.ingress[*].host}/version or metrics endpoints')
```
2. Verify all the noobaa specific targets are up and scraping metrics from those tragets in kubernates/ODF 

Design doc : https://ibm.ent.box.com/notes/1853310270159

- [X] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for metrics and version endpoint authentication, configurable via environment variables.
  - Introduced automatic creation and management of a metrics authorization token for secure Prometheus monitoring integration.
- **Chores**
  - Updated internal configuration to support new authentication options for metrics and version endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->