### PR TITLE
IAM | IAM Service and Route Addition

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -25,6 +25,10 @@ spec:
       jsonPath: .status.services.serviceSts.nodePorts
       name: Sts-Endpoints
       type: string
+    - description: IAM Endpoints
+      jsonPath: .status.services.serviceIam.nodePorts
+      name: Iam-Endpoints
+      type: string
     - description: Syslog Endpoints
       jsonPath: .status.services.serviceSyslog.nodePorts
       name: Syslog-Endpoints
@@ -1756,6 +1760,12 @@ spec:
                   only from the listed subnets. This field will have no effect if DisableLoadBalancerService is set
                   to true
                 properties:
+                  iam:
+                    description: IAM is a list of subnets that will be allowed to
+                      access the Noobaa IAM service
+                    items:
+                      type: string
+                    type: array
                   s3:
                     description: S3 is a list of subnets that will be allowed to access
                       the Noobaa S3 service
@@ -2082,6 +2092,61 @@ spec:
               services:
                 description: Services reports addresses for the services
                 properties:
+                  serviceIam:
+                    description: ServiceStatus is the status info and network addresses
+                      of a service
+                    properties:
+                      externalDNS:
+                        description: ExternalDNS are external public addresses for
+                          the service
+                        items:
+                          type: string
+                        type: array
+                      externalIP:
+                        description: |-
+                          ExternalIP are external public addresses for the service
+                          LoadBalancerPorts such as AWS ELB provide public address and load balancing for the service
+                          IngressPorts are manually created public addresses for the service
+                          https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+                          https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+                          https://kubernetes.io/docs/concepts/services-networking/ingress/
+                        items:
+                          type: string
+                        type: array
+                      internalDNS:
+                        description: InternalDNS are internal addresses of the service
+                          inside the cluster
+                        items:
+                          type: string
+                        type: array
+                      internalIP:
+                        description: |-
+                          InternalIP are internal addresses of the service inside the cluster
+                          https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                        items:
+                          type: string
+                        type: array
+                      nodePorts:
+                        description: |-
+                          NodePorts are the most basic network available.
+                          NodePorts use the networks available on the hosts of kubernetes nodes.
+                          This generally works from within a pod, and from the internal
+                          network of the nodes, but may fail from public network.
+                          https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                        items:
+                          type: string
+                        type: array
+                      podPorts:
+                        description: |-
+                          PodPorts are the second most basic network address.
+                          Every pod has an IP in the cluster and the pods network is a mesh
+                          so the operator running inside a pod in the cluster can use this address.
+                          Note: pod IPs are not guaranteed to persist over restarts, so should be rediscovered.
+                          Note2: when running the operator outside of the cluster, pod IP is not accessible.
+                        items:
+                          type: string
+                        type: array
+                    type: object
                   serviceMgmt:
                     description: ServiceStatus is the status info and network addresses
                       of a service

--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -37,6 +37,10 @@ spec:
           secret:
             secretName: noobaa-sts-serving-cert
             optional: true
+        - name: iam-secret
+          secret:
+            secretName: noobaa-iam-serving-cert
+            optional: true
         # This service account token can be used to provide identity outside the cluster.
         # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate with AWS using IAM OIDC provider and STS.
         - name: bound-sa-token
@@ -78,6 +82,8 @@ spec:
             - containerPort: 6001
             - containerPort: 6443
             - containerPort: 7443
+            - containerPort: 13443
+              name: iam-https
           env:
             - name: NODE_NAME
               valueFrom:
@@ -164,6 +170,9 @@ spec:
               readOnly: true
             - name: noobaa-server
               mountPath: /etc/noobaa-server
+              readOnly: true
+            - name: iam-secret
+              mountPath: /etc/iam-secret
               readOnly: true
             - name: sts-secret
               mountPath: /etc/sts-secret

--- a/deploy/internal/route-iam.yaml
+++ b/deploy/internal/route-iam.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: noobaa
+  name: iam
+spec:
+  port:
+    targetPort: iam-https
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: iam
+    weight: 100
+  wildcardPolicy: None

--- a/deploy/internal/service-iam.yaml
+++ b/deploy/internal/service-iam.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: iam
+  labels:
+    app: noobaa
+    noobaa-iam-svc: "true"
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: 'noobaa-iam-serving-cert'
+    service.alpha.openshift.io/serving-cert-secret-name: 'noobaa-iam-serving-cert'
+spec:
+  type: LoadBalancer
+  selector:
+    noobaa-s3: SYSNAME
+  ports:
+    - port: 443
+      targetPort: iam-https
+      name: iam-https

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -33,6 +33,7 @@ type AnnotationsSpec map[string]Annotations
 // +kubebuilder:resource:shortName=nb
 // +kubebuilder:printcolumn:name="S3-Endpoints",type="string",JSONPath=".status.services.serviceS3.nodePorts",description="S3 Endpoints"
 // +kubebuilder:printcolumn:name="Sts-Endpoints",type="string",JSONPath=".status.services.serviceSts.nodePorts",description="STS Endpoints"
+// +kubebuilder:printcolumn:name="Iam-Endpoints",type="string",JSONPath=".status.services.serviceIam.nodePorts",description="IAM Endpoints"
 // +kubebuilder:printcolumn:name="Syslog-Endpoints",type="string",JSONPath=".status.services.serviceSyslog.nodePorts",description="Syslog Endpoints"
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.actualImage",description="Actual Image"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Phase"
@@ -314,6 +315,10 @@ type LoadBalancerSourceSubnetSpec struct {
 	// STS is a list of subnets that will be allowed to access the Noobaa STS service
 	// +optional
 	STS []string `json:"sts,omitempty"`
+
+	// IAM is a list of subnets that will be allowed to access the Noobaa IAM service
+	// +optional
+	IAM []string `json:"iam,omitempty"`
 }
 
 // SecuritySpec is security spec to include various security items such as kms
@@ -559,6 +564,7 @@ type ServicesStatus struct {
 	ServiceS3   ServiceStatus `json:"serviceS3"`
 	// +optional
 	ServiceSts    ServiceStatus `json:"serviceSts,omitempty"`
+	ServiceIam    ServiceStatus `json:"serviceIam,omitempty"`
 	ServiceSyslog ServiceStatus `json:"serviceSyslog,omitempty"`
 }
 

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -741,6 +741,11 @@ func (in *LoadBalancerSourceSubnetSpec) DeepCopyInto(out *LoadBalancerSourceSubn
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IAM != nil {
+		in, out := &in.IAM, &out.IAM
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1568,6 +1573,7 @@ func (in *ServicesStatus) DeepCopyInto(out *ServicesStatus) {
 	in.ServiceMgmt.DeepCopyInto(&out.ServiceMgmt)
 	in.ServiceS3.DeepCopyInto(&out.ServiceS3)
 	in.ServiceSts.DeepCopyInto(&out.ServiceSts)
+	in.ServiceIam.DeepCopyInto(&out.ServiceIam)
 	in.ServiceSyslog.DeepCopyInto(&out.ServiceSyslog)
 	return
 }

--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -41,6 +41,7 @@ func (r *Reconciler) ReconcilePhaseConnecting() error {
 
 	r.CheckServiceStatus(r.ServiceS3, r.RouteS3, &r.NooBaa.Status.Services.ServiceS3, "s3-https")
 	r.CheckServiceStatus(r.ServiceSts, r.RouteSts, &r.NooBaa.Status.Services.ServiceSts, "sts-https")
+	r.CheckServiceStatus(r.ServiceIam, r.RouteIam, &r.NooBaa.Status.Services.ServiceIam, "iam-https")
 
 	return nil
 

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -80,6 +80,7 @@ type Reconciler struct {
 	ServiceMgmt               *corev1.Service
 	ServiceS3                 *corev1.Service
 	ServiceSts                *corev1.Service
+	ServiceIam                *corev1.Service
 	ServiceDb                 *corev1.Service
 	ServiceDbPg               *corev1.Service
 	ServiceSyslog             *corev1.Service
@@ -115,6 +116,7 @@ type Reconciler struct {
 	RouteMgmt                 *routev1.Route
 	RouteS3                   *routev1.Route
 	RouteSts                  *routev1.Route
+	RouteIam                  *routev1.Route
 	DeploymentEndpoint        *appsv1.Deployment
 	DefaultDeploymentEndpoint *corev1.PodSpec
 	JoinSecret                *corev1.Secret
@@ -160,6 +162,7 @@ func NewReconciler(
 		ServiceMgmt:               util.KubeObject(bundle.File_deploy_internal_service_mgmt_yaml).(*corev1.Service),
 		ServiceS3:                 util.KubeObject(bundle.File_deploy_internal_service_s3_yaml).(*corev1.Service),
 		ServiceSts:                util.KubeObject(bundle.File_deploy_internal_service_sts_yaml).(*corev1.Service),
+		ServiceIam:                util.KubeObject(bundle.File_deploy_internal_service_iam_yaml).(*corev1.Service),
 		ServiceSyslog:             util.KubeObject(bundle.File_deploy_internal_service_syslog_yaml).(*corev1.Service),
 		SecretServer:              util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretDB:                  util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
@@ -187,6 +190,7 @@ func NewReconciler(
 		RouteMgmt:                 util.KubeObject(bundle.File_deploy_internal_route_mgmt_yaml).(*routev1.Route),
 		RouteS3:                   util.KubeObject(bundle.File_deploy_internal_route_s3_yaml).(*routev1.Route),
 		RouteSts:                  util.KubeObject(bundle.File_deploy_internal_route_sts_yaml).(*routev1.Route),
+		RouteIam:                  util.KubeObject(bundle.File_deploy_internal_route_iam_yaml).(*routev1.Route),
 		DeploymentEndpoint:        util.KubeObject(bundle.File_deploy_internal_deployment_endpoint_yaml).(*appsv1.Deployment),
 		CaBundleConf:              util.KubeObject(bundle.File_deploy_internal_configmap_ca_inject_yaml).(*corev1.ConfigMap),
 		KedaTriggerAuthentication: util.KubeObject(bundle.File_deploy_internal_hpa_keda_trigger_authentication_yaml).(*kedav1alpha1.TriggerAuthentication),
@@ -209,6 +213,7 @@ func NewReconciler(
 	r.ServiceMgmt.Namespace = r.Request.Namespace
 	r.ServiceS3.Namespace = r.Request.Namespace
 	r.ServiceSts.Namespace = r.Request.Namespace
+	r.ServiceIam.Namespace = r.Request.Namespace
 	r.ServiceDb.Namespace = r.Request.Namespace
 	r.ServiceDbPg.Namespace = r.Request.Namespace
 	r.ServiceSyslog.Namespace = r.Request.Namespace
@@ -238,6 +243,7 @@ func NewReconciler(
 	r.RouteMgmt.Namespace = r.Request.Namespace
 	r.RouteS3.Namespace = r.Request.Namespace
 	r.RouteSts.Namespace = r.Request.Namespace
+	r.RouteIam.Namespace = r.Request.Namespace
 	r.DeploymentEndpoint.Namespace = r.Request.Namespace
 	r.CaBundleConf.Namespace = r.Request.Namespace
 	r.KedaTriggerAuthentication.Namespace = r.Request.Namespace
@@ -257,6 +263,7 @@ func NewReconciler(
 	r.ServiceSyslog.Name = "noobaa-syslog"
 	r.ServiceS3.Name = "s3"
 	r.ServiceSts.Name = "sts"
+	r.ServiceIam.Name = "iam"
 	r.ServiceDb.Name = r.Request.Name + "-db"
 	r.ServiceDbPg.Name = r.Request.Name + "-db-pg"
 	r.SecretServer.Name = r.Request.Name + "-server"
@@ -285,6 +292,7 @@ func NewReconciler(
 	r.RouteMgmt.Name = r.ServiceMgmt.Name
 	r.RouteS3.Name = r.ServiceS3.Name
 	r.RouteSts.Name = r.ServiceSts.Name
+	r.RouteIam.Name = r.ServiceIam.Name
 	r.DeploymentEndpoint.Name = r.Request.Name + "-endpoint"
 	r.CaBundleConf.Name = "ocp-injected-ca-bundle"
 	r.KedaScaled.Name = r.Request.Name
@@ -297,6 +305,7 @@ func NewReconciler(
 	r.RouteMgmt.Spec.To.Name = r.ServiceMgmt.Name
 	r.RouteS3.Spec.To.Name = r.ServiceS3.Name
 	r.RouteSts.Spec.To.Name = r.ServiceSts.Name
+	r.RouteIam.Spec.To.Name = r.ServiceIam.Name
 
 	// Since StorageClass is global we set the name and provisioner to have unique global name
 	r.OBCStorageClass.Name = options.SubDomainNS()
@@ -335,6 +344,7 @@ func (r *Reconciler) CheckAll() {
 	util.KubeCheck(r.ServiceMgmt)
 	util.KubeCheck(r.ServiceS3)
 	util.KubeCheck(r.ServiceSts)
+	util.KubeCheck(r.ServiceIam)
 	util.KubeCheck(r.ServiceSyslog)
 	if r.shouldReconcileStandaloneDB() {
 		util.KubeCheck(r.SecretDB)
@@ -366,6 +376,7 @@ func (r *Reconciler) CheckAll() {
 	util.KubeCheckOptional(r.RouteMgmt)
 	util.KubeCheckOptional(r.RouteS3)
 	util.KubeCheckOptional(r.RouteSts)
+	util.KubeCheckOptional(r.RouteIam)
 }
 
 // Reconcile reads that state of the cluster for a System object,

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -644,6 +644,7 @@ func RunList(cmd *cobra.Command, args []string) {
 		"NAME",
 		"S3-ENDPOINTS",
 		"STS-ENDPOINTS",
+		"IAM-ENDPOINTS",
 		"IMAGE",
 		"PHASE",
 		"AGE",
@@ -655,6 +656,7 @@ func RunList(cmd *cobra.Command, args []string) {
 			s.Name,
 			fmt.Sprint(s.Status.Services.ServiceS3.NodePorts),
 			fmt.Sprint(s.Status.Services.ServiceSts.NodePorts),
+			fmt.Sprint(s.Status.Services.ServiceIam.NodePorts),
 			s.Status.ActualImage,
 			string(s.Status.Phase),
 			util.HumanizeDuration(time.Since(s.CreationTimestamp.Time).Round(time.Second)),
@@ -828,6 +830,19 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	fmt.Println("InternalDNS :", r.NooBaa.Status.Services.ServiceS3.InternalDNS)
 	fmt.Println("InternalIP  :", r.NooBaa.Status.Services.ServiceS3.InternalIP)
 	fmt.Println("PodPorts    :", r.NooBaa.Status.Services.ServiceS3.PodPorts)
+
+	fmt.Println("")
+	fmt.Println("#-----------------#")
+	fmt.Println("#- IAM Addresses -#")
+	fmt.Println("#-----------------#")
+	fmt.Println("")
+
+	util.PrettyPrint("ExternalDNS", r.NooBaa.Status.Services.ServiceIam.ExternalDNS)
+	fmt.Println("ExternalIP  :", r.NooBaa.Status.Services.ServiceIam.ExternalIP)
+	fmt.Println("NodePorts   :", r.NooBaa.Status.Services.ServiceIam.NodePorts)
+	fmt.Println("InternalDNS :", r.NooBaa.Status.Services.ServiceIam.InternalDNS)
+	fmt.Println("InternalIP  :", r.NooBaa.Status.Services.ServiceIam.InternalIP)
+	fmt.Println("PodPorts    :", r.NooBaa.Status.Services.ServiceIam.PodPorts)
 
 	fmt.Println("")
 	fmt.Println("#------------------#")


### PR DESCRIPTION
### Explain the changes
1. IAM Service and Route Addition
Note: The port in the endpoint is 13443 (suffix of 443 and the 13 prefix was arbitrarily chosen).
Update: The core endpoint port update is in noobaa/noobaa-core#9262

### Issues: 
1. None

### Testing Instructions:
1. Use the cluster-bot, send 2 list-users requests using admin credentials and endpoint-url: (1) using the service address, (2) using the route address - expect both to work (More details can be found in [this comment](https://github.com/noobaa/noobaa-operator/pull/1721#issuecomment-3450260748)).

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IAM service endpoints added with full status reporting and display.
  * IAM-ENDPOINTS column in cluster listings showing IAM node ports.
  * Subnet access control for the IAM service (iam subnet list).
  * New IAM LoadBalancer Service and OpenShift Route with TLS re-encryption.
  * IAM service addresses now appear in cluster status (external/internal DNS & IP, nodePorts, podPorts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->