### PR TITLE
Add reconciliation logic for NooBaa with external PostgreSQL for secret creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build-releases/
 noobaa.cfg.yaml
 
 *.IGNORE
+.idea/

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1862,6 +1862,21 @@ func NooBaaCondition(noobaa *nbv1.NooBaa, t conditionsv1.ConditionType, s corev1
 	return found
 }
 
+// GetNooBaaExternalPgSecret returns the secret and adding the namespace if it is missing
+func GetNooBaaExternalPgSecret(nb *nbv1.NooBaa) *corev1.SecretReference {
+	var secretRef *corev1.SecretReference
+	if nb.Spec.ExternalPgSecret != nil {
+		secretRef = &corev1.SecretReference{
+			Name:      nb.Spec.ExternalPgSecret.Name,
+			Namespace: nb.Spec.ExternalPgSecret.Namespace,
+		}
+		if secretRef.Namespace == "" {
+			secretRef.Namespace = nb.Namespace
+		}
+	}
+	return secretRef
+}
+
 // GetAvailabeKubeCli will check which k8s cli command is availabe in the system: oc or kubectl
 // returns one of: "oc" or "kubectl"
 func GetAvailabeKubeCli() string {


### PR DESCRIPTION
### Explaining the PR

When creating a NooBaa instance that references an external PostgreSQL secret, the secret may not exist at the time of creation. This change ensures that once the external secret is created, the NooBaa system receives a reconciliation request to process it accordingly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The system now watches Kubernetes Secrets referenced by NooBaa external Postgres settings and triggers reconciliation when those Secrets change, ensuring credential/config updates are applied.
  * RPC messages now enqueue a rate-limited reconcile for the NooBaa system so external events prompt timely refreshes and state convergence.

* **Chores**
  * Added .idea/ to .gitignore to exclude IDE project files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->