### PR TITLE
Add a pre-commit linter hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,38 @@
+#!/bin/sh
+export PATH="$PATH:$(go env GOPATH)/bin"
+
+command -v golangci-lint >/dev/null 2>&1 || {
+  echo "❌ golangci-lint not found – run 'make lint' to install it automatically"
+  exit 1
+}
+
+# Get list of staged Go files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.go$' | sed 's| |\\ |g')
+
+# If there are no staged Go files, exit successfully
+if [ -z "$STAGED_FILES" ]; then
+  echo "✅ No staged Go files were found, exiting"
+  exit 0
+fi
+
+# Run golangci-lint on staged files
+echo "Running golangci-lint on staged files..."
+BASE=$(git rev-parse --verify HEAD 2>/dev/null || echo "")
+if [ -z "$BASE" ]; then
+  golangci-lint run $STAGED_FILES   # initial commit – lint everything staged
+else
+  golangci-lint run --new-from-rev="$BASE"
+fi
+
+# Store the exit code
+LINT_EXIT_CODE=$?
+
+# If golangci-lint found errors, exit with error
+if [ $LINT_EXIT_CODE -ne 0 ]; then
+  echo "❌ golangci-lint found errors in staged files. Please fix them before committing."
+  exit 1
+fi
+
+echo "✅ golangci-lint passed!"
+
+exit 0 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ release: release-docker release-cli
 #- Generate -#
 #------------#
 
-gen: vendor pkg/bundle/deploy.go
+gen: install-hooks vendor pkg/bundle/deploy.go
 	@echo "✅ gen"
 .PHONY: gen
 
@@ -329,3 +329,11 @@ deepcopy-gen:
 DEEPCOPY_GEN=$(GOBIN)/deepcopy-gen
 .PHONY: deepcopy-gen
 
+install-hooks:
+	@if [ -d .git ]; then \
+		if [ "$(shell git config core.hooksPath)" != ".githooks" ]; then \
+			git config core.hooksPath .githooks; \
+			echo "Git hooks path set to .githooks"; \
+		fi; \
+	fi
+.PHONY: install-hooks


### PR DESCRIPTION
### Explain the changes
1. Enforce pre-commit hooks for all contributors by using a shared `.githooks` directory and configuring `core.hooksPath` automatically upon calls to most `make <target>` runs (in order to ensure consistency across devs and envs)
2. Added an `install-hooks` Makefile target that sets the Git hooks path to `.githooks` only if not already set, and only if the repository is a Git repo.
3. Made `install-hooks` a dependency of the `gen` target, ensuring hooks are installed for both containerized and non-containerized workflows.
4. Improved Makefile logic to avoid unnecessary output if the hooks path is already set.

### Testing Instructions:
1. Clone the repository
2. Run `go mod vendor` to make sure `golangci-lint` is installed with the right version and in the right path
3. Run any standard Makefile target (e.g., `make gen`, `make build`, `make all`).
4. Verify that `.githooks` is set as the hooks path (`git config core.hooksPath` should output `.githooks`).
5. Attempt a commit (e.g. with an unused variable) and confirm that the pre-commit hook runs as expected.
6. Run `make gen` and confirm there are no prints related to git hooks in the console.

Alternatively, after cloning the repo, `cd` into the repo's root and run `git config core.hooksPath .githooks`.
Then, follow the instructions from step 3 onwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a Git pre-commit hook to run linting checks on staged Go files before committing.
  - Updated the build process to automatically configure Git hooks path for consistent linting enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->