### PR TITLE
Update ContainerImageTag to master-20250930

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20250911"
+	ContainerImageTag = "master-20250930"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
Automated update of ContainerImageTag to master-20250930 in options.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image tag to the latest build (master-20250930) to incorporate recent improvements.
  * No functional changes; existing deployments pinned to specific images are unaffected.
  * New deployments relying on defaults will use the updated image automatically.
  * No user action required unless you depend on the previous default image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->