### PR TITLE
Set default path for nsfs bucket OBC provisioning to the bucket name

### DIFF
--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -467,7 +467,11 @@ func (r *BucketRequest) CreateAndUpdateBucket(
 
 	// create NS bucket
 	if r.BucketClass.Spec.NamespacePolicy != nil {
-		createBucketParams.Namespace = bucketclass.CreateNamespaceBucketInfoStructure(*r.BucketClass.Spec.NamespacePolicy, r.OBC.Spec.AdditionalConfig["path"])
+		path := r.OBC.Spec.AdditionalConfig["path"]
+		if path == "" {
+			path = r.BucketName
+		}
+		createBucketParams.Namespace = bucketclass.CreateNamespaceBucketInfoStructure(*r.BucketClass.Spec.NamespacePolicy, path)
 	}
 
 	err = r.SysClient.NBClient.CreateBucketAPI(*createBucketParams)


### PR DESCRIPTION
### Explain the changes
1. When provisioning an NSFS bucket via OBC, use the bucket name as a default path in the nsfs_config. If "path" is set in `OBC.Spec.AdditionalConfig`, it should take precedence.


### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-3817

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace bucket provisioning: if a NamespacePolicy is set and no path is provided, the system now defaults the path to the bucket name. This prevents failures caused by empty paths and ensures reliable bucket creation.
  * No impact to other bucket creation flows; behavior remains unchanged outside this scenario.
  * No user-facing configuration or API changes required; existing setups without a path will work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->