### PR TITLE
Fix noobaa-core routes permission issue

### DIFF
--- a/deploy/role_core.yaml
+++ b/deploy/role_core.yaml
@@ -45,3 +45,13 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -6602,7 +6602,7 @@ subjects:
   name: custom-metrics-prometheus-adapter
 `
 
-const Sha256_deploy_role_core_yaml = "c3cfb5b87298224fd6e4e4bff32d3948ad168a0110b8569118a260739ef5d5e7"
+const Sha256_deploy_role_core_yaml = "1ec420603dcec64b247852d106535a85a1a866129f78f790c2e5c9285f029ae7"
 
 const File_deploy_role_core_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -6651,6 +6651,16 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
 `
 
 const Sha256_deploy_role_db_yaml = "bc7eeca1125dfcdb491ab8eb69e3dcbce9f004a467b88489f85678b3c6872cce"


### PR DESCRIPTION
### Explain the changes
1. Added missing routes permissions to core_role.yaml due to the following error - 
```
Error from server (Forbidden): routes.route.openshift.io is forbidden: User "system:serviceaccount:openshift-storage:noobaa-core" cannot list res
ource "routes" in API group "route.openshift.io" in the namespace "openshift-storage"

    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at ChildProcess.exithandler (node:child_process:414:12)
    at ChildProcess.emit (node:events:518:28)
    at ChildProcess.emit (node:domain:489:12)
    at maybeClose (node:internal/child_process:1101:16)
    at Socket.<anonymous> (node:internal/child_process:456:11)
    at Socket.emit (node:events:518:28)
    at Socket.emit (node:domain:489:12)
    at Pipe.<anonymous> (node:net:351:12) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'kubectl get route --selector="app=noobaa" -o=json',
  stdout: '{\n    "apiVersion": "v1",\n    "items": [],\n    "kind": "List",\n    "metadata": {\n        "resourceVersion": ""\n    }\n}\n',
  stderr: 'Error from server (Forbidden): routes.route.openshift.io is forbidden: User "system:serviceaccount:openshift-storage:noobaa-core" cann
ot list resource "routes" in API group "route.openshift.io" in the namespace "openshift-storage"\n'
}
```
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
Repro steps - 
1. `k logs noobaa-core-0 | less -R`
2. Search for the error mentioned above.
3. Edit noobaa-core role (in openshift get all roles and check using role bindings which one is the noobaa-core role).
and add the new routes permissions added in this PR.

Find noobaa-core role on openshift - 
```
k get rolebindings.rbac.authorization.k8s.io -o wide
k edit roles.rbac.authorization.k8s.io mcg-operator.v{version}.-{suffix}
```
4. delete noobaa-core pod - `k delete pod noobaa-core-0 --force`
5. Check noobaa-core-0 logs again and try to find the error mentioned above - after adding it you should see it anymore.
 
- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in support for OpenShift Route resources. When running on OpenShift, the system can create, read, update, list, and watch Routes to configure external access automatically. This reduces manual setup and improves compatibility, reliability, and out-of-the-box service exposure on OpenShift clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->