### PR TITLE
Add missing envs for external pg db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ noobaa.cfg.yaml
 .DS_Store
 
 *.IGNORE
+.idea/

--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -136,6 +136,7 @@ spec:
             - name: POSTGRES_PASSWORD_PATH
             - name: POSTGRES_DBNAME_PATH
             - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
             - name: VIRTUAL_HOSTS
             - name: REGION
             - name: ENDPOINT_GROUP_ID

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -119,7 +119,6 @@ spec:
                   name: noobaa-config
                   key: NOOBAA_VERSION_AUTH_ENABLED
             - name: POSTGRES_HOST
-              value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_HOST_RO
             - name: POSTGRES_PORT
             - name: POSTGRES_DBNAME
@@ -133,6 +132,7 @@ spec:
             - name: POSTGRES_PASSWORD_PATH
             - name: POSTGRES_DBNAME_PATH
             - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
             - name: GUARANTEED_LOGS_PATH
             - name: DB_TYPE
               value: postgres

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4207,7 +4207,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "f8c8dbc75ac2b8001ecda2145e1ed423a6a42c635d50d103518e9457a45b161f"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "a67f11787f36028d86c794479a25321da979968cda86339d8761248198cd198c"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4347,6 +4347,7 @@ spec:
             - name: POSTGRES_PASSWORD_PATH
             - name: POSTGRES_DBNAME_PATH
             - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
             - name: VIRTUAL_HOSTS
             - name: REGION
             - name: ENDPOINT_GROUP_ID
@@ -5384,7 +5385,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "950eaab1e58069eec4df071a6020f75914586a5a2b25f56470059cc9c0b7f892"
+const Sha256_deploy_internal_statefulset_core_yaml = "eba784851e7b0b47a13e96d44b956da9025f14e9b51474a1dcc25a6c5995dedc"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5507,7 +5508,6 @@ spec:
                   name: noobaa-config
                   key: NOOBAA_VERSION_AUTH_ENABLED
             - name: POSTGRES_HOST
-              value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_HOST_RO
             - name: POSTGRES_PORT
             - name: POSTGRES_DBNAME
@@ -5521,6 +5521,7 @@ spec:
             - name: POSTGRES_PASSWORD_PATH
             - name: POSTGRES_DBNAME_PATH
             - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
             - name: GUARANTEED_LOGS_PATH
             - name: DB_TYPE
               value: postgres

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -557,7 +557,9 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 		case "POSTGRES_HOST_PATH":
 			c.Env[j].Value = postgresSecretMountPath + "/host"
 		case "POSTGRES_CONNECTION_STRING_PATH":
-			c.Env[j].Value = postgresSecretMountPath + "/db_url"
+			if r.NooBaa.Spec.ExternalPgSecret != nil {
+				c.Env[j].Value = postgresSecretMountPath + "/db_url"
+			}
 
 		case "NODE_EXTRA_CA_CERTS":
 			c.Env[j].Value = r.ApplyCAsToPods


### PR DESCRIPTION
 ### Testing Instructions:
1. Install NooBaa with an externally managed PostgreSQL DB 
2. `noobaa install --postgres-url=''`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a configurable POSTGRES connection-string environment variable for core and endpoint; it's declared by default and populated only when an external PostgreSQL secret is provided.

* **Bug Fixes / Chores**
  * Removes a hard-coded DB host so DB settings can be supplied dynamically.
  * Deployment packaging updated to reflect the new env handling.
  * .gitignore updated to ignore IDE config files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->