### PR TITLE
Added a fix for DCO failure

### DIFF
--- a/.github/workflows/update-noobaa-core-tag.yml
+++ b/.github/workflows/update-noobaa-core-tag.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global user.name "NooBaa GitHub Action"
           git checkout -B update-core-tag-${{ steps.generate_tag.outputs.container_image_tag }}
           git add pkg/options/options.go
-          git commit -m "chore: update noobaa-core image tag to ${{ steps.generate_tag.outputs.container_image_tag }}"
+          git commit -s -m "chore: update noobaa-core image tag to ${{ steps.generate_tag.outputs.container_image_tag }}"
           git push origin update-core-tag-${{ steps.generate_tag.outputs.container_image_tag }}
 
       - name: Create Pull Request


### PR DESCRIPTION
### Explain the changes
1. Commit did not have a sign-off signature which is failing DCO.

### Issues: Fixed #xxx / Gap #xxx
1. Added the `-s` flag to the commit command to include a sign-off.
2. Fixed Gap: 
#1642
#1658 

### Testing Instructions:
1.  Run the workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration now appends a Signed-off-by line to automated commits generated by the workflow.
  * This change standardizes commit metadata for automated updates.
  * No impact on application features, behavior, or performance.
  * Public APIs and user-facing functionality remain unchanged.
  * Build, test, and release processes continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->