### PR TITLE
OBC on Hosted Cluster | OBC list by default would include remobe obc

### DIFF
--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -117,6 +117,8 @@ func CmdList() *cobra.Command {
 		Run:   RunList,
 		Args:  cobra.NoArgs,
 	}
+	cmd.Flags().Bool("local-obc-only", false,
+		"List only local OBCs (exclude remote OBCs created for client clusters)")
 	return cmd
 }
 
@@ -497,6 +499,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 
 // RunList runs a CLI command
 func RunList(cmd *cobra.Command, args []string) {
+	localObcOnly, _ := cmd.Flags().GetBool("local-obc-only")
 	list := &nbv1.ObjectBucketClaimList{
 		TypeMeta: metav1.TypeMeta{Kind: "ObjectBucketClaim"},
 	}
@@ -521,7 +524,7 @@ func RunList(cmd *cobra.Command, args []string) {
 		obc := &list.Items[i]
 
 		// Do not show remote OBCs in the list (OBCs that were created for client clusters)
-		if util.IsRemoteObcAnnotation(obc.Annotations) {
+		if localObcOnly && util.IsRemoteObcAnnotation(obc.Annotations) {
 			countRemoteOBCs++
 			continue
 		}


### PR DESCRIPTION
### Explain the changes
1. Continue of #1786 by changing the default so the remote OBC will be listed, since in `noobaa status` it uses `obc list` without any arguments, and in the web console it also shows all the OBC in the provider setup. If someone wanted to filter out the remote OBC added a flag for this.

### Issues: Fixed #xxx / Gap #xxx
1. Part of [RHSTOR-6230](https://issues.redhat.com/browse/RHSTOR-6230)

### Testing Instructions:
#### Manual Test
Run the following CLI commands:
- `noobaa obc list -n <namespace>` (should list the remote OBC)
- `nooba obc list -n <namespace> --local-obc-only` (should not list the remote OBC)
- `noobaa status` (look at the part of `Bucket Claims` (should list the remote OBC)

Option 1 - local Cluster
1. Run a local test as described in #1786 and run the above commands.

Option 2 - Provider-Client clusters setup
1. In case there is already a setup with provider-client clusters setup, create an OBC on the client setup and run the above commands.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--local-obc-only` flag to the `obc list` command to show only local OBCs.

* **Behavior Change**
  * `obc list` now shows remote OBCs by default; remote items are excluded only when `--local-obc-only` is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->