### PR TITLE
KMIP Upgrade - Fix for empty StringData after calling KubeUpdate

### DIFF
--- a/pkg/util/kms/kms_kmip_storage.go
+++ b/pkg/util/kms/kms_kmip_storage.go
@@ -264,6 +264,7 @@ func (k *KMIPSecretStorage) GetSecret(
 
 	lookfor := KMIPUniqueID // Addition to upgrade
 	var activeKeyID string
+	util.KubeCheck(k.secret)
 	if strings.HasSuffix(secretID, "-root-master-key-backend") {
 		lookfor = NewKMIPUniqueID
 		exists := false
@@ -415,9 +416,10 @@ func (k *KMIPSecretStorage) DeleteSecret(
 		lookfor = NewKMIPUniqueID
 	}
 	// Find the key ID
+	util.KubeCheck(k.secret)
 	uniqueIdentifier, exists := k.secret.StringData[lookfor]
 	if !exists {
-		log.Errorf("KMIPSecretStorage.DeleteSecret() No uniqueIdentifier in the secret")
+		log.Errorf("KMIPSecretStorage.DeleteSecret() No uniqueIdentifier %v in the secret %v", lookfor, k.secret.Name)
 		return secrets.ErrInvalidSecretId
 	}
 


### PR DESCRIPTION
### Explain the changes
1.  In Upgrade PutSecret is calling KubeUpdate which removes StringData from the secret. Later GetSecret failes to read any of the keys from the secret. Added KubeCheck which adds the missing StringData to the secret.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed https://issues.redhat.com/browse/DFBUGS-2844

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when retrieving or deleting secrets to ensure proper checks are performed.
  * Enhanced error messages for missing unique identifiers in secrets, providing clearer diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->