### PR TITLE
[Backport to 5.20] fixes to db capacity alerts

### DIFF
--- a/.github/workflows/update-noobaa-core-tag.yml
+++ b/.github/workflows/update-noobaa-core-tag.yml
@@ -1,11 +1,9 @@
 name: Update Noobaa-Core container image tag
 
 on:
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
-    inputs:
-      container_image_tag:
-        description: 'The container image tag for noobaa-core'
-        required: true
 
 permissions:
   contents: write
@@ -17,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      GITHUB_TOKEN: ${{ secrets.GHACTION_TOKEN_WRITE }} # We need a token with write permissions to create/merge the PR
+      GITHUB_TOKEN: ${{ secrets.GHACTION_TOKEN_PR_PERMS }}
 
     steps:
       - name: Checkout master
@@ -25,11 +23,18 @@ jobs:
         with:
           ref: master
 
+      - name: Generate container image tag
+        id: generate_tag
+        run: |
+          tag="master-$(date -d 'yesterday' +%Y%m%d)" # using yesterday's date to ensure the image is available
+          echo "Generated tag: $tag"
+          echo "container_image_tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Replace ContainerImageTag
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: 'ContainerImageTag = "[^"]*"'
-          replace: 'ContainerImageTag = "${{ github.event.inputs.container_image_tag }}"'
+          replace: 'ContainerImageTag = "${{ steps.generate_tag.outputs.container_image_tag }}"'
           include: 'pkg/options/options.go'
           regex: true
 
@@ -45,7 +50,7 @@ jobs:
         run: |
           git config --global user.email "github-action@noobaa.io"
           git config --global user.name "NooBaa GitHub Action"
-          git checkout -b update-core-tag-${{ github.event.inputs.container_image_tag }}
+          git checkout -B update-core-tag-${{ steps.generate_tag.outputs.container_image_tag }}
           git add pkg/options/options.go
           git commit -s -m "chore: update noobaa-core image tag to ${{ steps.generate_tag.outputs.container_image_tag }}"
           git push origin update-core-tag-${{ steps.generate_tag.outputs.container_image_tag }}
@@ -54,13 +59,12 @@ jobs:
         id: create_pr
         run: |
           PR_URL=$(gh pr create \
-            --title "Update ContainerImageTag to ${{ github.event.inputs.container_image_tag }}" \
-            --body "Automated update of ContainerImageTag to ${{ github.event.inputs.container_image_tag }} in options.go" \
-            --head update-core-tag-${{ github.event.inputs.container_image_tag }} \
+            --title "Update ContainerImageTag to ${{ steps.generate_tag.outputs.container_image_tag }}" \
+            --body "Automated update of ContainerImageTag to ${{ steps.generate_tag.outputs.container_image_tag }} in options.go" \
+            --head update-core-tag-${{ steps.generate_tag.outputs.container_image_tag }} \
             --base master)
           echo "PR created: $PR_URL"
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
-
 
       - name: Wait for PR checks and merge
         run: |
@@ -73,3 +77,12 @@ jobs:
 
           echo "Rebasing and merging PR..."
           gh pr merge "${{ steps.create_pr.outputs.pr_url }}" --rebase --admin --delete-branch
+
+      - name: Cleanup branch on failure
+        if: always()
+        run: |
+          branch_name="update-core-tag-${{ steps.generate_tag.outputs.container_image_tag }}"
+          if git ls-remote --heads origin "$branch_name" | grep -q "$branch_name"; then
+            echo "Branch $branch_name still exists, deleting..."
+            git push origin --delete "$branch_name"
+          fi

--- a/.github/workflows/update-noobaa-core-tag.yml
+++ b/.github/workflows/update-noobaa-core-tag.yml
@@ -47,8 +47,8 @@ jobs:
           git config --global user.name "NooBaa GitHub Action"
           git checkout -b update-core-tag-${{ github.event.inputs.container_image_tag }}
           git add pkg/options/options.go
-          git commit -m "chore: update noobaa-core image tag to ${{ github.event.inputs.container_image_tag }}"
-          git push origin update-core-tag-${{ github.event.inputs.container_image_tag }}
+          git commit -s -m "chore: update noobaa-core image tag to ${{ steps.generate_tag.outputs.container_image_tag }}"
+          git push origin update-core-tag-${{ steps.generate_tag.outputs.container_image_tag }}
 
       - name: Create Pull Request
         id: create_pr

--- a/deploy/internal/prometheus-rules.yaml
+++ b/deploy/internal/prometheus-rules.yaml
@@ -247,63 +247,35 @@ spec:
         severity: critical
   - name: noobaa-db-alert.rules
     rules:
-      - alert: NooBaaDatabaseReachingCapacity
-        annotations:
-          description: The NooBaa database on pod noobaa-db-pg-cluster-1 is using 80% of its PVC requested size.
-          message: NooBaa NooBaa database on pod noobaa-db-pg-cluster-1 is using 80% of its PVC capacity.
-          severity_level: warning
-          storage_type: NooBaa
-        expr: |
-          (
-            cnpg_pg_database_size_bytes{datname="nbcore", namespace="openshift-storage", pod="noobaa-db-pg-cluster-1"}
-            /on(namespace) group_left(persistentvolumeclaim)
-            kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage", persistentvolumeclaim="noobaa-db-pg-cluster-1"}
-          ) * 100 > 80
-        for: 5m
-        labels:
-          severity: warning
-      - alert: NooBaaDatabaseReachingCapacity
-        annotations:
-          description: The NooBaa database on pod noobaa-db-pg-cluster-2 is using 80% of its PVC requested size.
-          message: NooBaa NooBaa database on pod noobaa-db-pg-cluster-2 is using 80% of its PVC capacity.
-          severity_level: warning
-          storage_type: NooBaa
-        expr: |
-          (
-            cnpg_pg_database_size_bytes{datname="nbcore", namespace="openshift-storage", pod="noobaa-db-pg-cluster-2"}
-            /on(namespace) group_left(persistentvolumeclaim)
-            kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage", persistentvolumeclaim="noobaa-db-pg-cluster-2"}
-          ) * 100 > 80
-        for: 5m
-        labels:
-          severity: warning
-      - alert: NooBaaDatabaseStorageFull
-        annotations:
-          description: The NooBaa database on pod noobaa-db-pg-cluster-1 is using over 90% of its PVC requested size. Increase the DB size as soon as possible.
-          message: NooBaa NooBaa database on pod noobaa-db-pg-cluster-1 is using over 90% of its PVC capacity.
-          severity_level: critical
-          storage_type: NooBaa
-        expr: |
-          (
-            cnpg_pg_database_size_bytes{datname="nbcore", namespace="openshift-storage", pod="noobaa-db-pg-cluster-1"}
-            /on(namespace) group_left(persistentvolumeclaim)
-            kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage", persistentvolumeclaim="noobaa-db-pg-cluster-1"}
-          ) * 100 > 90
-        for: 5m
-        labels:
-          severity: critical
-      - alert: NooBaaDatabaseStorageFull
-        annotations:
-          description: The NooBaa database on pod noobaa-db-pg-cluster-2 is using over 90% of its PVC requested size. Increase the DB size as soon as possible.
-          message: NooBaa NooBaa database on pod noobaa-db-pg-cluster-2 is using over 90% of its PVC capacity.
-          severity_level: critical
-          storage_type: NooBaa
-        expr: |
-          (
-            cnpg_pg_database_size_bytes{datname="nbcore", namespace="openshift-storage", pod="noobaa-db-pg-cluster-2"}
-            /on(namespace) group_left(persistentvolumeclaim)
-            kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage", persistentvolumeclaim="noobaa-db-pg-cluster-2"}
-          ) * 100 > 90
-        for: 5m
-        labels:
-          severity: critical
+    - alert: NooBaaDatabaseReachingCapacity
+      annotations:
+        description: The NooBaa database on pod {{ $labels.pod }} has reached 80% of its PVC capacity.
+        message: The NooBaa database on pod {{ $labels.pod }} is consuming 80% of its PVC capacity. Plan to increase the PVC size soon to prevent service impact.
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        ((sum by (pod) (cnpg_collector_pg_wal{value="size"})
+        + sum by (pod) (cnpg_pg_database_size_bytes{datname="nbcore"}))
+        /
+        sum by (pod) (
+        label_replace(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage"}, "pod", "$1", "persistentvolumeclaim", "(.*)"
+        ))) * 100 > 80
+      for: 5m
+      labels:
+        severity: warning    
+    - alert: NooBaaDatabaseStorageFull
+      annotations:
+        description: The NooBaa database on pod {{ $labels.pod }} has exceeded 90% of its PVC capacity. Immediate action is required
+        message: The NooBaa database on pod {{ $labels.pod }} has exceeded 90% of its PVC capacity. Expand the PVC size now to avoid imminent service disruption.
+        severity_level: critical
+        storage_type: NooBaa
+      expr: |
+        ((sum by (pod) (cnpg_collector_pg_wal{value="size"})
+        + sum by (pod) (cnpg_pg_database_size_bytes{datname="nbcore"}))
+        /
+        sum by (pod) (
+        label_replace(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage"}, "pod", "$1", "persistentvolumeclaim", "(.*)"
+        ))) * 100 > 90
+      for: 1m
+      labels:
+        severity: critical

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4537,7 +4537,7 @@ spec:
         claimName: noobaa-pv-claim
 `
 
-const Sha256_deploy_internal_prometheus_rules_yaml = "3d136d9c9891c9d3bdfdab4d8b5104ab31329b0740744a2e0bbcb34fa26bebf2"
+const Sha256_deploy_internal_prometheus_rules_yaml = "9dba8cfe7b655d3467b091531c95e6d34e8bd179f36ece6eaf3cff8ef73df23d"
 
 const File_deploy_internal_prometheus_rules_yaml = `apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -4788,66 +4788,38 @@ spec:
         severity: critical
   - name: noobaa-db-alert.rules
     rules:
-      - alert: NooBaaDatabaseReachingCapacity
-        annotations:
-          description: The NooBaa database on pod noobaa-db-pg-cluster-1 is using 80% of its PVC requested size.
-          message: NooBaa NooBaa database on pod noobaa-db-pg-cluster-1 is using 80% of its PVC capacity.
-          severity_level: warning
-          storage_type: NooBaa
-        expr: |
-          (
-            cnpg_pg_database_size_bytes{datname="nbcore", namespace="openshift-storage", pod="noobaa-db-pg-cluster-1"}
-            /on(namespace) group_left(persistentvolumeclaim)
-            kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage", persistentvolumeclaim="noobaa-db-pg-cluster-1"}
-          ) * 100 > 80
-        for: 5m
-        labels:
-          severity: warning
-      - alert: NooBaaDatabaseReachingCapacity
-        annotations:
-          description: The NooBaa database on pod noobaa-db-pg-cluster-2 is using 80% of its PVC requested size.
-          message: NooBaa NooBaa database on pod noobaa-db-pg-cluster-2 is using 80% of its PVC capacity.
-          severity_level: warning
-          storage_type: NooBaa
-        expr: |
-          (
-            cnpg_pg_database_size_bytes{datname="nbcore", namespace="openshift-storage", pod="noobaa-db-pg-cluster-2"}
-            /on(namespace) group_left(persistentvolumeclaim)
-            kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage", persistentvolumeclaim="noobaa-db-pg-cluster-2"}
-          ) * 100 > 80
-        for: 5m
-        labels:
-          severity: warning
-      - alert: NooBaaDatabaseStorageFull
-        annotations:
-          description: The NooBaa database on pod noobaa-db-pg-cluster-1 is using over 90% of its PVC requested size. Increase the DB size as soon as possible.
-          message: NooBaa NooBaa database on pod noobaa-db-pg-cluster-1 is using over 90% of its PVC capacity.
-          severity_level: critical
-          storage_type: NooBaa
-        expr: |
-          (
-            cnpg_pg_database_size_bytes{datname="nbcore", namespace="openshift-storage", pod="noobaa-db-pg-cluster-1"}
-            /on(namespace) group_left(persistentvolumeclaim)
-            kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage", persistentvolumeclaim="noobaa-db-pg-cluster-1"}
-          ) * 100 > 90
-        for: 5m
-        labels:
-          severity: critical
-      - alert: NooBaaDatabaseStorageFull
-        annotations:
-          description: The NooBaa database on pod noobaa-db-pg-cluster-2 is using over 90% of its PVC requested size. Increase the DB size as soon as possible.
-          message: NooBaa NooBaa database on pod noobaa-db-pg-cluster-2 is using over 90% of its PVC capacity.
-          severity_level: critical
-          storage_type: NooBaa
-        expr: |
-          (
-            cnpg_pg_database_size_bytes{datname="nbcore", namespace="openshift-storage", pod="noobaa-db-pg-cluster-2"}
-            /on(namespace) group_left(persistentvolumeclaim)
-            kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage", persistentvolumeclaim="noobaa-db-pg-cluster-2"}
-          ) * 100 > 90
-        for: 5m
-        labels:
-          severity: critical
+    - alert: NooBaaDatabaseReachingCapacity
+      annotations:
+        description: The NooBaa database on pod {{ $labels.pod }} has reached 80% of its PVC capacity.
+        message: The NooBaa database on pod {{ $labels.pod }} is consuming 80% of its PVC capacity. Plan to increase the PVC size soon to prevent service impact.
+        severity_level: warning
+        storage_type: NooBaa
+      expr: |
+        ((sum by (pod) (cnpg_collector_pg_wal{value="size"})
+        + sum by (pod) (cnpg_pg_database_size_bytes{datname="nbcore"}))
+        /
+        sum by (pod) (
+        label_replace(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage"}, "pod", "$1", "persistentvolumeclaim", "(.*)"
+        ))) * 100 > 80
+      for: 5m
+      labels:
+        severity: warning    
+    - alert: NooBaaDatabaseStorageFull
+      annotations:
+        description: The NooBaa database on pod {{ $labels.pod }} has exceeded 90% of its PVC capacity. Immediate action is required
+        message: The NooBaa database on pod {{ $labels.pod }} has exceeded 90% of its PVC capacity. Expand the PVC size now to avoid imminent service disruption.
+        severity_level: critical
+        storage_type: NooBaa
+      expr: |
+        ((sum by (pod) (cnpg_collector_pg_wal{value="size"})
+        + sum by (pod) (cnpg_pg_database_size_bytes{datname="nbcore"}))
+        /
+        sum by (pod) (
+        label_replace(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="openshift-storage"}, "pod", "$1", "persistentvolumeclaim", "(.*)"
+        ))) * 100 > 90
+      for: 1m
+      labels:
+        severity: critical
 `
 
 const Sha256_deploy_internal_pvc_agent_yaml = "c76fd98867e2e098204377899568a6e1e60062ece903c7bcbeb3444193ec13f8"

--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -77,7 +77,7 @@ func (r *Reconciler) ReconcileCNPGCluster() error {
 			},
 		}
 
-		if util.KubeCheck(standaloneDBPod) {
+		if util.KubeCheckQuiet(standaloneDBPod) {
 			// stop the standalone DB pod. For now it is only scaled down to 0 replicas, to keep it around as backup
 			r.cnpgLog("Scaling down the standalone DB pod")
 			if err := r.ReconcileObject(r.NooBaaPostgresDB, func() error {


### PR DESCRIPTION
(cherry picked from commit 9d98e31dac651749efb6f51604f7a0cc4bd0cde6)

### Explain the changes
- changed the alert rules to take into account the WAL size in addition to the database size.
- refactored the alerts to be more generic instead of alert per DB pod.
- changed the description and messages of the alerts.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-3818 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
