### PR TITLE
Modify the `golangci-lint` pre-commit and Makefile flow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,38 +1,11 @@
 #!/bin/sh
-export PATH="$PATH:$(go env GOPATH)/bin"
 
-command -v golangci-lint >/dev/null 2>&1 || {
-  echo "❌ golangci-lint not found – run 'make lint' to install it automatically"
-  exit 1
-}
+# Pre-commit hook that runs golangci-lint on staged Go files
+# Uses the unified golangci-lint script
 
-# Get list of staged Go files
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.go$' | sed 's| |\\ |g')
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# If there are no staged Go files, exit successfully
-if [ -z "$STAGED_FILES" ]; then
-  echo "✅ No staged Go files were found, exiting"
-  exit 0
-fi
-
-# Run golangci-lint on staged files
-echo "Running golangci-lint on staged files..."
-BASE=$(git rev-parse --verify HEAD 2>/dev/null || echo "")
-if [ -z "$BASE" ]; then
-  golangci-lint run $STAGED_FILES   # initial commit – lint everything staged
-else
-  golangci-lint run --new-from-rev="$BASE"
-fi
-
-# Store the exit code
-LINT_EXIT_CODE=$?
-
-# If golangci-lint found errors, exit with error
-if [ $LINT_EXIT_CODE -ne 0 ]; then
-  echo "❌ golangci-lint found errors in staged files. Please fix them before committing."
-  exit 1
-fi
-
-echo "✅ golangci-lint passed!"
-
-exit 0 
+# Call the unified golangci-lint script in precommit mode
+exec "$PROJECT_ROOT/scripts/run-golangci-lint.sh" precommit 

--- a/Makefile
+++ b/Makefile
@@ -184,18 +184,7 @@ test: lint test-go
 .PHONY: test
 
 lint: gen
-	@echo ""
-	@if [ ! -f "$(GOBIN)/golangci-lint" ] || [ "v2.1.6" != "$$($(GOBIN)/golangci-lint --version 2>/dev/null | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' || echo '')" ]; then \
-		echo "Installing golangci-lint v2.1.6..."; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6; \
-	fi
-	@if [ -n "$(FILES)" ]; then \
-		echo "Running lint on changed files: $(FILES)"; \
-		$(GOBIN)/golangci-lint run --config .golangci.yml $(FILES); \
-	else \
-		echo "Running lint on all files"; \
-		$(GOBIN)/golangci-lint run --config .golangci.yml; \
-	fi
+	@./scripts/run-golangci-lint.sh makefile
 	@echo "✅ lint"
 .PHONY: lint
 

--- a/scripts/run-golangci-lint.sh
+++ b/scripts/run-golangci-lint.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+
+# Unified golangci-lint runner script
+# Usage: ./scripts/run-golangci-lint.sh <mode>
+# Modes: precommit, makefile
+
+# Uncomment this to see the commands being run
+# Note: We don't use 'set -e' because we need to handle golangci-lint's
+# exit codes manually to distinguish between linting issues and other errors
+# set -x
+
+# Exit code used by golangci-lint when linting issues are found
+# Allows us to distinguish between linting issues and other errors
+readonly ISSUES_EXIT_CODE=42
+
+MODE="${1}"
+
+# Safely check whether Go is installed and set the GOPATH
+# Also check for GOBIN and add it to the PATH in case the binary was installed to a non-standard location
+ if command -v go >/dev/null 2>&1; then
+     GOBIN="$(go env GOBIN)"
+     GOPATH_BIN="$(go env GOPATH)/bin"
+     [ -n "${GOBIN}" ] && export PATH="${PATH}:${GOBIN}"
+     export PATH="${PATH}:${GOPATH_BIN}"
+ fi
+
+# Function to install golangci-lint (for makefile mode)
+install_golangci_lint() {
+    echo "Installing the latest golangci-lint with local toolchain"
+    if ! go install -a "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"
+    then
+        echo "⚠️ Failed to install golangci-lint"
+        exit 0
+    fi
+}
+
+# Function to run golangci-lint in precommit mode
+run_precommit_lint() {
+    echo "Running golangci-lint in precommit mode..."
+    
+    # Check if golangci-lint is available - exit gracefully if it isn't
+    if ! command -v golangci-lint >/dev/null 2>&1
+    then
+        echo "⚠️ golangci-lint not found – run 'make lint' to install it automatically"
+        exit 0
+    fi
+    
+    # Collect staged Go files as positional args
+    # cached: retrieve only staged files
+    # name-only: retrieve only the names of the files
+    # diff-filter=ACMR: retrieve only the files that have been added, copied, modified, or renamed
+    # grep -E '\.go$': retrieve only the files that end with .go
+    # || true: if there are no staged Go files, return a zero-status exit code
+    set -- $(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.go$' || true)
+    # If there are no staged Go files, exit successfully
+    if [ "$#" -eq 0 ]; then
+        echo "✅ No staged Go files were found, exiting"
+        exit 0
+    fi
+    
+    echo "Running golangci-lint on staged files..."
+    BASE=$(git rev-parse --verify HEAD 2>/dev/null || echo "")
+    
+    if [ -z "${BASE}" ]
+    then
+        # Initial commit – lint only staged files
+        golangci-lint run --issues-exit-code=${ISSUES_EXIT_CODE} --config .golangci.yml "${@}"
+    else
+        # Lint only staged changes vs HEAD
+        golangci-lint run --issues-exit-code=${ISSUES_EXIT_CODE} --config .golangci.yml --new-from-rev="${BASE}" "${@}"
+    fi
+    
+    # Store the exit code
+    LINT_EXIT_CODE=${?}
+    
+    # Handle exit codes properly
+    if [ ${LINT_EXIT_CODE} -eq ${ISSUES_EXIT_CODE} ]
+    then
+        echo "❌ golangci-lint found linting issues in staged files. Please fix them before committing."
+        exit 1
+    elif [ ${LINT_EXIT_CODE} -ne 0 ]
+    then
+        echo "⚠️  golangci-lint encountered an error (exit code: ${LINT_EXIT_CODE})"
+        exit 0
+    fi
+    
+    echo "✅ golangci-lint passed!"
+}
+
+# Function to run golangci-lint in makefile mode
+run_makefile_lint() {
+    echo "Running golangci-lint in makefile mode..."
+    
+    # Install golangci-lint if needed
+    install_golangci_lint
+    
+    echo "Running lint on all files"
+    golangci-lint run --issues-exit-code=${ISSUES_EXIT_CODE} --config .golangci.yml
+    
+    # Store the exit code
+    LINT_EXIT_CODE=${?}
+    
+    # Handle exit codes properly
+    if [ ${LINT_EXIT_CODE} -eq ${ISSUES_EXIT_CODE} ]
+    then
+        echo "❌ golangci-lint found linting issues. Please fix them."
+        exit 1
+    elif [ ${LINT_EXIT_CODE} -ne 0 ]
+    then
+        echo "⚠️ golangci-lint encountered an error (exit code: ${LINT_EXIT_CODE})"
+        exit 0
+    fi
+    
+    echo "✅ golangci-lint passed!"
+}
+
+# Main logic
+case "${MODE}" in
+    "precommit")
+        run_precommit_lint
+        ;;
+    "makefile")
+        run_makefile_lint
+        ;;
+    *)
+        echo "Usage: ${0} <mode>"
+        echo "Modes: precommit, makefile"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
### Explain the changes
1. Flows related to `golandci-lint` were moved from `Makefile` and `pre-commit` to a unified script (`run-golangci-lint.sh`) to reduce bloat in external files, and also allow a central maintenance spot (and source of truth) for anything related to the linter
2. Exit codes were changed to only block commits/`make` commands in case of linting problems in reviewed files
3. Any exit code unrelated to linting problems is now printed as a warning to the git log/console, but is not blocking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a centralized lint runner; pre-commit hook and build/CI lint now delegate to it.
  * Pre-commit flow now relies on the centralized runner to check staged Go changes and ensure the linter is available.
  * CI/build linting runs through the centralized runner and reports clear pass/fail status.

* **Refactor**
  * Removed inline linter install/version checks and PATH modifications from hooks and Makefile.

* **Note**
  * No user-facing features changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->