### PR TITLE
Bumping version from 5.19.0 to 5.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ The following options can be passed to any command:
     --manual-default-backingstore=false: allow to delete the default backingstore
     --mini=false: Signal the operator that it is running in a low resource environment
     -n, --namespace='default': Target namespace
-    --noobaa-image='noobaa/noobaa-core:5.19.0': NooBaa image
-    --operator-image='noobaa/noobaa-operator:5.19.0': Operator image
+    --noobaa-image='noobaa/noobaa-core:5.20.0': NooBaa image
+    --operator-image='noobaa/noobaa-operator:5.20.0': Operator image
     --pg-ssl-cert='': ssl cert for postgres (client-side cert - need to be signed by external pg accepted CA)
     --pg-ssl-key='': ssl key for postgres (client-side cert - need to be signed by external pg accepted CA)
     --pg-ssl-required=false: Force noobaa to work with ssl (external postgres - server-side) [if server cert is self-signed, needs to add --ssl-unauthorized]
@@ -177,9 +177,9 @@ $ noobaa version
 ```
 
 ```
-INFO[0000] CLI version: 5.19.0
-INFO[0000] noobaa-image: noobaa/noobaa-core:5.19.0
-INFO[0000] operator-image: noobaa/noobaa-operator:5.19.0
+INFO[0000] CLI version: 5.20.0
+INFO[0000] noobaa-image: noobaa/noobaa-core:5.20.0
+INFO[0000] operator-image: noobaa/noobaa-operator:5.20.0
 ```
 
 ## Troubleshooting

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1,6 +1,6 @@
 package bundle
 
-const Version = "5.19.0"
+const Version = "5.20.0"
 
 const Sha256_deploy_cluster_role_yaml = "31fc622ff7fa66617be3895bddcb6cfdb97883b75b20bdb2bf04052bd14221a8"
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 const (
 	// Version is the noobaa-operator version (semver)
-	Version = "5.19.0"
+	Version = "5.20.0"
 )


### PR DESCRIPTION
### Explain the changes
Bumping version from 5.19.0 to 5.20.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect the new default version number 5.20.0 for the CLI and container images.

- **Chores**
  - Bumped default version references from 5.19.0 to 5.20.0 throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->