### PR TITLE
Update ContainerImageTag to master-20250812

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20250521"
+	ContainerImageTag = "master-20250812"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
Automated update of ContainerImageTag to master-20250812 in options.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default NooBaa container image to a newer master tag, so new deployments and upgrades using defaults will pull the latest image with recent fixes and improvements.
  * Enhances alignment with current backend components, reducing version drift and improving consistency across environments.
  * No action required for users who override the image; existing configurations and workflows remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->