### PR TITLE
OBC on Hosted Cluster | Exclude OBCs That Were Created for Client Clusters from CLI

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1592,6 +1592,18 @@ func IsRemoteClientNoobaa(annotations map[string]string) bool {
 	return annotationBoolVal
 }
 
+// IsRemoteObcAnnotation checks for the existance and value of the remote-obc-creation annotation
+// within an annotation map, if the annotation doesnt exist it's the same as if its value is false.
+// this annotation is added to OBC that were created for client clusters when using the setup of provider-client
+func IsRemoteObcAnnotation(annotations map[string]string) bool {
+	annotationValue, exists := GetAnnotationValue(annotations, "remote-obc-creation")
+	annotationBoolVal := false
+	if exists {
+		annotationBoolVal = strings.ToLower(annotationValue) == trueStr
+	}
+	return annotationBoolVal
+}
+
 // ReflectEnvVariable will add, update or remove an env variable base on the existence and value of an
 // env variable with the same name on the container running this function.
 func ReflectEnvVariable(env *[]corev1.EnvVar, name string) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -24,3 +24,46 @@ func TestMapAlternateKeysValue(t *testing.T) {
 		t.Fatalf("Canonical key: expected %q, got %q", keyVal, actualCanonicalValue)
 	}
 }
+
+func TestIsRemoteObcAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name:        "missing annotation",
+			annotations: map[string]string{"other": "true"},
+			expected:    false,
+		},
+		{
+			name:        "explicit false",
+			annotations: map[string]string{"remote-obc-creation": "false"},
+			expected:    false,
+		},
+		{
+			name:        "explicit true",
+			annotations: map[string]string{"remote-obc-creation": "true"},
+			expected:    true,
+		},
+		{
+			name:        "mixed case true",
+			annotations: map[string]string{"remote-obc-creation": "TrUe"},
+			expected:    true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := IsRemoteObcAnnotation(testCase.annotations)
+			if actual != testCase.expected {
+				t.Fatalf("expected %v, got %v", testCase.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Explain the changes
1. Added a helper function `IsRemoteObcAnnotation` to check if OBC has the annotation that indicates it is an OBC that was created for client clusters.
2. In the CLI of OBC, exclude running the operation on the OBC, except for `obc regenerate`, for which we added a flag in case must run the operation on it (also added in `oc status` since it is used by the regenerate function).
3. Added a generated test on the new function `IsRemoteObcAnnotation`.

### Issues: 
1. Part of [RHSTOR-6230](https://issues.redhat.com/browse/RHSTOR-6230)

### Testing Instructions:
#### Unit Test
Please run: `go test ./pkg/util`

#### Manual Tests
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
I installed the system on `test1` namespace.
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
4. Build the CLI with `make cli DOCKER_DEFAULT_PLATFORM=linux/arm64 GOARCH=arm64`
5. Create OBC: `nb obc create shira-obc1 -n test1 --show-secrets`
6. Add annotation to indicate that the OBC is used by client clusters: `kubectl annotate obc shira-obc1 -n test1 remote-obc-creation=true`
7. Run the OBC operations and expect it to fails: `nb obc delete shira-obc1 -n test1`, `nb obc status shira-obc1 -n test1`, `nb obc regenerate shira-obc1 -n test1`, the list should show as empty `nb obc list -n test1`
8. To regenerate the remote OBC need to run with a flag: `nb obc regenerate shira-obc1 -n test1 --remote-obc`

[link](https://github.com/noobaa/noobaa-operator/pull/1786#issuecomment-3799105502) to the output of the CLI with the changes.

#### Lint Comment
Note: to run the `make lint` locally had to switch go version, so it can be run with: `gvm use go1.24.4 && make lint`, I had this error:
```bash
compile: version "go1.24.7" does not match go tool version "go1.24.4"
⚠️ Failed to install golangci-lint
```

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --remote-obc flag to enable operations against remote OBCs.

* **Behavior Changes**
  * Regenerate, Delete, and Status now block or require --remote-obc for remote OBCs.
  * Remote OBCs are excluded from default listings; if all OBCs are remote, a "No OBCs found" message is shown.

* **Tests**
  * Added unit tests for remote OBC annotation detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->