### PR TITLE
Added TopologyKey to noobaa CRD for multizone support

### DIFF
--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -159,6 +159,10 @@ type NooBaaSpec struct {
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
+	// TopologyKey (optional) the TopologyKey to pass as the domain for TopologySpreadConstraint and Affinity of noobaa components
+	// It is used by the endpoints and the DB pods to control pods distribution between topology domains (host/zone)
+	TopologyKey string `json:"topologyKey,omitempty"`
+
 	// ImagePullSecret (optional) sets a pull secret for the system image
 	// +optional
 	ImagePullSecret *corev1.LocalObjectReference `json:"imagePullSecret,omitempty"`

--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -252,6 +252,9 @@ func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
 	if r.NooBaa.Spec.Tolerations != nil {
 		r.CNPGCluster.Spec.Affinity.Tolerations = r.NooBaa.Spec.Tolerations
 	}
+	if r.NooBaa.Spec.TopologyKey != "" {
+		r.CNPGCluster.Spec.Affinity.TopologyKey = r.NooBaa.Spec.TopologyKey
+	}
 
 	// by default enable monitoring of the DB instances. if the annotation is "true", disable monitoring
 	disableMonStr := r.NooBaa.Annotations[nbv1.DisableDBDefaultMonitoring]
@@ -517,6 +520,7 @@ func (r *Reconciler) wasClusterSpecChanged(existingClusterSpec *cnpgv1.ClusterSp
 	return !reflect.DeepEqual(existingClusterSpec.InheritedMetadata, r.CNPGCluster.Spec.InheritedMetadata) ||
 		!reflect.DeepEqual(existingClusterSpec.ImageCatalogRef, r.CNPGCluster.Spec.ImageCatalogRef) ||
 		existingClusterSpec.Instances != r.CNPGCluster.Spec.Instances ||
+		existingClusterSpec.Affinity.TopologyKey != r.CNPGCluster.Spec.Affinity.TopologyKey ||
 		!reflect.DeepEqual(existingClusterSpec.Resources, r.CNPGCluster.Spec.Resources) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.StorageClass, r.CNPGCluster.Spec.StorageConfiguration.StorageClass) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.Size, r.CNPGCluster.Spec.StorageConfiguration.Size) ||

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -333,7 +333,7 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 			r.DeploymentEndpoint.Name, nbv1.SkipTopologyConstraints)
 	} else {
 		r.Logger.Debugf("default TopologySpreadConstraints is added to %s deployment", r.DeploymentEndpoint.Name)
-		topologySpreadConstraint := corev1.TopologySpreadConstraint{
+		topologySpreadConstraintHost := corev1.TopologySpreadConstraint{
 			MaxSkew:           1,
 			TopologyKey:       "kubernetes.io/hostname",
 			WhenUnsatisfiable: corev1.ScheduleAnyway,
@@ -344,7 +344,20 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 				},
 			},
 		}
-		podSpec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{topologySpreadConstraint}
+		podSpec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{topologySpreadConstraintHost}
+		if r.NooBaa.Spec.TopologyKey != "" && r.NooBaa.Spec.TopologyKey != "kubernetes.io/hostname" {
+			podSpec.TopologySpreadConstraints = append(podSpec.TopologySpreadConstraints, corev1.TopologySpreadConstraint{
+				MaxSkew:           1,
+				TopologyKey:       r.NooBaa.Spec.TopologyKey,
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				NodeTaintsPolicy:  &honor,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"noobaa-s3": r.Request.Name,
+					},
+				},
+			})
+		}
 	}
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]


### PR DESCRIPTION
### Explain the changes
- Added `TopologyKey` to Noobaa Spec. This can be used for example to set `topology.kubernetes.io/zone` as the topology domain
- If a topologyKey is used and is different from the default `kubernetes.io/hostname` TopologyKey, adding another TopologySpreadConstraint with the additional key.
- Passing the TopologyKey to the DB cluster CR under affinity. This will be set to the podAntiAffinity of the DB pods.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2826 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
