### PR TITLE
Add a cleanup option to our pre-upgrade dbdump

### DIFF
--- a/deploy/internal/configmap-postgres-initdb.yaml
+++ b/deploy/internal/configmap-postgres-initdb.yaml
@@ -61,7 +61,7 @@ data:
           set +e
           # dump the db. retry 3 times in case of failure
           for i in {1..3}; do
-            pg_dumpall -U postgres > /$HOME/data/dump.sql
+            pg_dumpall -U postgres -c > /$HOME/data/dump.sql
             if [ $? -eq 0 ]; then
               break
             elif [ $i -eq 3 ]; then

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3651,7 +3651,7 @@ data:
     pg_stat_statements.track = all
 `
 
-const Sha256_deploy_internal_configmap_postgres_initdb_yaml = "5ef599d78f148d91023d38ef516f73a0d903dfb060eb382fb741b65291955fbe"
+const Sha256_deploy_internal_configmap_postgres_initdb_yaml = "8b0a6104e2cfe38b2d105548120319b0e8b6a0564c75ea0fb9152027785c95e4"
 
 const File_deploy_internal_configmap_postgres_initdb_yaml = `apiVersion: v1
 kind: ConfigMap
@@ -3716,7 +3716,7 @@ data:
           set +e
           # dump the db. retry 3 times in case of failure
           for i in {1..3}; do
-            pg_dumpall -U postgres > /$HOME/data/dump.sql
+            pg_dumpall -U postgres -c > /$HOME/data/dump.sql
             if [ $? -eq 0 ]; then
               break
             elif [ $i -eq 3 ]; then

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -1542,6 +1542,7 @@ func (r *Reconciler) ReconcileSetDbImageAndInitCode(targetImage string, initScri
 func (r *Reconciler) HasUpgradeDbContainerFailed(dbPod *corev1.Pod) string {
 	//when init container restart policy is Always, pod state will not be set to failed on container error.
 	//check for persistent error in container
+	r.Logger.Infof("HasUpgradeDbContainerFailed: upgrade-db containers status: %v", dbPod.Status.InitContainerStatuses)
 	for i := range dbPod.Status.InitContainerStatuses {
 		if dbPod.Status.InitContainerStatuses[i].Name == "upgrade-db" {
 			r.Logger.Infof("HasUpgradeDbContainerFailed: Checking state of upgrade-db container: %v", dbPod.Status.InitContainerStatuses[i].State)


### PR DESCRIPTION
### Explain the changes
1.  Added cleanup option do the db dump we are taking as part of db upgrade
2. Add a print of init containters status as once when upgrade failed I couldn't see why.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved database dump process to ensure objects are properly dropped before restore, reducing potential conflicts during database restoration.
- **Chores**
	- Enhanced logging for database upgrade containers to provide better visibility during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->