### PR TITLE
[Review only] Save DB diagnostics for CLBO debugging

### DIFF
--- a/deploy/internal/Dockerfile.postgres
+++ b/deploy/internal/Dockerfile.postgres
@@ -1,11 +1,15 @@
 FROM quay.io/sclorg/postgresql-15-c9s
 
-# Copy the wrapper scripts
-COPY scripts/run-postgresql-wrapper.sh /usr/local/bin/run-postgresql-wrapper.sh
-COPY scripts/db-crash-collector.sh /usr/local/bin/db-crash-collector.sh
+# Switch to root user for script preparation
+USER root
 
-# Make the scripts executable
+# Copy the wrapper scripts and make them executable
+COPY scripts/run-postgresql-wrapper.sh /usr/local/bin/
+COPY scripts/db-crash-collector.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/run-postgresql-wrapper.sh /usr/local/bin/db-crash-collector.sh
+
+# Switch back to the default user
+USER 1001
 
 # Use our wrapper as the command
 CMD ["/usr/local/bin/run-postgresql-wrapper.sh"] 

--- a/deploy/internal/Dockerfile.postgres
+++ b/deploy/internal/Dockerfile.postgres
@@ -1,0 +1,11 @@
+FROM quay.io/sclorg/postgresql-15-c9s
+
+# Copy the wrapper scripts
+COPY scripts/run-postgresql-wrapper.sh /usr/local/bin/run-postgresql-wrapper.sh
+COPY scripts/db-crash-collector.sh /usr/local/bin/db-crash-collector.sh
+
+# Make the scripts executable
+RUN chmod +x /usr/local/bin/run-postgresql-wrapper.sh /usr/local/bin/db-crash-collector.sh
+
+# Use our wrapper as the command
+CMD ["/usr/local/bin/run-postgresql-wrapper.sh"] 

--- a/deploy/internal/scripts/db-crash-collector.sh
+++ b/deploy/internal/scripts/db-crash-collector.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Create diagnostics directory if it doesn't exist
+DIAG_DIR="/var/lib/pgsql/diagnostics/crash_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$DIAG_DIR"
+
+# Function to log messages
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$DIAG_DIR/collector.log"
+}
+
+log "Starting crash diagnostics collection"
+
+# Find the correct userdata directory
+USERDATA_DIR=""
+if [ -d "/var/lib/pgsql/data/userdata" ]; then
+    USERDATA_DIR="/var/lib/pgsql/data/userdata"
+elif [ -d "/var/lib/pgsql/data/data/userdata/data/userdata" ]; then
+    USERDATA_DIR="/var/lib/pgsql/data/data/userdata/data/userdata"
+else
+    log "WARNING: Could not find userdata directory in either expected location."
+fi
+
+# Save relevant config files if possible
+if [ -n "$USERDATA_DIR" ]; then
+    log "Using userdata directory: $USERDATA_DIR"
+    for f in postgresql.conf pg_hba.conf; do
+        if [ -f "$USERDATA_DIR/$f" ]; then
+            cp "$USERDATA_DIR/$f" "$DIAG_DIR/"
+        fi
+    done
+    # Copy PostgreSQL logs if present
+    if [ -d "$USERDATA_DIR/log" ]; then
+        cp -r "$USERDATA_DIR/log" "$DIAG_DIR/pg_log"
+    fi
+fi
+
+# Collect PostgreSQL database information
+log "Collecting PostgreSQL database information"
+psql -c "\du" > "$DIAG_DIR/roles.txt" 2>/dev/null || log "Failed to get roles"
+psql -c "\l" > "$DIAG_DIR/databases.txt" 2>/dev/null || log "Failed to get databases"
+psql -d nbcore -c "\dt" > "$DIAG_DIR/nbcore_tables.txt" 2>/dev/null || log "Failed to get nbcore tables"
+
+# Collect environment variables
+log "Collecting environment variables"
+env | sort > "$DIAG_DIR/env.txt"
+
+# Collect process list
+log "Collecting process list"
+ps auxww > "$DIAG_DIR/ps.txt"
+
+# Save termination log if it exists
+if [ -f /dev/termination-log ]; then
+    log "Saving termination log"
+    cp /dev/termination-log "$DIAG_DIR/termination-log.txt"
+fi
+
+# Create a summary file
+SUMMARY_FILE="$DIAG_DIR/summary.txt"
+log "Creating summary file"
+echo "Crash Diagnostics Summary" > "$SUMMARY_FILE"
+echo "========================" >> "$SUMMARY_FILE"
+echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')" >> "$SUMMARY_FILE"
+echo "Hostname: $(hostname)" >> "$SUMMARY_FILE"
+echo "Pod Name: ${HOSTNAME:-unknown}" >> "$SUMMARY_FILE"
+echo "Container ID: $(cat /proc/self/cgroup | grep -o -E '[0-9a-f]{64}' | head -n1)" >> "$SUMMARY_FILE"
+echo "" >> "$SUMMARY_FILE"
+echo "Files collected:" >> "$SUMMARY_FILE"
+ls -l "$DIAG_DIR" >> "$SUMMARY_FILE"
+
+log "Crash diagnostics collection complete. Files saved in $DIAG_DIR" 

--- a/deploy/internal/scripts/run-postgresql-wrapper.sh
+++ b/deploy/internal/scripts/run-postgresql-wrapper.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Create diagnostics directory if it doesn't exist
+DIAG_DIR="/var/lib/pgsql/diagnostics"
+mkdir -p "$DIAG_DIR"
+
+# Create a timestamped log file for this run
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="${DIAG_DIR}/postgres_${TIMESTAMP}.log"
+
+# Function to log messages with timestamp
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+log "Starting PostgreSQL wrapper script"
+log "Log file: $LOG_FILE"
+
+# Log environment variables (excluding sensitive data)
+log "Environment variables:"
+env | grep -v -E 'PASSWORD|SECRET|KEY' | sort | tee -a "$LOG_FILE"
+
+# Log system information
+log "System information:"
+df -h | tee -a "$LOG_FILE"
+free -h | tee -a "$LOG_FILE"
+
+log "Starting PostgreSQL initialization..."
+
+# Set up logging for all subsequent commands and execute run-postgresql
+exec 1> >(tee -a "$LOG_FILE") 2>&1 /usr/bin/run-postgresql "$@" 

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -60,6 +60,10 @@ spec:
               mountPath: /opt/app-root/src/postgresql-cfg
             - name: shm
               mountPath: /dev/shm
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/usr/local/bin/db-crash-collector.sh"]
       volumes:
         - name: noobaa-postgres-config-volume
           configMap:

--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -60,10 +60,6 @@ spec:
               mountPath: /opt/app-root/src/postgresql-cfg
             - name: shm
               mountPath: /dev/shm
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/usr/local/bin/db-crash-collector.sh"]
       volumes:
         - name: noobaa-postgres-config-volume
           configMap:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3676,16 +3676,20 @@ metadata:
 spec: {}
 `
 
-const Sha256_deploy_internal_Dockerfile_postgres = "ed2f9a37fd057494e1dddace4685514c004678ed1d06b1092272395ee71c4406"
+const Sha256_deploy_internal_Dockerfile_postgres = "45f8d46af35b72be69e5e8a4c871d0466bbd61dbb8cc645c3714e7d8ec5ab88c"
 
 const File_deploy_internal_Dockerfile_postgres = `FROM quay.io/sclorg/postgresql-15-c9s
 
-# Copy the wrapper scripts
-COPY scripts/run-postgresql-wrapper.sh /usr/local/bin/run-postgresql-wrapper.sh
-COPY scripts/db-crash-collector.sh /usr/local/bin/db-crash-collector.sh
+# Switch to root user for script preparation
+USER root
 
-# Make the scripts executable
+# Copy the wrapper scripts and make them executable
+COPY scripts/run-postgresql-wrapper.sh /usr/local/bin/
+COPY scripts/db-crash-collector.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/run-postgresql-wrapper.sh /usr/local/bin/db-crash-collector.sh
+
+# Switch back to the default user
+USER 1001
 
 # Use our wrapper as the command
 CMD ["/usr/local/bin/run-postgresql-wrapper.sh"] `
@@ -5239,7 +5243,7 @@ spec:
                   resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "b323c6189379186bf2f2c3aa8086672192cabb9bc6ba6a81a4dd78a661a439dd"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "d0242805c8719ef45290746b42706fb69805cfd40be6258986454d256112fa7c"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5303,10 +5307,6 @@ spec:
               mountPath: /opt/app-root/src/postgresql-cfg
             - name: shm
               mountPath: /dev/shm
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/usr/local/bin/db-crash-collector.sh"]
       volumes:
         - name: noobaa-postgres-config-volume
           configMap:

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -283,7 +283,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 			c.Lifecycle = &corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/bin/sh", "-c", "pg_ctl -D /var/lib/pgsql/data/userdata/ -w -t 60 -m fast stop"},
+						Command: []string{"/bin/sh", "-c", "/usr/local/bin/db-crash-collector.sh &&pg_ctl -D /var/lib/pgsql/data/userdata/ -w -t 60 -m fast stop"},
 					},
 				},
 			}

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -283,7 +283,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 			c.Lifecycle = &corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/bin/sh", "-c", "/usr/local/bin/db-crash-collector.sh &&pg_ctl -D /var/lib/pgsql/data/userdata/ -w -t 60 -m fast stop"},
+						Command: []string{"/bin/sh", "-c", "/usr/local/bin/db-crash-collector.sh && pg_ctl -D /var/lib/pgsql/data/userdata/ -w -t 60 -m fast stop"},
 					},
 				},
 			}


### PR DESCRIPTION
### Explain the changes
This code enhances our PostgreSQL container with comprehensive logging and crash diagnostics. It will not be merged, it is only here for public access and review as part of our debugging efforts for [issue 2414](https://issues.redhat.com/browse/DFBUGS-2414). It introduces two key scripts:
1. run-postgresql-wrapper.sh
- Captures all stdout/stderr from PostgreSQL startup and runtime and saves it into logs on the DB PV
- Logs to timestamped files in /var/lib/pgsql/diagnostics/
2. db-crash-collector.sh
- Collects a snapshot of the environment upon crashing
- Saves termination logs, PostgreSQL configs, environment variables, and process list

There are two flows -
The first is executed on startup. It wraps the Postgres' pod [original CMD and ENTRYPOINT](https://github.com/sclorg/postgresql-container/blob/e0bd882176383a965eb736019bfcbfc8ec14e068/15/Dockerfile.c9s#L90-L91) and saves some diagnostics on the DB PV, while also redirecting stdout and stderr to a file on the PV.
The second is called upon the DB pod's termination via the preStop hook, which then collects additional diagnostics and saves them on the DB PV as well.