### PR TITLE
Added a CLI command to take a single DB backup

### DIFF
--- a/pkg/cnpg/cnpg.go
+++ b/pkg/cnpg/cnpg.go
@@ -620,6 +620,7 @@ func GetCnpgBackupObj(namespace string, name string) *cnpgv1.Backup {
 			Name:      name,
 			Namespace: namespace,
 		},
+		Spec: cnpgv1.BackupSpec{},
 	}
 	return cnpgBackup
 }


### PR DESCRIPTION
Depends on #1737 
### Explain the changes
1. Added a CLI command to take a single on-demand DB backup
2. Accepting `--name` flag to pass a custom name. The default name is `noobaa-db-pg-cluster-backup-[date and time]`. e.g.: `noobaa-db-pg-cluster-backup-20251201181523`

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/RHSTOR-8126

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI command to create CNPG backups as volume snapshots with progress and monitoring hints.

* **Improvements**
  * Recovery-aware bootstrap flow to initialize clusters from snapshots when recovery is configured.
  * Scheduled backups now target standby and existing backups are cleaned up to avoid snapshot conflicts.
  * Clearer lifecycle tracking and status transitions for creation vs. recovery.

* **Bug Fixes**
  * Backup objects now initialize their spec reliably so backups are created consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->