### PR TITLE
Check Noobaa core socket for ReadinessProbe.

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -52,11 +52,10 @@ spec:
         #----------------#
         - name: core
           readinessProbe:
-            httpGet:
-              path: /version
+            tcpSocket:
               port: 8080
-              initialDelaySeconds: 5
-              timeoutSeconds: 2
+            initialDelaySeconds: 5
+            timeoutSeconds: 2
           image: NOOBAA_CORE_IMAGE
           volumeMounts:
             - name: logs

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5054,7 +5054,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "7ac104a8eb3a333f0d0c356976bd6955290b1f90de02d47e3c291e935ab7c476"
+const Sha256_deploy_internal_statefulset_core_yaml = "40aefcf8dbd77e40dfcbe3db3725b56a832c8a81c282c6ba4adc98ce8a65d470"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5110,11 +5110,10 @@ spec:
         #----------------#
         - name: core
           readinessProbe:
-            httpGet:
-              path: /version
+            tcpSocket:
               port: 8080
-              initialDelaySeconds: 5
-              timeoutSeconds: 2
+            initialDelaySeconds: 5
+            timeoutSeconds: 2
           image: NOOBAA_CORE_IMAGE
           volumeMounts:
             - name: logs

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -564,10 +564,8 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 			if c.ReadinessProbe == nil {
 				c.ReadinessProbe = &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/version",
-							Port:   intstr.FromInt(8080),
-							Scheme: corev1.URISchemeHTTP,
+						TCPSocket: &corev1.TCPSocketAction{
+							Port: intstr.FromInt(8080),
 						},
 					},
 					InitialDelaySeconds: 5,


### PR DESCRIPTION
### Explain the changes
1. Before Noobaa core ReadinessProbe was based on the /version endpoint, but the version endpoint needs to be authenticated before accessing. It's not possible for ReadinessProbe
2. httpGet inside is removed, and  ReadinessProbe will return success when the noobaa core socket is up.

### Issues: Fixed #xxx / Gap #xxx
1. Noobaa deployment was failing because of Noobaa core ReadinessProbe

### Testing Instructions:
1. Deploy Noobaa inside Kubernetes and check deployment completed without the issue

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the health check mechanism for the "core" service from an HTTP-based readiness probe to a TCP socket probe on port 8080. The timing settings remain unchanged. This may affect how readiness is determined for the service but does not impact user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->