### PR TITLE
Remove the outdated `golangci-lint` makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,11 +183,6 @@ test: lint test-go
 	@echo "✅ test"
 .PHONY: test
 
-golangci-lint: gen
-	golangci-lint run --disable-all -E varcheck,structcheck,typecheck,errcheck,gosimple,unused,deadcode,ineffassign,staticcheck --timeout=10m
-	@echo "✅ golangci-lint"
-.PHONY: golangci-lint
-
 lint: gen
 	@echo ""
 	@if [ ! -f "$(GOBIN)/golangci-lint" ] || [ "v2.1.6" != "$$($(GOBIN)/golangci-lint --version 2>/dev/null | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' || echo '')" ]; then \


### PR DESCRIPTION
### Explain the changes
1. The (now-removed) `golangci-lint` make target was replaced by the new `lint` target, which runs v2 of `golangci-lint`, and renders the previous one redundant. Thus, this PR removes the appropriate code



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined development linting by consolidating to a single lint command; removed a redundant shortcut. Existing lint behavior remains unchanged.
  * Developers should use the primary lint command going forward; CI pipelines and local workflows are unaffected.
  * This reduces maintenance overhead and avoids duplicate commands. No impact on application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->