### PR TITLE
Update AWS Regions with ap-east-2

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1216,6 +1216,7 @@ func GetAWSRegion() (string, error) {
 		"eu-south-1":     "eu-south-1",
 		"eu-south-2":     "eu-south-2",
 		"ap-east-1":      "ap-east-1",
+		"ap-east-2":      "ap-east-2",
 		"ap-northeast-1": "ap-northeast-1",
 		"ap-northeast-2": "ap-northeast-2",
 		"ap-northeast-3": "ap-northeast-3",


### PR DESCRIPTION
### Explain the changes
- Update AWS Regions with ap-east-2

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the AWS region "ap-east-2".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->