### PR TITLE
Remove usage of create_auth and reset_password API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/go-playground/validator/v10 v10.15.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -944,7 +944,7 @@ func WaitReady(backStore *nbv1.BackingStore) bool {
 	log := util.Logger()
 	klient := util.KubeClient()
 
-	interval := time.Duration(3)
+	interval := time.Duration(30)
 
 	err := wait.PollUntilContextCancel(ctx, interval*time.Second, true, func(ctx context.Context) (bool, error) {
 		err := klient.Get(util.Context(), util.ObjectKey(backStore), backStore)

--- a/pkg/nb/api.go
+++ b/pkg/nb/api.go
@@ -22,7 +22,6 @@ type Client interface {
 	ListBucketsAPI(ListBucketsParams) (ListBucketsReply, error)
 	ListHostsAPI(ListHostsParams) (ListHostsReply, error)
 
-	CreateAuthAPI(CreateAuthParams) (CreateAuthReply, error)
 	CreateSystemAPI(CreateSystemParams) (CreateSystemReply, error)
 	CreateAccountAPI(CreateAccountParams) (CreateAccountReply, error)
 	CreateBucketAPI(CreateBucketParams) error
@@ -65,7 +64,6 @@ type Client interface {
 
 	GenerateAccountKeysAPI(GenerateAccountKeysParams) error
 	UpdateAccountKeysAPI(UpdateAccountKeysParams) error
-	ResetPasswordAPI(ResetPasswordParams) error
 }
 
 // ReadAuthAPI calls auth_api.read_auth()
@@ -162,17 +160,6 @@ func (c *RPCClient) ListHostsAPI(params ListHostsParams) (ListHostsReply, error)
 	res := &struct {
 		RPCMessage `json:",inline"`
 		Reply      ListHostsReply `json:"reply"`
-	}{}
-	err := c.Call(req, res)
-	return res.Reply, err
-}
-
-// CreateAuthAPI calls auth_api.create_auth()
-func (c *RPCClient) CreateAuthAPI(params CreateAuthParams) (CreateAuthReply, error) {
-	req := &RPCMessage{API: "auth_api", Method: "create_auth", Params: params}
-	res := &struct {
-		RPCMessage `json:",inline"`
-		Reply      CreateAuthReply `json:"reply"`
 	}{}
 	err := c.Call(req, res)
 	return res.Reply, err
@@ -442,11 +429,5 @@ func (c *RPCClient) GenerateAccountKeysAPI(params GenerateAccountKeysParams) err
 // UpdateAccountKeysAPI calls account_api.update_account_keys()
 func (c *RPCClient) UpdateAccountKeysAPI(params UpdateAccountKeysParams) error {
 	req := &RPCMessage{API: "account_api", Method: "update_account_keys", Params: params}
-	return c.Call(req, nil)
-}
-
-// ResetPasswordAPI calls account_api.reset_password()
-func (c *RPCClient) ResetPasswordAPI(params ResetPasswordParams) error {
-	req := &RPCMessage{API: "account_api", Method: "reset_password", Params: params}
 	return c.Call(req, nil)
 }

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -286,7 +286,7 @@ type ListAccountsReply struct {
 // ListBcuketsParams is the params to account_api.list_buckets()
 type ListBucketsParams struct {
 	ContinuationToken *string `json:"continuation_token,omitempty"`
-	MaxBuckets *int `json:"max_buckets,omitempty"`
+	MaxBuckets        *int    `json:"max_buckets,omitempty"`
 }
 
 // ListBucketsReply is the reply of bucket_api.list_buckets()
@@ -314,19 +314,6 @@ type ListHostsReply struct {
 // HostInfo is the information of a host(partial)
 type HostInfo struct {
 	Name string `json:"name"`
-}
-
-// CreateAuthParams is the params of auth_api.create_auth()
-type CreateAuthParams struct {
-	System   string `json:"system"`
-	Role     string `json:"role"`
-	Email    string `json:"email"`
-	Password string `json:"password,omitempty"`
-}
-
-// CreateAuthReply is the reply of auth_api.create_auth()
-type CreateAuthReply struct {
-	Token string `json:"token"`
 }
 
 // CreateSystemParams is the params of system_api.create_system()
@@ -437,13 +424,6 @@ type GenerateAccountKeysParams struct {
 type UpdateAccountKeysParams struct {
 	Email      string       `json:"email"`
 	AccessKeys S3AccessKeys `json:"access_keys"`
-}
-
-// ResetPasswordParams is the params of account_api.reset_password()
-type ResetPasswordParams struct {
-	Email                string       `json:"email"`
-	VerificationPassword MaskedString `json:"verification_password"`
-	Password             MaskedString `json:"password"`
 }
 
 // BackingStoreInfo describes backingstore info
@@ -585,15 +565,15 @@ type DeleteNamespaceResourceParams struct {
 
 // UpdateAccountParams is the params of account_api.update_account_s3_access()
 type UpdateAccountParams struct {
-	Name                *string                  `json:"username,omitempty"`
-	Email               string                   `json:"email"`
-	NewEmail            *string                  `json:"new_email,omitempty"`
-	AllowedIPs          *[]struct {
-		Start   string `json:"start"`
-		End     string `json:"end"`
+	Name       *string `json:"username,omitempty"`
+	Email      string  `json:"email"`
+	NewEmail   *string `json:"new_email,omitempty"`
+	AllowedIPs *[]struct {
+		Start string `json:"start"`
+		End   string `json:"end"`
 	} `json:"ips,omitempty"`
-	RoleConfig          interface{}              `json:"role_config,omitempty"`
-	RemoveRoleConfig    bool                     `json:"remove_role_config,omitempty"`
+	RoleConfig       interface{} `json:"role_config,omitempty"`
+	RemoveRoleConfig bool        `json:"remove_role_config,omitempty"`
 }
 
 // UpdateAccountS3AccessParams is the params of account_api.update_account_s3_access()

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20250521"
+	ContainerImageTag = "master-20250911"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -791,8 +791,6 @@ function account_cycle {
     #admin account that don't have a secret and don't have CRD 
     account_regenerate_keys "operator@noobaa.io"
     account_update_keys "operator@noobaa.io" "Ab987654321987654321" "Ab+/987654321987654321987654321987654321"
-    # testing account reset password
-    account_reset_password "admin@noobaa.io"
     # testing nsfs accounts
     # account_nsfs_cycle TODO re-enable.
     # update account default resource
@@ -938,31 +936,6 @@ function account_update_keys {
         echo_time "❌ Looks like the SECRET_ACCESS were not updated, Exiting"
         exit 1
     fi
-}
-
-function account_reset_password {
-    local account=${1}
-    local password=$(get_admin_password)
-    #reset password should work
-    test_noobaa account passwd ${account} --old-password ${password} --new-password "test" --retype-new-password "test"
-    # Should fail if the old password is not correct
-    test_noobaa should_fail account passwd ${account} --old-password "test1" --new-password "test" --retype-new-password "test"
-    # Should fail if we got the same password as the old one
-    test_noobaa should_fail account passwd ${account} --old-password "test" --new-password "test" --retype-new-password "test"
-    # Should fail if we got the same password twice 
-    test_noobaa should_fail account passwd ${account} --old-password "test" --new-password "test1" --retype-new-password "test2"
-}
-
-function get_admin_password {
-    local password
-    while read line
-    do
-        if [[ ${line} =~ "password" ]]
-        then
-            password=$(echo ${line//\"/} | awk -F ":" '{print $2}')
-        fi
-    done < <(yes | test_noobaa status --show-secrets)
-    echo ${password}
 }
 
 function account_nsfs_cycle {
@@ -1218,6 +1191,7 @@ function check_default_backingstore {
     echo_time "💬 Creating new-default-backing-store and updating the admin account default_resourse with it"
     test_noobaa backingstore create pv-pool new-default-backing-store --num-volumes 1 --pv-size-gb 16
     test_noobaa account update admin@noobaa.io --new_default_resource=new-default-backing-store
+    test_noobaa account update operator@noobaa.io --new_default_resource=new-default-backing-store
     test_noobaa api account list_accounts {}
     test_noobaa account list
 


### PR DESCRIPTION
### Explain the changes
‼️ This PR depends on https://github.com/noobaa/noobaa-core/pull/9211

This PR:
1. Removes the usage of `CreateAuthAPI` and replaces it with generating tokens using a new utility function `MakeAuthToken`.
2. Removes password reset functionality and `ResetPasswordAPI` and associated tests.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Remote authentication now uses internally generated JWTs for operator, admin, and metrics flows.
  - Removed client auth API surface and password-reset API/types; CLI password-reset command and test helpers removed.

- Behavior Changes
  - Increased readiness polling cadence for backing stores and extended certain condition timeouts to 5 minutes.

- Chores
  - Updated default container image tag to master-20250911.
  - JWT library promoted to a direct dependency; added token-generation utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->