### PR TITLE
Update ContainerImageTag to master-20250813

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20250521"
+	ContainerImageTag = "master-20250813"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
Automated update of ContainerImageTag to master-20250813 in options.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the default container image to the latest master build, ensuring deployments pull the most recent core image with cumulative fixes, security patches, and performance improvements.
  * No functional behavior changes expected; impacts only default image selection for new deployments or when not overridden.
  * Users overriding the image tag are unaffected; existing deployments continue running their pinned images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->