### PR TITLE
Changed DB PVC access mode to RWOP

### DIFF
--- a/deploy/internal/statefulset-postgres-db.yaml
+++ b/deploy/internal/statefulset-postgres-db.yaml
@@ -75,7 +75,7 @@ spec:
           app: noobaa
       spec:
         accessModes:
-          - ReadWriteOnce
+          - ReadWriteOncePod
         resources:
           requests:
             storage: 50Gi

--- a/deploy/olm/noobaa-operator.clusterserviceversion.yaml
+++ b/deploy/olm/noobaa-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   displayName: NooBaa Operator
   version: "999.999.999-placeholder"
-  minKubeVersion: 1.16.0
+  minKubeVersion: 1.22.0
   maturity: alpha
   provider:
     name: NooBaa

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5503,7 +5503,7 @@ spec:
                   resource: limits.memory
 `
 
-const Sha256_deploy_internal_statefulset_postgres_db_yaml = "cd739b491f35e77972c55078e6b1ea1362f3897194ed9c89fcf962a1ad6a4c3c"
+const Sha256_deploy_internal_statefulset_postgres_db_yaml = "53b628aaceffc1952efed5ed1131f16461fde6eb78c1a5f0f281f3efc30c30b4"
 
 const File_deploy_internal_statefulset_postgres_db_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5582,7 +5582,7 @@ spec:
           app: noobaa
       spec:
         accessModes:
-          - ReadWriteOnce
+          - ReadWriteOncePod
         resources:
           requests:
             storage: 50Gi
@@ -6272,7 +6272,7 @@ s3 ls s3://first.bucket
 ` + "`" + `` + "`" + `` + "`" + `
 `
 
-const Sha256_deploy_olm_noobaa_operator_clusterserviceversion_yaml = "3b11ab7cce6a4dfc36ad13f75b37821c8e200aec4cf21007208948e74ce9cc44"
+const Sha256_deploy_olm_noobaa_operator_clusterserviceversion_yaml = "4316a5d3ea52ed0e82489ad380b596f41e3675737b5d5ad80e403759f39fc128"
 
 const File_deploy_olm_noobaa_operator_clusterserviceversion_yaml = `apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
@@ -6293,7 +6293,7 @@ metadata:
 spec:
   displayName: NooBaa Operator
   version: "999.999.999-placeholder"
-  minKubeVersion: 1.16.0
+  minKubeVersion: 1.22.0
   maturity: alpha
   provider:
     name: NooBaa

--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -628,6 +628,10 @@ func setDesiredStorageConf(storageConfiguration *cnpgv1.StorageConfiguration, db
 	if storageConfiguration == nil {
 		return fmt.Errorf("storage configuration is nil")
 	}
+	if storageConfiguration.PersistentVolumeClaimTemplate == nil {
+		storageConfiguration.PersistentVolumeClaimTemplate = &corev1.PersistentVolumeClaimSpec{}
+	}
+	storageConfiguration.PersistentVolumeClaimTemplate.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod}
 	if dbSpec.DBStorageClass != nil {
 		storageConfiguration.StorageClass = dbSpec.DBStorageClass
 	} else {
@@ -726,6 +730,7 @@ func (r *Reconciler) wasClusterSpecChanged(existingClusterSpec *cnpgv1.ClusterSp
 		!reflect.DeepEqual(existingClusterSpec.Resources, r.CNPGCluster.Spec.Resources) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.StorageClass, r.CNPGCluster.Spec.StorageConfiguration.StorageClass) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.Size, r.CNPGCluster.Spec.StorageConfiguration.Size) ||
+		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.PersistentVolumeClaimTemplate, r.CNPGCluster.Spec.StorageConfiguration.PersistentVolumeClaimTemplate) ||
 		!reflect.DeepEqual(existingClusterSpec.Monitoring, r.CNPGCluster.Spec.Monitoring) ||
 		!reflect.DeepEqual(existingClusterSpec.PostgresConfiguration.Parameters, r.CNPGCluster.Spec.PostgresConfiguration.Parameters) ||
 		!reflect.DeepEqual(existingClusterSpec.Backup, r.CNPGCluster.Spec.Backup)


### PR DESCRIPTION
### Explain the changes
1. Changing the access mode of the DB cluster PVCs from `ReadWriteOnce` to `ReadWriteOncePod`. 
2. This change should better avoid the case of two containers mounting the same volume, even if deployed on the same node.
   1. This is a possible race condition when the DB pod is force-deleted with `--force --grace-period 0` 
3. This PR only changes the access mode for new deployments. Changing the access mode for existing deployments on upgrade is not supported. 

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-4757

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * PostgreSQL storage access mode changed to pod-level volume access (ReadWriteOncePod).
  * A default persistent volume claim template is now applied when storage is configured.
  * Changes to the storage claim template are now detected and will trigger cluster updates.
  * Minimum supported Kubernetes version raised to 1.22.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->