### PR TITLE
Changed the version variable to be var

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const (
+var (
 	// Version is the noobaa-operator version (semver)
 	Version = "5.20.0"
 )


### PR DESCRIPTION
### Explain the changes
- Changed the version variable to be var

We are doing that, so in the downstream build, we will be able to edit it at build time


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal version representation changed to allow runtime updates while keeping the reported version unchanged (5.20.0).
  * No changes to commands, APIs, UI behavior, or performance.
  * External tools and scripts that read the version will continue to see the same value.
  * Stability and compatibility remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->