### PR TITLE
[Backport to 5.19] Fixing KMIP issues

### DIFF
--- a/pkg/util/kms/kms_kmip.go
+++ b/pkg/util/kms/kms_kmip.go
@@ -15,6 +15,7 @@ const (
 	KMIPSecret        = "KMIP_CERTS_SECRET"
 	KMIPUniqueID      = "UniqueIdentifier"
 	NewKMIPUniqueID   = "UniqueIdentifierNew"
+	NewActiveKeyID    = "NewActiveKeyID"
 	KMIPTLSServerName = "TLS_SERVER_NAME"
 	KMIPReadTimeOut   = "READ_TIMEOUT"
 	KMIPWriteTimeOut  = "WRITE_TIMEOUT"

--- a/pkg/util/kms/kms_kmip_storage.go
+++ b/pkg/util/kms/kms_kmip_storage.go
@@ -35,6 +35,8 @@ const (
 	protocolMajor = 1
 	protocolMinor = 4
 
+	// Expected secret data length in bits
+	cryptographicLength = 256
 )
 
 // KMIPSecretStorage is a KMIP backend Key Management Systems (KMS)
@@ -208,7 +210,7 @@ func (k *KMIPSecretStorage) response(respMsg *kmip.ResponseMessage, operation km
 		return nil, fmt.Errorf("Unexpected uniqueBatchItemID, real %v expected %v", bi.UniqueBatchItemID, uniqueBatchItemID)
 	}
 	if kmip14.ResultStatusSuccess != bi.ResultStatus {
-		return nil, fmt.Errorf("Unexpected result status %v expected success %v", bi.ResultStatus, kmip14.ResultStatusSuccess)
+		return nil, fmt.Errorf("Unexpected result status %v: Reason: %v Message: %v", bi.ResultStatus, bi.ResultReason, bi.ResultMessage)
 	}
 
 	return &bi, nil
@@ -261,14 +263,21 @@ func (k *KMIPSecretStorage) GetSecret(
 	log := util.Logger()
 
 	lookfor := KMIPUniqueID // Addition to upgrade
+	var activeKeyID string
 	if strings.HasSuffix(secretID, "-root-master-key-backend") {
 		lookfor = NewKMIPUniqueID
+		exists := false
+		activeKeyID, exists = k.secret.StringData[NewActiveKeyID]
+		if !exists {
+			log.Errorf("KMIPSecretStorage.GetSecret() activeKeyID %v does not exist in secret %v", activeKeyID, k.secret.Name)
+			return nil, secrets.NoVersion, secrets.ErrInvalidSecretId
+		}
 	}
 
 	// KMIP key uniqueIdentifier
 	uniqueIdentifier, exists := k.secret.StringData[lookfor]
 	if !exists {
-		log.Errorf("KMIPSecretStorage.GetSecret() uniqueIdentifier %v does not exist in secret %v", lookfor, k.secret)
+		log.Errorf("KMIPSecretStorage.GetSecret() uniqueIdentifier %v does not exist in secret %v", lookfor, k.secret.Name)
 		return nil, secrets.NoVersion, secrets.ErrInvalidSecretId
 	}
 
@@ -306,6 +315,9 @@ func (k *KMIPSecretStorage) GetSecret(
 	if getRespPayload.SymmetricKey == nil {
 		return nil, secrets.NoVersion, fmt.Errorf("Unexpected  get response SymmetricKey can not be nil")
 	}
+	if getRespPayload.SymmetricKey.KeyBlock.CryptographicLength != cryptographicLength {
+		return nil, secrets.NoVersion, fmt.Errorf("Unexpected  KeyBlock crypto len actual %v, expected %v", getRespPayload.SymmetricKey.KeyBlock.CryptographicLength, cryptographicLength)
+	}
 	if getRespPayload.SymmetricKey.KeyBlock.KeyFormatType != kmip14.KeyFormatTypeRaw {
 		return nil, secrets.NoVersion, fmt.Errorf("Unexpected  KeyBlock format type actual %v, expected KeyFormatTypeRaw %v", getRespPayload.SymmetricKey.KeyBlock.KeyFormatType, kmip14.KeyFormatTypeRaw)
 	}
@@ -316,10 +328,13 @@ func (k *KMIPSecretStorage) GetSecret(
 	secretBytes := getRespPayload.SymmetricKey.KeyBlock.KeyValue.KeyMaterial.([]byte)
 	secretBase64 := base64.StdEncoding.EncodeToString(secretBytes)
 
-	// Return the fetched key value
-	r := map[string]interface{}{secretID: secretBase64}
-
-	return r, secrets.NoVersion, nil
+	if len(activeKeyID) > 0 {
+		r := map[string]interface{}{ActiveRootKey: activeKeyID, activeKeyID: secretBase64}
+		return r, secrets.NoVersion, nil
+	} else {
+		r := map[string]interface{}{secretID: secretBase64}
+		return r, secrets.NoVersion, nil
+	}
 }
 
 // PutSecret will associate an secretId to its secret data
@@ -332,7 +347,8 @@ func (k *KMIPSecretStorage) PutSecret(
 	log := util.Logger()
 
 	// Register the key value the KMIP endpoint
-	value := plainText[secretID].(string)
+	activeKey := plainText[ActiveRootKey].(string)
+	value := plainText[activeKey].(string)
 	valueBytes, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
 		return secrets.NoVersion, err
@@ -353,7 +369,7 @@ func (k *KMIPSecretStorage) PutSecret(
 				KeyValue: &kmip.KeyValue{
 					KeyMaterial: valueBytes,
 				},
-				CryptographicLength:    len(valueBytes) * 8, // in bits
+				CryptographicLength:    cryptographicLength,
 				CryptographicAlgorithm: kmip14.CryptographicAlgorithmAES,
 			},
 		},
@@ -377,6 +393,7 @@ func (k *KMIPSecretStorage) PutSecret(
 		return secrets.NoVersion, err
 	}
 
+	k.secret.StringData[NewActiveKeyID] = activeKey
 	k.secret.StringData[NewKMIPUniqueID] = registerRespPayload.UniqueIdentifier
 	if !util.KubeUpdate(k.secret) {
 		log.Errorf("Failed to update KMS secret %v in ns %v", k.secret.Name, k.secret.Namespace)

--- a/pkg/util/kms/kms_version.go
+++ b/pkg/util/kms/kms_version.go
@@ -1,8 +1,6 @@
 package kms
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -115,23 +113,6 @@ func (v *VersionRotatingSecret) Get() error {
 		return err
 	}
 
-	if (v.k.driver.Name() == "KMIPSecret") {
-		encodedData, ok := s[v.BackendSecretName()]
-		if !ok {
-			return secrets.ErrInvalidSecretData
-		}
-		data := map[string]string{}
-		decodedString, err := base64.StdEncoding.DecodeString(encodedData.(string))
-		if err != nil {
-			return secrets.ErrInvalidSecretData
-		}
-		err = json.Unmarshal(decodedString, &data)
-		if err != nil {
-			return secrets.ErrInvalidSecretData
-		}
-		v.data = data
-		return nil
-	}
 	rc := map[string]string{}
 	for k, v := range s {
 		rc[k] = v.(string)
@@ -157,17 +138,7 @@ func (v *VersionRotatingSecret) Set(val string) error {
 	s[ActiveRootKey] = key
 	s[key] = val
 	v.data = s
-	var err error
-	if (v.k.driver.Name() == "KMIPSecret") {
-		jsonData, err := json.Marshal(s)
-		encodedString := base64.StdEncoding.EncodeToString(jsonData)
-		if err != nil {
-			return err
-		}
-		_, err = v.k.PutSecret(v.BackendSecretName(), map[string]interface{}{v.BackendSecretName(): encodedString}, v.k.driver.SetContext())
-		return err
-	}
-	_, err = v.k.PutSecret(v.BackendSecretName(), toInterfaceMap(s), v.k.driver.SetContext())
+	_, err := v.k.PutSecret(v.BackendSecretName(), toInterfaceMap(s), v.k.driver.SetContext())
 	return err
 }
 


### PR DESCRIPTION

### Explain the changes
1.  As some KMIP doesn't support any CryptographicLength, we will revert to saving only one key in KMIP. Once we want to support rotating secrets, we will need to find a better solution

(cherry picked from commit 5b3aa9edaf290fa7452588075b8ead431c862a81)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
