### PR TITLE
[Backport into 5.19] Update AWS Regions with ap-east-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ The following options can be passed to any command:
     --manual-default-backingstore=false: allow to delete the default backingstore
     --mini=false: Signal the operator that it is running in a low resource environment
     -n, --namespace='default': Target namespace
-    --noobaa-image='noobaa/noobaa-core:5.19.3': NooBaa image
-    --operator-image='noobaa/noobaa-operator:5.19.3': Operator image
+    --noobaa-image='noobaa/noobaa-core:5.19.4': NooBaa image
+    --operator-image='noobaa/noobaa-operator:5.19.4': Operator image
     --pg-ssl-cert='': ssl cert for postgres (client-side cert - need to be signed by external pg accepted CA)
     --pg-ssl-key='': ssl key for postgres (client-side cert - need to be signed by external pg accepted CA)
     --pg-ssl-required=false: Force noobaa to work with ssl (external postgres - server-side) [if server cert is self-signed, needs to add --ssl-unauthorized]
@@ -177,9 +177,9 @@ $ noobaa version
 ```
 
 ```
-INFO[0000] CLI version: 5.19.3
-INFO[0000] noobaa-image: noobaa/noobaa-core:5.19.3
-INFO[0000] operator-image: noobaa/noobaa-operator:5.19.3
+INFO[0000] CLI version: 5.19.4
+INFO[0000] noobaa-image: noobaa/noobaa-core:5.19.4
+INFO[0000] operator-image: noobaa/noobaa-operator:5.19.4
 ```
 
 ## Troubleshooting

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1,6 +1,6 @@
 package bundle
 
-const Version = "5.19.3"
+const Version = "5.19.4"
 
 const Sha256_deploy_cluster_role_yaml = "31fc622ff7fa66617be3895bddcb6cfdb97883b75b20bdb2bf04052bd14221a8"
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1216,6 +1216,7 @@ func GetAWSRegion() (string, error) {
 		"eu-south-1":     "eu-south-1",
 		"eu-south-2":     "eu-south-2",
 		"ap-east-1":      "ap-east-1",
+		"ap-east-2":      "ap-east-2",
 		"ap-northeast-1": "ap-northeast-1",
 		"ap-northeast-2": "ap-northeast-2",
 		"ap-northeast-3": "ap-northeast-3",

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const (
+var (
 	// Version is the noobaa-operator version (semver)
-	Version = "5.19.3"
+	Version = "5.19.4"
 )


### PR DESCRIPTION
### Explain the changes
- Update AWS Regions with ap-east-2


(cherry picked from commit 376fc5337430b99887212f989effe8380b27c778)


### Issues:
1. https://issues.redhat.com/browse/DFBUGS-2915
