### PR TITLE
CI | Upgrade Tests

### DIFF
--- a/.github/workflows/manual-upgrade-tests.yaml
+++ b/.github/workflows/manual-upgrade-tests.yaml
@@ -1,0 +1,18 @@
+name: Full Upgrade Test
+on:
+  workflow_dispatch:
+    inputs:
+      source_version:
+        description: "Version to upgrade From"
+        required: false
+      target_version:
+        description: "Version to upgrade to"
+        required: false
+
+jobs:
+  nightly-upgrade-tests:
+    uses: ./.github/workflows/upgrade-tests-workflow.yaml
+    secrets: inherit
+    with:
+      source_version: ${{ github.event.inputs.source_version }}
+      target_version: ${{ github.event.inputs.target_version }}

--- a/.github/workflows/nightly-upgrade-tests.yaml
+++ b/.github/workflows/nightly-upgrade-tests.yaml
@@ -1,0 +1,9 @@
+name: Nightly Upgrade Tests
+on:
+  schedule:
+    - cron: '0 4 * * *'
+      
+jobs:
+  nightly-upgrade-tests:
+    uses: ./.github/workflows/upgrade-tests-workflow.yaml
+    secrets: inherit

--- a/.github/workflows/upgrade-tests-workflow.yaml
+++ b/.github/workflows/upgrade-tests-workflow.yaml
@@ -1,0 +1,41 @@
+name: Upgrade Tests Workflow
+on: 
+  workflow_call:
+    inputs:
+      source_version:
+        type: string
+        description: "Version to upgrade From"
+        required: false
+      target_version:
+        type: string
+        description: "Version to upgrade to"
+        required: false
+    
+jobs:
+  upgrade-tests-workflow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Set environment variables
+        run: |
+          echo PATH=$PATH:$HOME/go/bin  >> $GITHUB_ENV
+
+      - name: Deploy Dependencies
+        run: |
+          set -x
+          bash .travis/install-5nodes-kind-cluster.sh
+          go get -v github.com/onsi/ginkgo/v2
+          go install -v github.com/onsi/ginkgo/v2/ginkgo
+          ginkgo version
+
+      - name: Run Upgrade test
+        run: UPGRADE_TEST_OPERATOR_SOURCE_VERSION=${{ inputs.source_version }} UPGRADE_TEST_OPERATOR_TARGET_VERSION=${{ inputs.target_version }} make test-upgrade

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,11 @@ test-validations:
 	@echo "✅ test-validations"
 .PHONY: test-validations
 
+test-upgrade: vendor
+	ginkgo -v test/upgrade
+	@echo "✅ test-upgrade"
+.PHONY: test-upgrade
+
 # find or download controller-gen if necessary
 controller-gen:
 ifneq ($(CONTROLLER_GEN_VERSION), $(shell controller-gen --version | awk -F ":" '{print $2}'))

--- a/doc/CI&Tests/UpgradeTests.md
+++ b/doc/CI&Tests/UpgradeTests.md
@@ -1,0 +1,51 @@
+# NooBaa Operator - CI & Tests
+
+1. [Introduction](#introduction)
+2. [Upgrade Tests](#upgrade-tests)
+
+## Introduction
+
+NooBaa employs a Continuous Integration (CI) process to ensure the reliability and quality of its software. 
+NooBaa Tests cover various aspects of functionality and integration. 
+This proactive approach to testing enables NooBaa to deliver stable and efficient solutions for its users.
+
+## Upgrade Tests
+
+The NooBaa operator upgrade tests are part of the continuous integration (CI) pipeline and are designed to verify the stability and reliability of the system during version transitions.
+
+The upgrade test process includes the following steps:
+
+1. **Initial Deployment**: The latest release of the NooBaa operator is deployed on a Kubernetes cluster by default, see - [NooBaa Latest Release](https://api.github.com/repos/noobaa/noobaa-operator/releases/latest).
+2. **System Initialization**: A fully functional NooBaa system is created, including resources such as buckets, objects, backing stores, and endpoints.
+3. **Upgrade Execution**: The operator is upgraded to the target version using the noobaa CLI, the default target version is the latest noobaa-operator nightly build that could be found in [quay.io/noobaa/noobaa-operator](https://quay.io/repository/noobaa/noobaa-operator?tab=tags).
+4. **Post-Upgrade Validation**: The health and functionality of the NooBaa system are verified after the upgrade. This includes checking the readiness of control plane components, data accessibility, and the integrity of configurations and runtime state.
+
+These tests simulate upgrade scenarios and are continuously executed in the CI pipeline to detect upgrade-related issues early and ensure smooth operator version transitions.
+
+### Run upgrade tests locally
+
+In order to run upgrade tests locally with the default source and target versions, run the following command - 
+```bash
+make test-upgrade
+```
+
+In order to run upgrade tests locally with custom source and target versions, run the following command - 
+```bash
+UPGRADE_TEST_OPERATOR_SOURCE_VERSION=<upgrade-operator-source-version> UPGRADE_TEST_OPERATOR_TARGET_VERSION=<upgrade-operator-target-version> make test-upgrade
+```
+
+For instance - 
+```bash
+UPGRADE_TEST_OPERATOR_SOURCE_VERSION=5.17.0 UPGRADE_TEST_OPERATOR_TARGET_VERSION=5.18.6 make test-upgrade
+```
+
+### Manual Upgrade Tests Action 
+
+The following action is a dispatchable GitHub Action for running the upgrade tests manually.  
+It was implemented as part of the continuous integration (CI) process to allow on-demand execution of upgrade scenarios outside the scheduled or automated test pipeline.
+See - [Manual Upgrade Tests Action](../../.github/workflows/manual-upgrade-tests.yaml).
+
+### Nightly Upgrade Tests Action 
+
+A nightly Upgrade tests github actions runs every night at 4AM UTC.
+See - [Nightly Upgrade Tests Action](../../.github/workflows/nightly-upgrade-tests.yaml).

--- a/test/upgrade/upgrade_suit_test.go
+++ b/test/upgrade/upgrade_suit_test.go
@@ -1,0 +1,13 @@
+package upgrade_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Upgrade Suite")
+}

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -1,0 +1,429 @@
+package upgrade_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	operatorRepo         = "noobaa/noobaa-operator:"
+	operatorQuayRepo     = "quay.io/noobaa/noobaa-operator:"
+	ns                   = "noobaa-upgrade-test-ns"
+	obcNameBeforeUpgrade = "upgrade-test-obc-before-upgrade"
+	obcNameAfterUpgrade  = "upgrade-test-obc-after-upgrade"
+	numObjectsToPut      = 5
+	objectKeyLength      = 5
+	objectContentLength  = 5 * 1024 * 1024         // 5 MB
+	s3Endpoint           = "http://localhost:8080" // Assuming port-forwarding is set up to localhost:8080
+	CLIpath              = "../../build/_output/bin/noobaa-operator-local"
+	charset              = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
+
+var accessKey, secretKey string
+var log = util.Logger()
+
+// Notice that the upgrade tests are serial, so they run one after another
+var _ = Describe("NooBaa Operator Upgrade Tests", Serial, func() {
+	KeyToContentBeforeUpgradeMap := make(map[string]string)
+	It("should install NooBaa operator at source version", func() {
+		operatorSourceVersion, err := getOperatorSourceVersion()
+		Expect(err).NotTo(HaveOccurred())
+		installNooBaa(operatorSourceVersion)
+	})
+
+	It("should port forward NooBaa service", func() {
+		portForwardNoobaa()
+	})
+
+	It("should create OBC before upgrade", func() {
+		createObc(obcNameBeforeUpgrade, "noobaa-default-bucket-class")
+	})
+
+	It("should put/get objects before the upgrade", func() {
+		s3Client := getS3ClientForOBC(obcNameBeforeUpgrade)
+		for i := 0; i < numObjectsToPut; i++ {
+			objectKey := generateRandomString(objectKeyLength)
+			objectContent := generateRandomString(objectContentLength)
+			putObject(s3Client, obcNameBeforeUpgrade, objectKey, objectContent)
+			KeyToContentBeforeUpgradeMap[objectKey] = objectContent
+		}
+		for objectKey, objectContent := range KeyToContentBeforeUpgradeMap {
+			getObject(s3Client, obcNameBeforeUpgrade, objectKey, objectContent)
+		}
+	})
+
+	It("should stop port forward NooBaa service", func() {
+		stopPortForwardNoobaa()
+	})
+
+	It("should upgrade correctly", func() {
+		operatorTargetVersion, err := getOperatorTargetVersion()
+		Expect(err).NotTo(HaveOccurred())
+		upgradeNooBaa(operatorTargetVersion)
+	})
+
+	It("should port forward NooBaa service", func() {
+		portForwardNoobaa()
+	})
+
+	It("should get objects that were uploaded before the upgrade correctly", func() {
+		s3Client := getS3ClientForOBC(obcNameBeforeUpgrade)
+		for objectKey, objectContent := range KeyToContentBeforeUpgradeMap {
+			getObject(s3Client, obcNameBeforeUpgrade, objectKey, objectContent)
+		}
+	})
+
+	It("should put/get objects after the upgrade on bucket before upgrade correctly", func() {
+		s3Client := getS3ClientForOBC(obcNameBeforeUpgrade)
+		for i := 0; i < numObjectsToPut; i++ {
+			objectKey := generateRandomString(objectKeyLength)
+			objectContent := generateRandomString(objectContentLength)
+			putObject(s3Client, obcNameBeforeUpgrade, objectKey, objectContent)
+			getObject(s3Client, obcNameBeforeUpgrade, objectKey, objectContent)
+		}
+	})
+
+	It("should put/get bucket after the upgrade correctly", func() {
+		createObc(obcNameAfterUpgrade, "noobaa-default-bucket-class")
+	})
+
+	It("should put/get objects after the upgrade on bucket after upgrade correctly", func() {
+		s3Client := getS3ClientForOBC(obcNameAfterUpgrade)
+		for i := 0; i < numObjectsToPut; i++ {
+			objectKey := generateRandomString(objectKeyLength)
+			objectContent := generateRandomString(objectContentLength)
+			putObject(s3Client, obcNameAfterUpgrade, objectKey, objectContent)
+			getObject(s3Client, obcNameAfterUpgrade, objectKey, objectContent)
+		}
+	})
+
+	It("should stop port forward NooBaa service", func() {
+		stopPortForwardNoobaa()
+	})
+})
+
+// portForwardNoobaa sets up port forwarding for the NooBaa service to allow access to S3.
+func portForwardNoobaa() {
+	cmd := exec.Command("kubectl", "port-forward", "-n", ns, "service/s3", "8080:80")
+	Expect(cmd.Start()).To(Succeed())
+	time.Sleep(5 * time.Second) // wait for port forward to establish
+}
+
+// stopPortForwardNoobaa stops port forwarding for the NooBaa S3 service.
+func stopPortForwardNoobaa() {
+	cmd := exec.Command("pkill", "-f", "kubectl port-forward")
+	Expect(cmd.Start()).To(Succeed())
+	time.Sleep(5 * time.Second) // wait for port forward to establish
+}
+
+// getOBCSpec returns a new ObjectBucketClaim (OBC) specification with the given name and bucket class.
+func getOBCSpec(obcName string, bucketclass string) *nbv1.ObjectBucketClaim {
+	obc := &nbv1.ObjectBucketClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      obcName,
+			Namespace: ns,
+		},
+		Spec: nbv1.ObjectBucketClaimSpec{
+			BucketName:       obcName,
+			StorageClassName: fmt.Sprintf("%s.noobaa.io", ns),
+			AdditionalConfig: map[string]string{
+				"bucketclass": bucketclass,
+			},
+		},
+	}
+	return obc
+}
+
+// createObc creates an Object Bucket Claim (OBC) with the specified name and bucket class.
+// TODO - support more types of bucketclasses/obcs
+func createObc(obcName string, bucketclass string) {
+	obc := getOBCSpec(obcName, bucketclass)
+	ok := util.KubeApply(obc)
+	Expect(ok).To(BeTrue())
+	validateOBCIsBound(obcName)
+}
+
+var _ = BeforeSuite(func(ctx context.Context) {
+	util.InitLogger(logrus.DebugLevel)
+	_ = exec.Command("kubectl", "delete", "ns", ns, "--ignore-not-found").Run()
+	Expect(exec.Command("kubectl", "create", "ns", ns).Run()).To(Succeed())
+}, NodeTimeout(7*60*time.Second))
+
+var _ = AfterSuite(func(ctx context.Context) {
+	cmd := exec.Command(CLIpath, "uninstall", "--cleanup", "--cleanup_data", "-n", ns)
+	cmd.Stdin = strings.NewReader("y")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	Expect(cmd.Start()).To(Succeed())
+}, NodeTimeout(5*60*time.Second))
+
+///////////////////////////////
+//        CLI FUNCTIONS      //
+///////////////////////////////
+
+// installNooBaa installs the NooBaa operator at the specified source version.
+func installNooBaa(operatorSourceVersion string) {
+	Expect(exec.Command(CLIpath, "--dev", fmt.Sprintf("--operator-image=%s%s", operatorRepo, operatorSourceVersion), "install", "-n", ns).Run()).To(Succeed())
+	validateNooBaaCR()
+}
+
+// upgradeNooBaa upgrades the NooBaa operator to the specified target version.
+// It uses the CLI tool to perform the upgrade and validates the NooBaa CR status
+// TODO - add validation of the new version of core & db images This can be done by checking the version in the NooBaa CR
+func upgradeNooBaa(upgradeTargetVersion string) {
+	Expect(exec.Command(CLIpath, fmt.Sprintf("--operator-image=%s%s", operatorQuayRepo, upgradeTargetVersion), "upgrade", "-n", ns).Run()).To(Succeed())
+	validateNooBaaOperatorImage(upgradeTargetVersion)
+	validateNooBaaCR()
+}
+
+//////////////////////////////
+//        S3 FUNCTIONS      //
+//////////////////////////////
+
+func getS3ClientForOBC(obcName string) *s3.S3 {
+	accessKey, secretKey = getAccountCredentials(obcName)
+	Expect(accessKey).ToNot(BeEmpty())
+	Expect(secretKey).ToNot(BeEmpty())
+	s3Client, err := getS3Client(accessKey, secretKey)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(s3Client).NotTo(BeNil())
+	return s3Client
+}
+
+// getS3Client creates an S3 client using the provided access key and secret key.
+func getS3Client(accessKey string, secretKey string) (*s3.S3, error) {
+	client := &http.Client{Transport: util.InsecureHTTPTransport}
+	s3Config := &aws.Config{
+		Credentials: credentials.NewStaticCredentials(
+			accessKey,
+			secretKey,
+			"",
+		),
+		Region:           aws.String("us-east-1"),
+		Endpoint:         aws.String(s3Endpoint),
+		S3ForcePathStyle: aws.Bool(true),
+		HTTPClient:       client,
+	}
+	s3Session, err := session.NewSession(s3Config)
+	if err != nil {
+		return nil, err
+	}
+	s3Client := s3.New(s3Session)
+	return s3Client, nil
+}
+
+// getAccountCredentials retrieves the AWS access key and secret key from the OBC secret.
+func getAccountCredentials(bucketName string) (string, string) {
+	get := func(key string) string {
+		out, err := exec.Command("kubectl", "-n", ns, "get", "secret", bucketName, "-o", fmt.Sprintf("jsonpath={.data.%s}", key)).Output()
+		Expect(err).NotTo(HaveOccurred())
+		decoded, err := base64.StdEncoding.DecodeString(string(out))
+		Expect(err).NotTo(HaveOccurred())
+		return string(decoded)
+	}
+	accessKey := get("AWS_ACCESS_KEY_ID")
+	secretKey := get("AWS_SECRET_ACCESS_KEY")
+	return accessKey, secretKey
+}
+
+// putObject uploads an object to the specified bucket.
+func putObject(s3Client *s3.S3, bucketName string, objectKey string, objectContent string) {
+	_, err := s3Client.PutObject(&s3.PutObjectInput{
+		Bucket: &bucketName,
+		Key:    &objectKey,
+		Body:   strings.NewReader(objectContent),
+	})
+
+	Expect(err).To(BeNil())
+	log.Infof("Successfully put object %s to bucket %s\n", objectKey, bucketName)
+}
+
+// getObject retrieves an object from the specified bucket and validates its content.
+func getObject(s3Client *s3.S3, bucketName string, objectKey string, objectContent string) {
+	getObjectOutput, err := s3Client.GetObject(&s3.GetObjectInput{
+		Bucket: &bucketName,
+		Key:    &objectKey,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	buf := new(bytes.Buffer)
+	buf.Reset()
+	_, err = buf.ReadFrom(getObjectOutput.Body)
+	Expect(err).NotTo(HaveOccurred())
+	validateObjectContent(buf.String(), objectContent)
+	log.Infof("Successfully get object %s to bucket %s\n", objectKey, bucketName)
+}
+
+//////////////////////////////
+//    VALIDATION FUNCTIONS  //
+//////////////////////////////
+
+// validateNooBaaCR waits for the NooBaa CR to be in Ready state.
+// TODO - validate noobaa core & db images
+func validateNooBaaCR() {
+	Eventually(func() string {
+		out, _ := exec.Command("kubectl", "-n", ns, "get", "noobaa", "noobaa", "-o", "jsonpath={.status.phase}").Output()
+		return string(out)
+	}, 3*time.Minute, 5*time.Second).Should(Equal("Ready"))
+}
+
+// validateNooBaaOperatorImage asserts that the NooBaa operator image is running the expected version.
+func validateNooBaaOperatorImage(expectedVersion string) {
+	Eventually(func() string {
+		out, _ := exec.Command("kubectl", "-n", ns, "get", "deployment", "noobaa-operator", "-o", "jsonpath={.spec.template.spec.containers[0].image}").Output()
+		log.Infof("Current NooBaa Operator image: %s\n expected version: %s\n", string(out), expectedVersion)
+		return string(out)
+	}, 3*time.Minute, 5*time.Second).Should(ContainSubstring(expectedVersion))
+
+	Eventually(func() string {
+		out, _ := exec.Command("kubectl", "-n", ns, "get", "deployment", "noobaa-operator", "-o", "jsonpath={.status.readyReplicas}").Output()
+		log.Infof("NooBaa Operator deployment ready replicas: %s\n", string(out))
+		return string(out)
+	}, 3*time.Minute, 5*time.Second).Should(Equal("1"))
+}
+
+// validateObjectContent checks if the actual content matches the expected content.
+func validateObjectContent(actualContent string, expectedContent string) {
+	Expect(actualContent).To(Equal(expectedContent))
+}
+
+// validateOBCIsBound checks if the OBC is in Bound state.
+func validateOBCIsBound(obcName string) {
+	Eventually(func() (string, error) {
+		out, err := exec.Command("kubectl", "-n", ns, "get", "obc", obcName, "-o", "json").Output()
+		if err != nil {
+			return "", err
+		}
+		var obc struct {
+			Status struct {
+				Phase string `json:"phase"`
+			} `json:"status"`
+		}
+		if json.Unmarshal(out, &obc) != nil {
+			return "", fmt.Errorf("failed to unmarshal OBC status")
+		}
+		return obc.Status.Phase, nil
+	}, 4*time.Minute, 5*time.Second).Should(Equal("Bound"))
+}
+
+////////////////////////////
+//    VERSIONS FUNCTIONS  //
+////////////////////////////
+
+// getLastNightlyOperatorBuild retrieves the latest nightly operator build tag from Quay.io API.
+func getLastNightlyOperatorBuild() (string, error) {
+	operatorTagsQuayPath := "https://quay.io/api/v1/repository/noobaa/noobaa-operator/tag/"
+	cmd := exec.Command("curl", "-s", operatorTagsQuayPath)
+	out, err := cmd.CombinedOutput()
+	Expect(err).To(BeNil())
+	var tagsMap map[string]interface{}
+	err = json.Unmarshal(out, &tagsMap)
+	Expect(err).To(BeNil())
+	tags := tagsMap["tags"]
+	tagsSlice, ok := tags.([]interface{})
+	Expect(ok).To(BeTrue())
+	Expect(len(tagsSlice)).To(BeNumerically(">", 0))
+	tagInfo, ok := tagsSlice[0].(map[string]interface{})
+	Expect(ok).To(BeTrue())
+	name, ok := tagInfo["name"].(string)
+	Expect(ok).To(BeTrue())
+	Expect(err).To(BeNil())
+	log.Infof("Latest nightly operator build tag: %s\n", name)
+	return name, nil
+}
+
+// getLatestOperatorRelease retrieves the latest operator release tag from GitHub API.
+func getLatestOperatorRelease() (string, error) {
+	releaseTagsQuayPath := "https://api.github.com/repos/noobaa/noobaa-operator/releases/latest"
+	cmd := exec.Command("curl", "-s", releaseTagsQuayPath)
+	out, err := cmd.CombinedOutput()
+	Expect(err).To(BeNil())
+	var latestRelease map[string]interface{}
+	err = json.Unmarshal(out, &latestRelease)
+	Expect(err).To(BeNil())
+	log.Infof("latestTag %s\n", latestRelease["tag_name"])
+	Expect(err).To(BeNil())
+	Expect(latestRelease["tag_name"]).ToNot(BeNil())
+	tagName, ok := latestRelease["tag_name"].(string)
+	Expect(ok).ToNot(BeNil())
+	return tagName, nil
+}
+
+// getOperatorSourceVersion retrieves the operator source version from environment variables or defaults to the latest release.
+func getOperatorSourceVersion() (string, error) {
+	versionFromEnv := os.Getenv("UPGRADE_TEST_OPERATOR_SOURCE_VERSION")
+	if versionFromEnv != "" {
+		return versionFromEnv, nil
+	}
+
+	latestTag, err := getLatestOperatorRelease()
+	if err == nil && latestTag != "" {
+		trimmedTag := strings.TrimPrefix(latestTag, "v")
+		return trimmedTag, nil
+	}
+	return "", err
+}
+
+// getOperatorTargetVersion retrieves the operator target version from environment variables or defaults to the latest nightly build.
+// If the environment variable is not set, it fetches the latest nightly build tag.
+func getOperatorTargetVersion() (string, error) {
+	versionFromEnv := os.Getenv("UPGRADE_TEST_OPERATOR_TARGET_VERSION")
+	if versionFromEnv != "" {
+		return versionFromEnv, nil
+	}
+	latestNightlyBuildTag, err := getLastNightlyOperatorBuild()
+	if err == nil && latestNightlyBuildTag != "" {
+		return latestNightlyBuildTag, nil
+	}
+	return "", err
+}
+
+// generateRandomString generates a random string of the specified length using alphanumeric characters.
+func generateRandomString(length int) string {
+	src := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(src)
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[r.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+// TODO - enable noobaa-core source and target versions functionality
+// getCoreSourceVersion retrieves the core source version from environment variables or defaults to an empty string.
+// func getCoreSourceVersion() string {
+// 	versionFromEnv := os.Getenv("UPGRADE_TEST_CORE_SOURCE_VERSION")
+// 	if versionFromEnv != "" {
+// 		return versionFromEnv
+// 	}
+// 	return ""
+// }
+
+// // getCoreTargetVersion retrieves the core target version from environment variables or defaults to an empty string.
+// func getCoreTargetVersion() string {
+// 	versionFromEnv := os.Getenv("UPGRADE_TEST_CORE_TARGET_VERSION")
+// 	if versionFromEnv != "" {
+// 		return versionFromEnv
+// 	}
+// 	return ""
+// }


### PR DESCRIPTION
### Explain the changes
1. Added upgrade tests that do the following - 
- Install noobaa based on source operator version - by default it's the latest release operator build.
- Create buckets and objects.
- Upgrade NooBaa to the target operator version - by default it's the latest nightly operator build.
- Create objects on old bucket, create buckets and validates the objects content.

2. Added Manual and Nightly upgrade tests github actions.
3. Added documentation.

### Issues: Fixed #xxx / Gap #xxx
Some ideas I had during the work on this epic -
1. upgrade via olm
2. Add custom noobaa-core source and target images support.
5. Add custom noobaa-db source and target images support.
6. Add support of more types of buckets and more objects.
7. Add warp run before and after the upgrade.

Gap - 
1. There is a warning showing from util.kubeApply about `log.SetLogger(...) was never called; logs will not be displayed.` 

### Testing Instructions:
1. mentioned in the docs. 

- [x] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced automated upgrade testing for the NooBaa operator, including comprehensive end-to-end tests validating operator upgrades and S3 object operations.
  * Added manual and nightly GitHub Actions workflows to run upgrade tests on demand or on a schedule.
  * Provided a Makefile target for running upgrade tests locally.
* **Documentation**
  * Added detailed documentation explaining the upgrade testing process and instructions for running tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->