### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,16 @@
+version: "2"
+
+linters:
+  exclusions:
+    paths:
+      - pkg/apis/noobaa/v1alpha1
+      - pkg/bundle
+      - zz_generated\.go
+    rules:
+      - linters:
+          - staticcheck
+        # We ignore capitalized error strings since it's a common pattern in the codebase
+        text: "ST1005:"
+
 run:
   timeout: 5m
-
-issues:
-  exclude-dirs:
-    - pkg/apis/noobaa/v1alpha1
-    - pkg/bundle
-  exclude-files:
-    - zz_generated\.go

--- a/Makefile
+++ b/Makefile
@@ -190,8 +190,17 @@ golangci-lint: gen
 
 lint: gen
 	@echo ""
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	golangci-lint run --config .golangci.yml
+	@if [ ! -f "$(GOBIN)/golangci-lint" ] || [ "v2.1.6" != "$$($(GOBIN)/golangci-lint --version 2>/dev/null | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' || echo '')" ]; then \
+		echo "Installing golangci-lint v2.1.6..."; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6; \
+	fi
+	@if [ -n "$(FILES)" ]; then \
+		echo "Running lint on changed files: $(FILES)"; \
+		$(GOBIN)/golangci-lint run --config .golangci.yml $(FILES); \
+	else \
+		echo "Running lint on all files"; \
+		$(GOBIN)/golangci-lint run --config .golangci.yml; \
+	fi
 	@echo "✅ lint"
 .PHONY: lint
 


### PR DESCRIPTION
### Explain the changes
#### 1. Updated `.golangci.yml` to v2 format
- Added `version: "2"` at the top to target golangci-lint v2.  
- Replaced the old `issues.exclude-dirs`/`exclude-files` keys with a `linters.exclusions.paths` list for ignoring generated code and CRD packages.  
- Introduced a custom rule to silence `ST1005` (`text: "ST1005:"`)

#### 2. Makefile adjustments
- Now installs `golangci-lint/v2` at `v2.1.6` if missing or mismatched (required for upgrading pre-existing clones)
- Supports linting only changed files when `FILES` is set; falls back to a full run otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration for improved exclusion handling and compatibility with the latest linter version.
  * Enhanced the linting process in the build system to ensure consistent linter version usage and provide more informative output when linting specific files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->