### PR TITLE
Improve upgrade handling to sync pods restarts

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -51,6 +51,12 @@ spec:
         # CORE CONTAINER #
         #----------------#
         - name: core
+          readinessProbe:
+            httpGet:
+              path: /version
+              port: 8080
+              initialDelaySeconds: 5
+              timeoutSeconds: 2
           image: NOOBAA_CORE_IMAGE
           volumeMounts:
             - name: logs

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5054,7 +5054,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "477895e38effe338eeec7c35c1e051ea361db0b21946f03dcdbe46b08dc79f03"
+const Sha256_deploy_internal_statefulset_core_yaml = "7ac104a8eb3a333f0d0c356976bd6955290b1f90de02d47e3c291e935ab7c476"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5109,6 +5109,12 @@ spec:
         # CORE CONTAINER #
         #----------------#
         - name: core
+          readinessProbe:
+            httpGet:
+              path: /version
+              port: 8080
+              initialDelaySeconds: 5
+              timeoutSeconds: 2
           image: NOOBAA_CORE_IMAGE
           volumeMounts:
             - name: logs

--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -26,6 +26,15 @@ func (r *Reconciler) ReconcilePhaseConnecting() error {
 	if r.JoinSecret == nil {
 		r.CheckServiceStatus(r.ServiceMgmt, r.RouteMgmt, &r.NooBaa.Status.Services.ServiceMgmt, "mgmt-https")
 	}
+
+	// wait for noobaa core statefulset to be ready before proceeding
+	if r.CoreApp.Spec.Replicas == nil {
+		return fmt.Errorf("noobaa core statefulset replicas is nil, cannot proceed")
+	} else if r.CoreApp.Status.ReadyReplicas < *r.CoreApp.Spec.Replicas {
+		return fmt.Errorf("waiting for noobaa core pod to be ready, currently ready replicas: %d, expected: %d",
+			r.CoreApp.Status.ReadyReplicas, *r.CoreApp.Spec.Replicas)
+	}
+
 	if err := r.InitNBClient(); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Explain the changes
- added a readiness probe to the core container in the core statefulset. the core will be ready when `/version` route in the webserver returns success code.
- in phase 2 of the system reconciliation - if the noobaa image was changed, stop core and endpoint pods
- after the pods stop, reconcile the core sts to start the pod with the new image. the core pod will run the upgrade_manager without interruptions.
- in phase 3, wait for the core readiness before proceeding


### Issues: Fixed #xxx / Gap #xxx
1. operator side of https://issues.redhat.com/browse/DFBUGS-2457

### Testing Instructions:
1. update the core image
3. inspect the core and endpoints pods. 
4. all pods should be terminated first. noobaa core should start first and only after the upgrade process runs, the core pod becomes ready and the endpoint pods start.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a readiness check for the core application, ensuring pods are fully ready before proceeding with further operations.
  * Enhanced upgrade handling by stopping core and endpoint pods before applying updates, with clear status feedback if pods are still terminating.
  * Introduced a readiness probe on the core container to monitor its availability via the `/version` endpoint.

* **Bug Fixes**
  * Improved consistency in pod readiness and upgrade workflows to prevent premature actions during upgrades.

* **Chores**
  * Updated internal configuration and manifest checksums for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->