### PR TITLE
[Direct to 5.19] Check if Spec.Affinity is changed in wasClusterSpecChanged

### DIFF
--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -546,6 +546,7 @@ func (r *Reconciler) wasClusterSpecChanged(existingClusterSpec *cnpgv1.ClusterSp
 	return !reflect.DeepEqual(existingClusterSpec.InheritedMetadata, r.CNPGCluster.Spec.InheritedMetadata) ||
 		!reflect.DeepEqual(existingClusterSpec.ImageCatalogRef, r.CNPGCluster.Spec.ImageCatalogRef) ||
 		existingClusterSpec.Instances != r.CNPGCluster.Spec.Instances ||
+		!reflect.DeepEqual(existingClusterSpec.Affinity, r.CNPGCluster.Spec.Affinity) ||
 		!reflect.DeepEqual(existingClusterSpec.Resources, r.CNPGCluster.Spec.Resources) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.StorageClass, r.CNPGCluster.Spec.StorageConfiguration.StorageClass) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.Size, r.CNPGCluster.Spec.StorageConfiguration.Size) ||


### PR DESCRIPTION
### Explain the changes
1. when checking if the cluster spec is changed, the `Spec.Affinity` field was not checked.
2. This is already fixed in master as part of other changes, and should be fixed in 4.19 only.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-3797 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
