### PR TITLE
Add `ObjectBucketClaimStatus` and the different statuses in `obc_types.go`

### DIFF
--- a/pkg/apis/noobaa/v1alpha1/obc_types.go
+++ b/pkg/apis/noobaa/v1alpha1/obc_types.go
@@ -37,3 +37,13 @@ type ObjectBucketAuthentication = obv1.Authentication
 
 // ObjectBucketAccessKeys is the access keys inside ObjectBucketAuthentication
 type ObjectBucketAccessKeys = obv1.AccessKeys
+
+// ObjectBucketClaimStatus is the observed state of ObjectBucketClaim
+type ObjectBucketClaimStatus = obv1.ObjectBucketClaimStatus
+
+const (
+	ObjectBucketClaimStatusPhasePending  = obv1.ObjectBucketClaimStatusPhasePending
+	ObjectBucketClaimStatusPhaseBound    = obv1.ObjectBucketClaimStatusPhaseBound
+	ObjectBucketClaimStatusPhaseReleased = obv1.ObjectBucketClaimStatusPhaseReleased
+	ObjectBucketClaimStatusPhaseFailed   = obv1.ObjectBucketClaimStatusPhaseFailed
+)


### PR DESCRIPTION
### Explain the changes
1. Adding an alias of `ObjectBucketClaimStatus` so we can use it in case only noobaa is imported (`github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1`) without lib-bucket-provisioner.
It might be used as part of red-hat-storage/ocs-operator#3692 (see comment - [link](https://github.com/red-hat-storage/ocs-operator/pull/3692#discussion_r2872492171)).
2. Adding the different statuses
It might be used as part of red-hat-storage/ocs-client-operator#520 

### Issues: Fixed #xxx / Gap #xxx
1. none 

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced support for object bucket claim status management with distinct lifecycle phases: Pending, Bound, Released, and Failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->