### PR TITLE
Support key rotation for KMIP KMS

### DIFF
--- a/pkg/util/kms/kms_kmip.go
+++ b/pkg/util/kms/kms_kmip.go
@@ -14,6 +14,7 @@ const (
 	KMIPEndpoint      = "KMIP_ENDPOINT"
 	KMIPSecret        = "KMIP_CERTS_SECRET"
 	KMIPUniqueID      = "UniqueIdentifier"
+	NewKMIPUniqueID   = "UniqueIdentifierNew"
 	KMIPTLSServerName = "TLS_SERVER_NAME"
 	KMIPReadTimeOut   = "READ_TIMEOUT"
 	KMIPWriteTimeOut  = "WRITE_TIMEOUT"
@@ -25,6 +26,9 @@ const (
 
 // KMIP is a kmip driver
 type KMIP struct {
+	UID  string // NooBaa system UID
+	name string // NooBaa system name
+	ns   string // NooBaa system namespace
 }
 
 // NewKMIP is KMIP driver constructor
@@ -33,7 +37,7 @@ func NewKMIP(
 	namespace string,
 	uid string,
 ) Driver {
-	return &KMIP{}
+	return &KMIP{uid, name, namespace}
 }
 
 //
@@ -108,7 +112,7 @@ func (k *KMIP) DeleteContext() map[string]string {
 // Version returns the current driver KMS version
 // either single string or map, i.e. rotating key
 func (k *KMIP) Version(kms *KMS) Version {
-	return &VersionSingleSecret{kms, nil}
+	return &VersionRotatingSecret{VersionBase{kms, nil}, k.name, k.ns}
 }
 
 // Register KMIP driver with KMS layer

--- a/pkg/util/kms/kms_kmip_storage.go
+++ b/pkg/util/kms/kms_kmip_storage.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 
 	"crypto/tls"
@@ -34,8 +35,6 @@ const (
 	protocolMajor = 1
 	protocolMinor = 4
 
-	// Expected secret data length in bits
-	cryptographicLength = 256
 )
 
 // KMIPSecretStorage is a KMIP backend Key Management Systems (KMS)
@@ -261,10 +260,15 @@ func (k *KMIPSecretStorage) GetSecret(
 
 	log := util.Logger()
 
+	lookfor := KMIPUniqueID // Addition to upgrade
+	if strings.HasSuffix(secretID, "-root-master-key-backend") {
+		lookfor = NewKMIPUniqueID
+	}
+
 	// KMIP key uniqueIdentifier
-	uniqueIdentifier, exists := k.secret.StringData[KMIPUniqueID]
+	uniqueIdentifier, exists := k.secret.StringData[lookfor]
 	if !exists {
-		log.Errorf("KMIPSecretStorage.GetSecret() uniqueIdentifier %v does not exist in secret %v", KMIPUniqueID, k.secret)
+		log.Errorf("KMIPSecretStorage.GetSecret() uniqueIdentifier %v does not exist in secret %v", lookfor, k.secret)
 		return nil, secrets.NoVersion, secrets.ErrInvalidSecretId
 	}
 
@@ -305,9 +309,6 @@ func (k *KMIPSecretStorage) GetSecret(
 	if getRespPayload.SymmetricKey.KeyBlock.KeyFormatType != kmip14.KeyFormatTypeRaw {
 		return nil, secrets.NoVersion, fmt.Errorf("Unexpected  KeyBlock format type actual %v, expected KeyFormatTypeRaw %v", getRespPayload.SymmetricKey.KeyBlock.KeyFormatType, kmip14.KeyFormatTypeRaw)
 	}
-	if getRespPayload.SymmetricKey.KeyBlock.CryptographicLength != cryptographicLength {
-		return nil, secrets.NoVersion, fmt.Errorf("Unexpected  KeyBlock crypto len actual %v, expected %v", getRespPayload.SymmetricKey.KeyBlock.CryptographicLength, cryptographicLength)
-	}
 	if getRespPayload.SymmetricKey.KeyBlock.CryptographicAlgorithm != kmip14.CryptographicAlgorithmAES {
 		return nil, secrets.NoVersion, fmt.Errorf("Unexpected  KeyBlock crypto algo actual %v, expected CryptographicAlgorithmAES %v", getRespPayload.SymmetricKey.KeyBlock.CryptographicAlgorithm, kmip14.CryptographicAlgorithmAES)
 	}
@@ -329,10 +330,6 @@ func (k *KMIPSecretStorage) PutSecret(
 	keyContext map[string]string,
 ) (secrets.Version, error) {
 	log := util.Logger()
-	if _, exists := k.secret.StringData[KMIPUniqueID]; exists {
-		log.Errorf("KMIPSecretStorage.PutSecret() Key UniqueIdentifier %v was not found in the secret", KMIPUniqueID)
-		return secrets.NoVersion, secrets.ErrSecretExists
-	}
 
 	// Register the key value the KMIP endpoint
 	value := plainText[secretID].(string)
@@ -356,7 +353,7 @@ func (k *KMIPSecretStorage) PutSecret(
 				KeyValue: &kmip.KeyValue{
 					KeyMaterial: valueBytes,
 				},
-				CryptographicLength:    cryptographicLength,
+				CryptographicLength:    len(valueBytes) * 8, // in bits
 				CryptographicAlgorithm: kmip14.CryptographicAlgorithmAES,
 			},
 		},
@@ -380,7 +377,7 @@ func (k *KMIPSecretStorage) PutSecret(
 		return secrets.NoVersion, err
 	}
 
-	k.secret.StringData[KMIPUniqueID] = registerRespPayload.UniqueIdentifier
+	k.secret.StringData[NewKMIPUniqueID] = registerRespPayload.UniqueIdentifier
 	if !util.KubeUpdate(k.secret) {
 		log.Errorf("Failed to update KMS secret %v in ns %v", k.secret.Name, k.secret.Namespace)
 		return secrets.NoVersion, fmt.Errorf("Failed to update KMS secret %v in ns %v", k.secret.Name, k.secret.Namespace)
@@ -396,8 +393,12 @@ func (k *KMIPSecretStorage) DeleteSecret(
 ) error {
 	log := util.Logger()
 
+	lookfor := KMIPUniqueID // Addition to upgrade
+	if strings.HasSuffix(secretID, "-root-master-key-backend") {
+		lookfor = NewKMIPUniqueID
+	}
 	// Find the key ID
-	uniqueIdentifier, exists := k.secret.StringData[KMIPUniqueID]
+	uniqueIdentifier, exists := k.secret.StringData[lookfor]
 	if !exists {
 		log.Errorf("KMIPSecretStorage.DeleteSecret() No uniqueIdentifier in the secret")
 		return secrets.ErrInvalidSecretId
@@ -437,8 +438,8 @@ func (k *KMIPSecretStorage) DeleteSecret(
 		return fmt.Errorf("Unexpected uniqueIdentifier %v in destroy response , expected %v", destroyRespPayload.UniqueIdentifier, uniqueIdentifier)
 	}
 
-	delete(k.secret.Data, KMIPUniqueID)
-	delete(k.secret.StringData, KMIPUniqueID)
+	delete(k.secret.Data, lookfor)
+	delete(k.secret.StringData, lookfor)
 	if !util.KubeUpdate(k.secret) {
 		log.Errorf("Failed to update KMS secret %v in ns %v", k.secret.Name, k.secret.Namespace)
 		return fmt.Errorf("Failed to update KMS secret %v in ns %v", k.secret.Name, k.secret.Namespace)

--- a/pkg/util/kms/kms_version.go
+++ b/pkg/util/kms/kms_version.go
@@ -1,6 +1,8 @@
 package kms
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -44,7 +46,7 @@ func (v *VersionSingleSecret) Get() error {
 	s, _, err := v.k.GetSecret(v.k.driver.Path(), v.k.driver.GetContext())
 	if err != nil {
 		// handle k8s get from non-existent secret
-		if strings.Contains(err.Error(), "not found") {
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "does not exist") {
 			return secrets.ErrInvalidSecretId
 		}
 		return err
@@ -107,17 +109,33 @@ func (v *VersionRotatingSecret) Get() error {
 	s, _, err := v.k.GetSecret(v.BackendSecretName(), v.k.driver.GetContext())
 	if err != nil {
 		// handle k8s get from non-existent secret
-		if strings.Contains(err.Error(), "not found") {
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "does not exist") {
 			return secrets.ErrInvalidSecretId
 		}
 		return err
 	}
 
+	if (v.k.driver.Name() == "KMIPSecret") {
+		encodedData, ok := s[v.BackendSecretName()]
+		if !ok {
+			return secrets.ErrInvalidSecretData
+		}
+		data := map[string]string{}
+		decodedString, err := base64.StdEncoding.DecodeString(encodedData.(string))
+		if err != nil {
+			return secrets.ErrInvalidSecretData
+		}
+		err = json.Unmarshal(decodedString, &data)
+		if err != nil {
+			return secrets.ErrInvalidSecretData
+		}
+		v.data = data
+		return nil
+	}
 	rc := map[string]string{}
 	for k, v := range s {
 		rc[k] = v.(string)
 	}
-
 	v.data = rc
 	return nil
 }
@@ -139,7 +157,17 @@ func (v *VersionRotatingSecret) Set(val string) error {
 	s[ActiveRootKey] = key
 	s[key] = val
 	v.data = s
-	_, err := v.k.PutSecret(v.BackendSecretName(), toInterfaceMap(s), v.k.driver.SetContext())
+	var err error
+	if (v.k.driver.Name() == "KMIPSecret") {
+		jsonData, err := json.Marshal(s)
+		encodedString := base64.StdEncoding.EncodeToString(jsonData)
+		if err != nil {
+			return err
+		}
+		_, err = v.k.PutSecret(v.BackendSecretName(), map[string]interface{}{v.BackendSecretName(): encodedString}, v.k.driver.SetContext())
+		return err
+	}
+	_, err = v.k.PutSecret(v.BackendSecretName(), toInterfaceMap(s), v.k.driver.SetContext())
 	return err
 }
 

--- a/pkg/util/kms/test/kmip/kms_kmip_test.go
+++ b/pkg/util/kms/test/kmip/kms_kmip_test.go
@@ -41,7 +41,7 @@ func checkExternalSecret(noobaa *nbv1.NooBaa, expectExists bool) {
 	secret.Namespace = noobaa.Namespace
 	secret.Name = k.TokenSecretName
 	Expect(util.KubeCheck(secret)).To(BeTrue())
-	_, exists := secret.StringData[kms.KMIPUniqueID]
+	_, exists := secret.StringData[kms.NewKMIPUniqueID]
 	Expect(exists == expectExists).To(BeTrue())
 }
 
@@ -116,6 +116,44 @@ var _ = Describe("KMS - KMIP", func() {
 			delete(noobaa.Spec.Security.KeyManagementService.ConnectionDetails, kms.KMIPEndpoint)
 			Expect(util.KubeCreateFailExisting(noobaa)).To(BeTrue())
 			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSInvalid)).To(BeTrue())
+			Expect(util.KubeDelete(noobaa)).To(BeTrue())
+		})
+	})
+
+	Context("Verify Rotate", func() {
+		noobaa := getMiniNooBaa()
+		noobaa.Spec.Security.KeyManagementService = simpleKmsSpec(tokenSecretName, apiAddress)
+		noobaa.Spec.Security.KeyManagementService.EnableKeyRotation = true
+		noobaa.Spec.Security.KeyManagementService.Schedule = "* * * * *" // every min
+
+		Specify("Verify API Address", func() {
+			Expect(apiAddressFound).To(BeTrue())
+		})
+		Specify("Create key rotate schedule system", func() {
+			Expect(util.KubeCreateFailExisting(noobaa)).To(BeTrue())
+		})
+		Specify("Verify KMS condition Type", func() {
+			Expect(util.NooBaaCondition(noobaa, nbv1.ConditionTypeKMSType, "kmip")).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Init", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSInit)).To(BeTrue())
+		})
+		Specify("Restart NooBaa operator", func() {
+			podList := &corev1.PodList{}
+			podSelector, _ := labels.Parse("noobaa-operator=deployment")
+			listOptions := client.ListOptions{Namespace: options.Namespace, LabelSelector: podSelector}
+
+			Expect(util.KubeList(podList, &listOptions)).To(BeTrue())
+			Expect(len(podList.Items)).To(BeEquivalentTo(1))
+			Expect(util.KubeDelete(&podList.Items[0])).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Sync", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSSync)).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Key Rotate", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSKeyRotate)).To(BeTrue())
+		})
+		Specify("Delete NooBaa", func() {
 			Expect(util.KubeDelete(noobaa)).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
### Explain the changes
1. Due to the removal of NOOBAA_ROOT_SECRET, we have to move KMIP KMS support from a single string to a rotating secret.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-2844

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced KMIP integration to support key rotation with additional system name and namespace fields.
  - Improved secret handling with dynamic unique identifier keys and updated encoding for KMIP secrets.

- **Tests**
  - Added new tests to verify key rotation functionality and related conditions for KMIP integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->