### PR TITLE
Update project linting to adhere to golangci-lint v2 defaults

### DIFF
--- a/pkg/bucketclass/bucketclass.go
+++ b/pkg/bucketclass/bucketclass.go
@@ -658,7 +658,8 @@ func MapNamespacestoreToBucketclasses(namespacestore types.NamespacedName) []rec
 			continue
 		}
 		policyType := bc.Spec.NamespacePolicy.Type
-		if policyType == nbv1.NSBucketClassTypeSingle {
+		switch policyType {
+		case nbv1.NSBucketClassTypeSingle:
 			nsr := bc.Spec.NamespacePolicy.Single.Resource
 			if nsr == namespacestore.Name {
 				reqs = append(reqs, reconcile.Request{
@@ -668,7 +669,7 @@ func MapNamespacestoreToBucketclasses(namespacestore types.NamespacedName) []rec
 					},
 				})
 			}
-		} else if policyType == nbv1.NSBucketClassTypeCache {
+		case nbv1.NSBucketClassTypeCache:
 			nsr := bc.Spec.NamespacePolicy.Cache.HubResource
 			if nsr == namespacestore.Name {
 				reqs = append(reqs, reconcile.Request{
@@ -678,7 +679,7 @@ func MapNamespacestoreToBucketclasses(namespacestore types.NamespacedName) []rec
 					},
 				})
 			}
-		} else if policyType == nbv1.NSBucketClassTypeMulti {
+		case nbv1.NSBucketClassTypeMulti:
 			nsr := bc.Spec.NamespacePolicy.Multi.WriteResource
 			if nsr == namespacestore.Name {
 				reqs = append(reqs, reconcile.Request{
@@ -749,7 +750,8 @@ func CreateNamespaceBucketInfoStructure(namespacePolicy nbv1.NamespacePolicy, pa
 	var readResources []nb.NamespaceResourceFullConfig
 	namespaceBucketInfo := &nb.NamespaceBucketInfo{}
 
-	if namespacePolicyType == nbv1.NSBucketClassTypeSingle {
+	switch namespacePolicyType {
+	case nbv1.NSBucketClassTypeSingle:
 
 		namespaceBucketInfo.WriteResource = nb.NamespaceResourceFullConfig{
 			Resource: namespacePolicy.Single.Resource,
@@ -757,7 +759,7 @@ func CreateNamespaceBucketInfoStructure(namespacePolicy nbv1.NamespacePolicy, pa
 		}
 		namespaceBucketInfo.ReadResources = append(readResources, nb.NamespaceResourceFullConfig{
 			Resource: namespacePolicy.Single.Resource})
-	} else if namespacePolicyType == nbv1.NSBucketClassTypeMulti {
+	case nbv1.NSBucketClassTypeMulti:
 		if namespacePolicy.Multi.WriteResource != "" {
 			namespaceBucketInfo.WriteResource = nb.NamespaceResourceFullConfig{
 				Resource: namespacePolicy.Multi.WriteResource,
@@ -769,7 +771,7 @@ func CreateNamespaceBucketInfoStructure(namespacePolicy nbv1.NamespacePolicy, pa
 			readResources = append(readResources, nb.NamespaceResourceFullConfig{Resource: rr})
 		}
 		namespaceBucketInfo.ReadResources = readResources
-	} else if namespacePolicyType == nbv1.NSBucketClassTypeCache {
+	case nbv1.NSBucketClassTypeCache:
 		namespaceBucketInfo.WriteResource = nb.NamespaceResourceFullConfig{Resource: namespacePolicy.Cache.HubResource}
 		namespaceBucketInfo.ReadResources = append(readResources, nb.NamespaceResourceFullConfig{Resource: namespacePolicy.Cache.HubResource})
 		namespaceBucketInfo.Caching = &nb.CacheSpec{TTLMs: namespacePolicy.Cache.Caching.TTL}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -19,7 +18,7 @@ const (
 
 var _ = Describe("CLI tests", func() {
 
-	os.Setenv("TEST_ENV", "true")
+	util.SafeSetEnv("TEST_ENV", "true")
 
 	Context("Noobaa CLI functions", func() {
 		It("CLI with no arguments", func() {

--- a/pkg/controller/cephcluster/cephcluster_controller.go
+++ b/pkg/controller/cephcluster/cephcluster_controller.go
@@ -34,7 +34,7 @@ func Add(mgr manager.Manager) error {
 	c, err := controller.New("noobaa-controller", mgr, controller.Options{
 		MaxConcurrentReconciles: 1,
 		Reconciler:              reconcile.Func(doReconcile),
-		SkipNameValidation: &[]bool{true}[0],
+		SkipNameValidation:      &[]bool{true}[0],
 	})
 	if err != nil {
 		return err
@@ -93,8 +93,8 @@ func doReconcile(context context.Context, req reconcile.Request) (reconcile.Resu
 	backingStoreList := nbv1.BackingStoreList{}
 	util.KubeList(&backingStoreList, client.InNamespace(options.Namespace))
 	for _, bs := range backingStoreList.Items {
-		if bs.Spec.S3Compatible != nil && bs.ObjectMeta.Annotations != nil {
-			if _, ok := bs.ObjectMeta.Annotations["rgw"]; ok {
+		if bs.Spec.S3Compatible != nil && bs.Annotations != nil {
+			if _, ok := bs.Annotations["rgw"]; ok {
 				avail := nb.UInt64ToBigInt(cephCapacity.AvailableBytes)
 				err := nbClient.UpdateCloudPoolAPI(nb.UpdateCloudPoolParams{
 					Name:              bs.Name,

--- a/pkg/cosi/cosi_bucket_class.go
+++ b/pkg/cosi/cosi_bucket_class.go
@@ -229,11 +229,12 @@ func createCommonCOSIBucketclass(cmd *cobra.Command, args []string, bucketClassT
 	bucketClass.DriverName = options.COSIDriverName()
 
 	deletionPolicy, _ := cmd.Flags().GetString("deletion-policy")
-	if deletionPolicy == "delete" {
+	switch deletionPolicy {
+	case "delete":
 		bucketClass.DeletionPolicy = nbv1.COSIDeletionPolicyDelete
-	} else if deletionPolicy == "retain" {
+	case "retain":
 		bucketClass.DeletionPolicy = nbv1.COSIDeletionPolicyRetain
-	} else {
+	default:
 		log.Fatalf(`❌ Invalid deletion policy, valid values are delete or retain %s`, deletionPolicy)
 	}
 

--- a/pkg/cosi/cosi_cli_test.go
+++ b/pkg/cosi/cosi_cli_test.go
@@ -2,7 +2,6 @@ package cosi
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -17,7 +16,7 @@ import (
 )
 
 var _ = Describe("COSI CLI tests", func() {
-	os.Setenv("TEST_ENV", "true")
+	util.SafeSetEnv("TEST_ENV", "true")
 	options.Namespace = "test"
 
 	CLIPath := "../../build/_output/bin/noobaa-operator-local"

--- a/pkg/cosi/cosi_test.go
+++ b/pkg/cosi/cosi_test.go
@@ -3,7 +3,6 @@ package cosi
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
@@ -21,7 +20,7 @@ import (
 )
 
 var _ = Describe("COSI driver/provisioner tests", func() {
-	os.Setenv("TEST_ENV", "true")
+	util.SafeSetEnv("TEST_ENV", "true")
 	options.Namespace = "test"
 
 	defaultBackingStoreName := "noobaa-default-backing-store"

--- a/pkg/cosi/provisioner.go
+++ b/pkg/cosi/provisioner.go
@@ -69,7 +69,9 @@ func RunProvisioner(client client.Client, scheme *runtime.Scheme, recorder recor
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		// remove socket in case it is already bound
-		os.Remove(options.CosiDriverPath)
+		if err := os.Remove(options.CosiDriverPath); err != nil && !os.IsNotExist(err) {
+			log.Warnf("Failed to remove existing socket file %s: %v", options.CosiDriverPath, err)
+		}
 		util.Panic(cosiProv.Run(ctx))
 	}()
 
@@ -240,10 +242,8 @@ func NewBucketRequest(
 	bucketDelReq *cosi.DriverDeleteBucketRequest,
 ) (*APIRequest, error) {
 	log := p.Logger
-	IsExternalRPCConnection := false
-	if util.IsTestEnv() {
-		IsExternalRPCConnection = true
-	}
+	IsExternalRPCConnection := util.IsTestEnv()
+
 	sysClient, err := system.Connect(IsExternalRPCConnection)
 	if err != nil {
 		return nil, err
@@ -283,10 +283,8 @@ func NewAccountRequest(
 	accountCreateReq *cosi.DriverGrantBucketAccessRequest,
 	accountDelReq *cosi.DriverRevokeBucketAccessRequest,
 ) (*APIRequest, error) {
-	IsExternalRPCConnection := false
-	if util.IsTestEnv() {
-		IsExternalRPCConnection = true
-	}
+	IsExternalRPCConnection := util.IsTestEnv()
+
 	sysClient, err := system.Connect(IsExternalRPCConnection)
 	if err != nil {
 		return nil, err

--- a/pkg/diagnostics/analyze.go
+++ b/pkg/diagnostics/analyze.go
@@ -418,7 +418,7 @@ func setJobAnalyzeResource(cmd *cobra.Command, analyzeResourceJob *batchv1.Job, 
 func waitFinish(job *batchv1.Job) bool {
 	klient := util.KubeClient()
 	interval := time.Duration(3)
-	
+
 	err := wait.PollUntilContextCancel(ctx, interval*time.Second, true, func(ctx context.Context) (bool, error) {
 		err := klient.Get(util.Context(), util.ObjectKey(job), job)
 		if err != nil {
@@ -474,7 +474,7 @@ func printTestsSummary(folderName string) error {
 				log.Errorf("❌ Could not open file: %v", err)
 				return err
 			}
-			defer file.Close()
+			defer util.SafeClose(file, fmt.Sprintf("Failed to close file %s", path))
 
 			scanner := bufio.NewScanner(file)
 			shouldPrint := false

--- a/pkg/diagnostics/collect.go
+++ b/pkg/diagnostics/collect.go
@@ -116,7 +116,7 @@ func (c *Collector) CollectDescribe(Kind string, Name string) {
 		c.log.Printf(`❌ cannot create file %v: %v`, fileName, err)
 		return
 	}
-	defer outfile.Close()
+	defer util.SafeClose(outfile, fmt.Sprintf("Failed to close file %s", fileName))
 	cmd.Stdout = outfile
 
 	// run kubectl describe

--- a/pkg/diagnostics/dbdump.go
+++ b/pkg/diagnostics/dbdump.go
@@ -94,7 +94,7 @@ func (c *CollectorDbDump) generatePostgresDump(destDir string) error {
 	}
 
 	// Redirect the command's output to the local dump file
-	defer outfile.Close()
+	defer util.SafeClose(outfile, fmt.Sprintf("Failed to close dump file %s", dumpFilePath))
 	cmd.Stdout = outfile
 
 	// Execute the command, generating the dump file

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -555,7 +555,7 @@ func (r *Reconciler) LoadNamespaceStoreSecret() error {
 				}
 				secret = suggestedSecret
 			}
-			if util.IsOwnedByNoobaa(secret.ObjectMeta.OwnerReferences) {
+			if util.IsOwnedByNoobaa(secret.OwnerReferences) {
 				err = util.SetOwnerReference(r.NamespaceStore, secret, r.Scheme)
 				if _, isAlreadyOwnedErr := err.(*controllerutil.AlreadyOwnedError); !isAlreadyOwnedErr {
 					if err == nil {

--- a/pkg/nb/rpc_http.go
+++ b/pkg/nb/rpc_http.go
@@ -45,7 +45,7 @@ func (c *RPCConnHTTP) Call(req *RPCMessage, res RPCResponse) error {
 	httpResponse, err := c.RPC.HTTPClient.Do(httpRequest)
 	defer func() {
 		if httpResponse != nil && httpResponse.Body != nil {
-			httpResponse.Body.Close()
+			util.SafeClose(httpResponse.Body, "Failed to close HTTP response body")
 		}
 	}()
 	if err != nil {

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -391,10 +391,10 @@ func NewBucketRequest(
 			},
 		}
 	} else {
-		if ob.Spec.Connection == nil || ob.Spec.Connection.Endpoint == nil {
+		if ob.Spec.Connection == nil || ob.Spec.Endpoint == nil {
 			return nil, fmt.Errorf("ObjectBucket has no connection/endpoint info %+v", ob)
 		}
-		r.BucketName = ob.Spec.Connection.Endpoint.BucketName
+		r.BucketName = ob.Spec.Endpoint.BucketName
 		r.AccountName = ob.Spec.AdditionalState["account"]
 		bucketClassName := ob.Spec.AdditionalState["bucketclass"]
 
@@ -403,8 +403,8 @@ func NewBucketRequest(
 			p.Logger.Warnf("BucketClass %q not found in namespace %q", bucketClassName, p.Namespace)
 		}
 		r.BucketClass = bucketClass
-		if r.OB.Spec.Connection.Endpoint.AdditionalConfigData == nil {
-			r.OB.Spec.Connection.Endpoint.AdditionalConfigData = map[string]string{}
+		if r.OB.Spec.Endpoint.AdditionalConfigData == nil {
+			r.OB.Spec.Endpoint.AdditionalConfigData = map[string]string{}
 		}
 	}
 

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -742,15 +742,16 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 			},
 		}
 
-		if c.Spec.Group == nbv1.SchemeGroupVersion.Group {
+		switch c.Spec.Group {
+		case nbv1.SchemeGroupVersion.Group:
 			csv.Spec.CustomResourceDefinitions.Owned = append(csv.Spec.CustomResourceDefinitions.Owned, crdDesc)
-		} else if c.Spec.Group == obAPI.Domain {
+		case obAPI.Domain:
 			if csvParams != nil && csvParams.OBCMode == OBCOwned {
 				csv.Spec.CustomResourceDefinitions.Owned = append(csv.Spec.CustomResourceDefinitions.Owned, crdDesc)
 			} else if csvParams == nil || csvParams.OBCMode == OBCRequired {
 				csv.Spec.CustomResourceDefinitions.Required = append(csv.Spec.CustomResourceDefinitions.Required, crdDesc)
 			} // else OBCMode == OBCNone, do nothing
-		} else {
+		default:
 			csv.Spec.CustomResourceDefinitions.Required = append(csv.Spec.CustomResourceDefinitions.Required, crdDesc)
 		}
 	})

--- a/pkg/system/autoscaler.go
+++ b/pkg/system/autoscaler.go
@@ -351,7 +351,7 @@ func (r *Reconciler) creatBasicSecretTargetRef(log *logrus.Entry) []kedav1alpha1
 
 func (r *Reconciler) validateKeda() bool {
 	err := r.Client.Get(r.Ctx, util.ObjectKey(r.KedaScaled), r.KedaScaled)
-	return !(meta.IsNoMatchError(err) || runtime.IsNotRegisteredError(err))
+	return !meta.IsNoMatchError(err) && !runtime.IsNotRegisteredError(err)
 }
 
 func getPrometheus(log *logrus.Entry, prometheusNamespace string) (*monitoringv1.Prometheus, error) {

--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -254,7 +254,7 @@ func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
 	}
 
 	// by default enable monitoring of the DB instances. if the annotation is "true", disable monitoring
-	disableMonStr := r.NooBaa.ObjectMeta.Annotations[nbv1.DisableDBDefaultMonitoring]
+	disableMonStr := r.NooBaa.Annotations[nbv1.DisableDBDefaultMonitoring]
 	if r.CNPGCluster.Spec.Monitoring == nil {
 		r.CNPGCluster.Spec.Monitoring = &cnpgv1.MonitoringConfiguration{}
 	}

--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -58,8 +58,8 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 			if err != nil {
 				return fmt.Errorf("failed to write k8s secret tls.key content to a file %v", err)
 			}
-			os.Setenv("PGSSLKEY", "/tmp/tls.key")
-			os.Setenv("PGSSLCERT", "/tmp/tls.crt")
+			util.SafeSetEnv("PGSSLKEY", "/tmp/tls.key")
+			util.SafeSetEnv("PGSSLCERT", "/tmp/tls.crt")
 		}
 		if err := r.checkExternalPg(r.ExternalPgSecret.StringData["db_url"]); err != nil {
 			return err
@@ -233,7 +233,7 @@ func (r *Reconciler) checkExternalPg(postgresDbURL string) error {
 			fmt.Sprintf("failed openning a connection to external DB url: %q, error: %s",
 				dbURL, err))
 	}
-	defer db.Close()
+	defer util.SafeClose(db, "Failed to close database connection")
 	err = db.Ping()
 	if err != nil {
 		return util.NewPersistentError("InvalidExternalPgUrl",

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -388,7 +388,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 						r.Recorder.Eventf(r.NooBaa, corev1.EventTypeWarning, "DBStorageClassIsImmutable",
 							"spec.dbStorageClass is immutable and cannot be updated for volume %q in existing %s %q"+
 								" since it requires volume recreate and migrate which is unsupported by the operator",
-							pvc.Name, r.CoreApp.TypeMeta.Kind, r.CoreApp.Name)
+							pvc.Name, r.CoreApp.Kind, r.CoreApp.Name)
 					}
 				}
 				if r.NooBaa.Spec.DBVolumeResources != nil &&
@@ -397,7 +397,7 @@ func (r *Reconciler) SetDesiredNooBaaDB() error {
 					r.Recorder.Eventf(r.NooBaa, corev1.EventTypeWarning, "DBVolumeResourcesIsImmutable",
 						"spec.dbVolumeResources is immutable and cannot be updated for volume %q in existing %s %q"+
 							" since it requires volume recreate and migrate which is unsupported by the operator",
-						pvc.Name, r.CoreApp.TypeMeta.Kind, r.CoreApp.Name)
+						pvc.Name, r.CoreApp.Kind, r.CoreApp.Name)
 				}
 			}
 		}
@@ -855,7 +855,7 @@ func (r *Reconciler) ReconcileRGWCredentials() error {
 	// Log all stores and take the first one for not.
 	// TODO: need to decide what to do if multiple objectstores in one namespace
 	r.Logger.Infof("found %d ceph objectstores: %v", len(cephObjectStoreList.Items), cephObjectStoreList.Items)
-	storeName := cephObjectStoreList.Items[0].ObjectMeta.Name
+	storeName := cephObjectStoreList.Items[0].Name
 	r.Logger.Infof("using objectstore %q as a default backing store", storeName)
 
 	// create ceph objectstore user
@@ -1469,7 +1469,7 @@ func findLocalStorageClass() (string, error) {
 	scList := &storagev1.StorageClassList{}
 	util.KubeList(scList)
 	for _, sc := range scList.Items {
-		if sc.ObjectMeta.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
 			return sc.Name, nil
 		}
 		if sc.Provisioner == "kubernetes.io/no-provisioner" {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -278,7 +278,8 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 		if viper.IsSet(fmt.Sprintf("resources.%s", componentName)) {
 			var component *corev1.ResourceRequirements
 
-			if componentName == "core" {
+			switch componentName {
+			case "core":
 				if sys.Spec.CoreResources == nil {
 					sys.Spec.CoreResources = &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{},
@@ -286,7 +287,7 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 					}
 				}
 				component = sys.Spec.CoreResources
-			} else if componentName == "db" {
+			case "db":
 				if sys.Spec.DBResources == nil {
 					sys.Spec.DBResources = &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{},
@@ -294,7 +295,7 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 					}
 				}
 				component = sys.Spec.DBResources
-			} else if componentName == "endpoints" {
+			case "endpoints":
 				if sys.Spec.Endpoints == nil {
 					sys.Spec.Endpoints = &nbv1.EndpointsSpec{
 						MinCount: viper.GetInt32("resources.endpoints.minCount"),
@@ -765,7 +766,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	sysKey := client.ObjectKey{Namespace: options.Namespace, Name: options.SystemName}
 	r := NewReconciler(sysKey, klient, scheme.Scheme, nil)
 	r.CheckAll()
-	var NooBaaDB *appsv1.StatefulSet = r.NooBaaPostgresDB
+	var NooBaaDB = r.NooBaaPostgresDB
 
 	if r.shouldReconcileStandaloneDB() {
 		// NoobaaDB

--- a/pkg/util/kms/kms_ibm_kp.go
+++ b/pkg/util/kms/kms_ibm_kp.go
@@ -2,7 +2,6 @@ package kms
 
 import (
 	"fmt"
-	"os"
 	"syscall"
 
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
@@ -41,7 +40,7 @@ func (i *IBM) Config(config map[string]string, tokenSecretName, namespace string
 	if !instanceIDFound {
 		return nil, fmt.Errorf("❌ Unable to find IBM Key Protect instance ID in CR %v", IbmInstanceIDKey)
 	}
-	os.Setenv(IbmInstanceIDKey, instanceID)
+	util.SafeSetEnv(IbmInstanceIDKey, instanceID)
 
 	// Fetch API Key from k8s secret
 	_, api := syscall.Getenv(IbmServiceAPIKey)
@@ -69,7 +68,7 @@ func (*IBM) keysFromSecret(tokenSecretName, namespace string, c map[string]inter
 			return fmt.Errorf(`❌ Could not find key %v in secret %q in namespace %q`, key, secret.Name, secret.Namespace)
 		}
 		c[key] = val
-		os.Setenv(key, val) // cache the value in environment
+		util.SafeSetEnv(key, val) // cache the value in environment
 	}
 
 	return nil

--- a/pkg/util/kms/kms_kmip_storage.go
+++ b/pkg/util/kms/kms_kmip_storage.go
@@ -134,13 +134,13 @@ func (k *KMIPSecretStorage) connect() (*tls.Conn, error) {
 		}
 	}
 	if err = conn.Handshake(); err != nil {
-		conn.Close()
+		util.SafeClose(conn, "Failed to close connection after handshake error")
 		return nil, err
 	}
 
 	// KMIP handshake
 	if err = k.discover(conn); err != nil {
-		conn.Close()
+		util.SafeClose(conn, "Failed to close connection after discover error")
 		return nil, err
 	}
 	return conn, nil
@@ -277,7 +277,7 @@ func (k *KMIPSecretStorage) GetSecret(
 		log.Errorf("KMIPSecretStorage.GetSecret() failed to connect %v", err)
 		return nil, secrets.NoVersion, err
 	}
-	defer conn.Close()
+	defer util.SafeClose(conn, "Failed to close connection after get secret")
 
 	respMsg, decoder, uniqueBatchItemID, err := k.send(conn, kmip14.OperationGet, kmip.GetRequestPayload{
 		UniqueIdentifier: uniqueIdentifier,
@@ -343,7 +343,7 @@ func (k *KMIPSecretStorage) PutSecret(
 		log.Errorf("KMIPSecretStorage.PutSecret() can not connect %v", err)
 		return secrets.NoVersion, err
 	}
-	defer conn.Close()
+	defer util.SafeClose(conn, "Failed to close connection after put secret")
 
 	registerPayload := kmip.RegisterRequestPayload{
 		ObjectType: kmip14.ObjectTypeSymmetricKey,
@@ -408,7 +408,7 @@ func (k *KMIPSecretStorage) DeleteSecret(
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer util.SafeClose(conn, "Failed to close connection after delete secret")
 
 	respMsg, decoder, uniqueBatchItemID, err := k.send(conn, kmip14.OperationDestroy, kmip.DestroyRequestPayload{
 		UniqueIdentifier: uniqueIdentifier,

--- a/pkg/util/kms/kms_vault.go
+++ b/pkg/util/kms/kms_vault.go
@@ -160,7 +160,7 @@ func writeCrtsToFile(secretName string, namespace string, secretValue []byte, en
 	}
 
 	// close the temp file when out of scope
-	defer file.Close()
+	defer util.SafeClose(file, fmt.Sprintf("Failed to close temp file %s", file.Name()))
 
 	// Write into a file
 	err = os.WriteFile(file.Name(), secretValue, 0444)

--- a/pkg/validations/backingstore_validations.go
+++ b/pkg/validations/backingstore_validations.go
@@ -261,9 +261,10 @@ func ValidateTargetBSBucketChange(bs nbv1.BackingStore, oldBs nbv1.BackingStore)
 func ValidateBackingstoreDeletion(bs nbv1.BackingStore, systemInfo nb.SystemInfo) error {
 	for _, pool := range systemInfo.Pools {
 		if pool.Name == bs.Name {
-			if pool.Undeletable == "IS_BACKINGSTORE" || pool.Undeletable == "BEING_DELETED" {
+			switch pool.Undeletable {
+			case "IS_BACKINGSTORE", "BEING_DELETED":
 				return nil
-			} else if pool.Undeletable == "CONNECTED_BUCKET_DELETING" {
+			case "CONNECTED_BUCKET_DELETING":
 				return util.ValidationError{
 					Msg: fmt.Sprintf("cannot complete because objects in Backingstore %q are still being deleted, Please try later", pool.Name),
 				}

--- a/pkg/validations/common_bucket_validations.go
+++ b/pkg/validations/common_bucket_validations.go
@@ -41,11 +41,11 @@ func ValidateNSFSAccountConfig(NSFSConfig string, bucketclass string) error {
 		// Check whether only UID or only GID were provided
 		if *configObj.UID < 0 || *configObj.GID < 0 {
 			return fmt.Errorf("UID and GID must be positive integers")
-		// Check whether a distinguished name was provided alongside UID or GID
+			// Check whether a distinguished name was provided alongside UID or GID
 		} else if configObj.DistinguishedName != "" && (*configObj.GID > -1 || *configObj.UID > -1) {
 			return fmt.Errorf(`NSFS account config cannot include both distinguished name and UID/GID`)
 		}
-	// Otherwise, validate the distinguished name
+		// Otherwise, validate the distinguished name
 	} else if configObj.DistinguishedName != "" {
 		if !linuxUsernameRegex.MatchString(configObj.DistinguishedName) {
 			return fmt.Errorf("DistinguishedName must be a valid username by Linux standards")
@@ -82,10 +82,8 @@ func ValidateReplicationPolicy(bucketName string, replicationPolicy string, upda
 	}
 
 	log.Infof("ValidateReplicationPolicy: validating replication: replicationParams: %+v", replicationParams)
-	IsExternalRPCConnection := false
-	if util.IsTestEnv() || isCLI {
-		IsExternalRPCConnection = true
-	}
+	IsExternalRPCConnection := util.IsTestEnv() || isCLI
+
 	sysClient, err := system.Connect(IsExternalRPCConnection)
 	if err != nil {
 		return fmt.Errorf("Provisioner Failed to validate replication of bucket %q with error: %v", bucketName, err)


### PR DESCRIPTION
### Explain the changes
#### 1. General lint-driven refactors
- Converted repetitive `if…else` chains (e.g. signature-version checks, bucket-class mapping, CSV grouping) into `switch` blocks for clarity and fewer conditions.
- Swapped direct field accesses like `secret.ObjectMeta.OwnerReferences` and `sc.ObjectMeta.Annotations` for the shorter `secret.OwnerReferences` and `sc.Annotations`.

#### 2. Errcheck fixes & cleanup
- Replaced plain `defer file.Close()` (and similar) with closures that log any close-errors, unified under a new `util.SafeClose` helper.
- Routed all `os.Setenv` calls through `util.SafeSetEnv` to remove repeated error-check boilerplate.

#### 3. New helpers
- **`SafeClose[T interface{ Close() error }](resource T, errorMsg string)`**  
  Centralizes error logging on `Close()` failures, leveraging Go 1.18+ generics.
- **`SafeSetEnv(name, value string)`**  
  Wraps `os.Setenv` calls, logging any errors to keep tests and mocks clean.

#### 4. Small goodies
- Removed unused imports (`os` in several files).
- Simplified boolean logic (`return !(A || B)` → `return !A && !B`).
- Trimmed redundant type info (e.g. `var NooBaaDB = …` instead of specifying `*StatefulSet`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved code clarity and maintainability by replacing multiple if-else chains with switch statements in various configuration and validation routines.
  - Simplified and corrected how annotations and metadata are accessed for Kubernetes resources.
  - Streamlined boolean variable assignments and variable declarations for better readability.

- **Bug Fixes**
  - Enhanced error handling by introducing safer utility functions for closing resources and setting environment variables, ensuring errors are logged rather than ignored.
  - Improved handling of environment variables and resource cleanup in tests and operational flows.

- **Chores**
  - Minor formatting and comment adjustments for consistency and readability.
  - Updated imports to remove unused packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->