### PR TITLE
Add pqc readiness scanner, make target, CI workflow and doc

### DIFF
--- a/.github/workflows/run_tls_pqc_test.yml
+++ b/.github/workflows/run_tls_pqc_test.yml
@@ -1,0 +1,68 @@
+name: Run TLS PQC Test
+
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-tls-pqc-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+
+      - name: Set environment variables
+        run: |
+          echo "PATH=$PATH:$HOME/go/bin" >> $GITHUB_ENV
+          echo "OPERATOR_IMAGE=noobaa/noobaa-operator:integration" >> $GITHUB_ENV
+          echo "NAMESPACE=test" >> $GITHUB_ENV
+
+      - name: Setup Minikube
+        uses: medyagh/setup-minikube@v0.0.19
+        with:
+          driver: docker
+          kubernetes-version: v1.33.0
+
+      - name: Verify Minikube is running
+        run: minikube status
+
+      - name: Install Tools
+        run: |
+          bash ./.travis/install-tools.sh
+          bash ./.travis/install-python.sh
+
+      - name: Build operator image
+        run: |
+          set -x
+          make cli
+          make image
+          docker tag noobaa/noobaa-operator:$(go run cmd/version/main.go) $OPERATOR_IMAGE
+          minikube image load $OPERATOR_IMAGE
+
+      - name: Install NooBaa
+        run: |
+          build/_output/bin/noobaa-operator-local install --mini --namespace $NAMESPACE --operator-image $OPERATOR_IMAGE --use-standalone-db
+          build/_output/bin/noobaa-operator-local status --namespace $NAMESPACE
+
+      - name: Run TLS PQC scan
+        run: make test-tls-pqc-readiness
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: noobaa-tls-pqc-scan-report
+          path: noobaa_pqc_readiness_report.json

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,11 @@ test-upgrade: gen cli
 	@echo "✅ test-upgrade"
 .PHONY: test-upgrade
 
+test-tls-pqc-readiness:
+	$(TIME) bash test/tls_pqc_readiness_check.sh
+	@echo "✅ test-tls-pqc-readiness"
+.PHONY: test-tls-pqc-readiness
+
 # find or download controller-gen if necessary
 controller-gen:
 ifneq ($(CONTROLLER_GEN_VERSION), $(shell controller-gen --version | awk -F ":" '{print $2}'))

--- a/doc/tls-pqc-readiness-check.md
+++ b/doc/tls-pqc-readiness-check.md
@@ -1,0 +1,185 @@
+[NooBaa Operator](../README.md) /
+# TLS PQC Readiness Check
+
+## Overview
+
+The TLS PQC readiness check verifies that NooBaa services support **TLS 1.3** and **post-quantum cryptography (PQC) hybrid key exchange** (X25519MLKEM768).
+
+It dynamically discovers all NooBaa services (label `app=noobaa`) and their ports. A port is classified as HTTPS (and scanned with testssl.sh) when its name contains "https", "ssl", "tls", or "secure", when its port number is 443, or when its `appProtocol` is set to "https". All other ports are reported as plaintext HTTP.
+
+The following services and ports are typically discovered:
+
+| Service | Port | Name | Protocol |
+|---------|------|------|----------|
+| noobaa-mgmt | 443 | mgmt-https | HTTPS (scanned) |
+| noobaa-mgmt | 8445 | bg-https | HTTPS (scanned) |
+| noobaa-mgmt | 8446 | hosted-agents-https | HTTPS (scanned) |
+| s3 | 443 | s3-https | HTTPS (scanned) |
+| s3 | 8444 | md-https | HTTPS (scanned) |
+| s3 | 9443 | metrics-https | HTTPS (scanned) |
+| sts | 443 | sts-https | HTTPS (scanned) |
+| iam | 443 | iam-https | HTTPS (scanned) |
+| noobaa-db-pg-cluster-r | 5432 | postgresql | HTTP (reported only) |
+| noobaa-db-pg-cluster-ro | 5432 | postgresql | HTTP (reported only) |
+| noobaa-db-pg-cluster-rw | 5432 | postgresql | HTTP (reported only) |
+| noobaa-mgmt | 80 | mgmt | HTTP (reported only) |
+| s3 | 80 | s3 | HTTP (reported only) |
+| noobaa-syslog | 514 | syslog | HTTP (reported only) |
+
+For each HTTPS endpoint, a [testssl.sh](https://github.com/testssl/testssl.sh) pod is launched inside the cluster to probe the port. The results are collected as JSON, merged into a single report, and a readiness summary is appended.
+
+## testssl.sh Command
+
+The scanner pod runs the following testssl.sh command against each HTTPS endpoint:
+
+```bash
+testssl.sh --forward-secrecy --protocols --server-preference --client-simulation --quiet --wide --jsonfile /tmp/res.json https://<service>.<namespace>.svc.cluster.local:<port>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--protocols` | Tests which TLS/SSL protocols are supported (SSLv2, SSLv3, TLS 1.0–1.3) |
+| `--forward-secrecy` | Checks forward secrecy support and lists key exchange curves, including PQC hybrid groups like X25519MLKEM768 |
+| `--server-preference` | Checks whether the server enforces its own cipher order preference |
+| `--client-simulation` | Simulates connections from common TLS clients to show which protocol and cipher each would negotiate |
+| `--quiet` | Suppresses banner and other non-essential output |
+| `--wide` | Uses wider output format for more detailed cipher and protocol information |
+| `--jsonfile /tmp/res.json` | Writes structured results in JSON format for programmatic analysis |
+
+## Prerequisites
+
+- `kubectl` (or `oc`) with access to the target cluster
+- `jq` installed locally
+- NooBaa deployed in the target namespace
+
+## Running the Check
+
+### Via Make
+
+```bash
+make test-tls-pqc-readiness
+```
+
+### Directly
+
+```bash
+bash test/tls_pqc_readiness_check.sh
+```
+
+### With Custom Namespace
+
+```bash
+NAMESPACE=openshift-storage bash test/tls_pqc_readiness_check.sh
+```
+
+### On OpenShift (using oc)
+
+```bash
+KUBECTL=oc NAMESPACE=openshift-storage bash test/tls_pqc_readiness_check.sh
+```
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NAMESPACE` | `test` | Kubernetes namespace where NooBaa is deployed |
+| `SCAN_TIMEOUT` | `600` | Maximum seconds to wait for each scan pod to complete |
+| `KUBECTL` | `kubectl` | Command to interact with the cluster (`kubectl` or `oc`) |
+
+## Output
+
+### Console
+
+A summary table is printed to stdout:
+
+```
+================================================================
+                 NooBaa TLS Security Summary
+================================================================
+ENDPOINT                         TLS 1.3      HYBRID KEY EXCHANGE
+----------------------------------------------------------------
+noobaa-mgmt:443                  YES          YES
+noobaa-mgmt:8445                 YES          YES
+noobaa-mgmt:8446                 YES          YES
+s3:443                           YES          YES
+s3:8444                          YES          YES
+s3:9443                          YES          YES
+sts:443                          YES          YES
+iam:443                          YES          YES
+noobaa-db-pg-cluster-r:5432      HTTP         N/A (plaintext)
+noobaa-db-pg-cluster-ro:5432     HTTP         N/A (plaintext)
+noobaa-db-pg-cluster-rw:5432     HTTP         N/A (plaintext)
+noobaa-mgmt:80                   HTTP         N/A (plaintext)
+s3:80                            HTTP         N/A (plaintext)
+noobaa-syslog:514                HTTP         N/A (plaintext)
+================================================================
+Full results saved to noobaa_pqc_readiness_report.json
+
+RESULT: PASS - All endpoints support TLS 1.3 and hybrid (PQC) key exchange
+```
+
+### JSON Report
+
+The file `noobaa_pqc_readiness_report.json` is written to the current working directory. It contains:
+
+1. **Raw testssl results** — the full protocol and forward-secrecy scan output for each service
+2. **Readiness summary** — appended as the last entry:
+
+```json
+{
+  "id": "pqc_readiness_summary",
+  "result": "PASS",
+  "endpoints": [
+    { "service": "noobaa-mgmt", "port": 443, "tls_1_3": "YES", "hybrid_key_exchange": "YES" },
+    { "service": "noobaa-mgmt", "port": 8445, "tls_1_3": "YES", "hybrid_key_exchange": "YES" },
+    { "service": "noobaa-mgmt", "port": 8446, "tls_1_3": "YES", "hybrid_key_exchange": "YES" },
+    { "service": "s3", "port": 443, "tls_1_3": "YES", "hybrid_key_exchange": "YES" },
+    { "service": "s3", "port": 8444, "tls_1_3": "YES", "hybrid_key_exchange": "YES" },
+    { "service": "s3", "port": 9443, "tls_1_3": "YES", "hybrid_key_exchange": "YES" },
+    { "service": "sts", "port": 443, "tls_1_3": "YES", "hybrid_key_exchange": "YES" },
+    { "service": "iam", "port": 443, "tls_1_3": "YES", "hybrid_key_exchange": "YES" },
+    { "service": "noobaa-db-pg-cluster-r", "port": 5432, "tls_1_3": "HTTP", "hybrid_key_exchange": "N/A" },
+    { "service": "noobaa-db-pg-cluster-ro", "port": 5432, "tls_1_3": "HTTP", "hybrid_key_exchange": "N/A" },
+    { "service": "noobaa-db-pg-cluster-rw", "port": 5432, "tls_1_3": "HTTP", "hybrid_key_exchange": "N/A" },
+    { "service": "noobaa-mgmt", "port": 80, "tls_1_3": "HTTP", "hybrid_key_exchange": "N/A" },
+    { "service": "s3", "port": 80, "tls_1_3": "HTTP", "hybrid_key_exchange": "N/A" },
+    { "service": "noobaa-syslog", "port": 514, "tls_1_3": "HTTP", "hybrid_key_exchange": "N/A" }
+  ]
+}
+```
+
+### Field Descriptions
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| `tls_1_3` | `YES` | The endpoint advertises TLS 1.3 as a supported protocol. This is required for PQC key exchange. |
+| `tls_1_3` | `NO` | The endpoint does not support TLS 1.3. PQC key exchange will not be available. |
+| `tls_1_3` | `HTTP` | The port is plaintext HTTP — TLS is not applicable. |
+| `hybrid_key_exchange` | `YES` | The endpoint supports hybrid post-quantum key exchange (X25519MLKEM768), combining classical X25519 ECDH with ML-KEM-768 post-quantum KEM. Connections to this endpoint are protected against both classical and future quantum attacks. |
+| `hybrid_key_exchange` | `NO` | The endpoint does not offer any PQC hybrid key exchange group. Connections use classical-only key exchange. |
+| `hybrid_key_exchange` | `N/A` | The port is plaintext HTTP — key exchange is not applicable. |
+| `result` | `PASS` | All HTTPS endpoints support both TLS 1.3 and hybrid PQC key exchange. |
+| `result` | `FAIL` | One or more HTTPS endpoints are missing TLS 1.3 or hybrid PQC key exchange support. |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All endpoints support TLS 1.3 and hybrid key exchange |
+| `1` | One or more endpoints failed the check |
+
+## CI Integration
+
+The check runs automatically via the **Run TLS PQC Test** GitHub Actions workflow (`.github/workflows/run_tls_pqc_test.yml`). The workflow:
+
+1. Sets up a Minikube cluster
+2. Builds and installs the NooBaa operator
+3. Installs NooBaa into the `test` namespace
+4. Runs `make test-tls-pqc-readiness`
+5. Uploads `noobaa_pqc_readiness_report.json` as a workflow artifact
+
+## Background
+
+Post-quantum cryptography protects TLS connections against future quantum computer attacks. The hybrid key exchange X25519MLKEM768 combines the classical X25519 ECDH with the ML-KEM-768 post-quantum KEM, providing security against both classical and quantum adversaries. TLS 1.3 is required for PQC key exchange support.

--- a/test/tls_pqc_readiness_check.sh
+++ b/test/tls_pqc_readiness_check.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+#
+# TLS PQC Readiness Check
+#
+# Dynamically discovers all NooBaa services (label app=noobaa) and their
+# ports, then scans every HTTPS port for TLS 1.3 support and post-quantum
+# cryptography (PQC) hybrid key exchange (X25519MLKEM768). HTTP ports are
+# reported as plaintext but not scanned.
+#
+# Ports are classified as HTTPS when the port name contains "https", "ssl",
+# "tls", or "secure", OR the port number is 443, OR the appProtocol is
+# "https". All other ports are reported as HTTP/plaintext.
+#
+# All HTTPS endpoints are scanned concurrently: testssl.sh pods are launched
+# in-cluster for every port at once, then the script waits for all pods to
+# finish before collecting results. Results are merged into a single JSON
+# report file with a per-endpoint pass/fail summary.
+#
+# Prerequisites:
+#   - kubectl (or oc) access to the target cluster
+#   - jq installed locally
+#   - The target namespace must have NooBaa deployed
+#
+# Environment variables:
+#   NAMESPACE     - Kubernetes namespace where NooBaa is deployed (default: test)
+#   SCAN_TIMEOUT  - Max seconds to wait for each scan pod (default: 600)
+#   KUBECTL       - kubectl or oc command to use (default: kubectl)
+#
+# Usage:
+#   bash test/tls_pqc_readiness_check.sh
+#   NAMESPACE=openshift-storage bash test/tls_pqc_readiness_check.sh
+#   KUBECTL=oc NAMESPACE=openshift-storage bash test/tls_pqc_readiness_check.sh
+#   make test-tls-pqc-readiness
+#
+# Output:
+#   noobaa_pqc_readiness_report.json  - Full testssl results + pqc_readiness_summary
+#   stdout                       - Per-endpoint summary table
+#
+# Exit codes:
+#   0 - All endpoints support TLS 1.3 and hybrid key exchange
+#   1 - One or more endpoints failed the check
+#
+
+NAMESPACE="${NAMESPACE:-test}"
+OUTPUT_FILE="noobaa_pqc_readiness_report.json"
+SCAN_TIMEOUT="${SCAN_TIMEOUT:-600}"
+KUBECTL="${KUBECTL:-kubectl}"
+
+echo "[]" > "$OUTPUT_FILE"
+
+# Discover all ports from NooBaa services dynamically
+# Output format per line: service:port:portname:appprotocol
+# we may need to extend this check if there are cases of non-standard HTTPS ports without indicative names or appProtocol,
+# but this should cover most common scenarios and expecially user facing services.
+echo "Discovering NooBaa service ports in namespace $NAMESPACE..."
+ALL_PORTS=$($KUBECTL get svc -n "$NAMESPACE" -l app=noobaa -o json | \
+  jq -r '.items[] | .metadata.name as $svc | .spec.ports[] | "\($svc):\(.port):\(.name // ""):\(.appProtocol // "")"')
+
+if [ -z "$ALL_PORTS" ]; then
+  echo "ERROR: No NooBaa services found in namespace $NAMESPACE (label app=noobaa)" >&2
+  exit 1
+fi
+
+ENDPOINTS=""
+HTTP_ENDPOINTS=""
+for ENTRY in $ALL_PORTS; do
+  SVC=$(echo "$ENTRY" | cut -d: -f1)
+  PORT=$(echo "$ENTRY" | cut -d: -f2)
+  PORT_NAME=$(echo "$ENTRY" | cut -d: -f3)
+  APP_PROTO=$(echo "$ENTRY" | cut -d: -f4)
+  if echo "$PORT_NAME" | grep -qiE "https|ssl|tls|secure"; then
+    ENDPOINTS="$ENDPOINTS $SVC:$PORT"
+  elif [ "$PORT" = "443" ]; then
+    ENDPOINTS="$ENDPOINTS $SVC:$PORT"
+  elif echo "$APP_PROTO" | grep -qi "https"; then
+    ENDPOINTS="$ENDPOINTS $SVC:$PORT"
+  else
+    HTTP_ENDPOINTS="$HTTP_ENDPOINTS $SVC:$PORT"
+  fi
+done
+
+echo "  HTTPS endpoints:$ENDPOINTS"
+echo "  HTTP endpoints:$HTTP_ENDPOINTS"
+echo ""
+
+SUMMARY=""
+SUMMARY_JSON=""
+ALL_PASS=true
+
+# --- Phase 1: Launch all scanner pods concurrently ---
+echo "Launching scanner pods for all HTTPS endpoints..."
+for ENDPOINT in $ENDPOINTS; do
+  SVC="${ENDPOINT%%:*}"
+  PORT="${ENDPOINT##*:}"
+  POD_NAME="testssl-scanner-${SVC}-${PORT}"
+
+  $KUBECTL delete pod "$POD_NAME" -n "$NAMESPACE" --ignore-not-found 2>/dev/null
+
+  $KUBECTL run "$POD_NAME" -n "$NAMESPACE" --restart=Never \
+    --labels="app=noobaa" \
+    --image=ghcr.io/testssl/testssl.sh \
+    --command -- sh -c \
+    "testssl.sh --forward-secrecy --protocols --server-preference --client-simulation --quiet --wide --jsonfile /tmp/res.json --quiet https://${SVC}.${NAMESPACE}.svc.cluster.local:${PORT} > /dev/null 2>&1; cat /tmp/res.json 2>/dev/null || echo '[]'"
+
+  echo "  Started pod $POD_NAME for $SVC:$PORT"
+done
+
+# --- Phase 2: Wait for all scanner pods to complete ---
+echo ""
+echo "Waiting for all scanner pods to finish (timeout: ${SCAN_TIMEOUT}s)..."
+ELAPSED=0
+while [ $ELAPSED -lt $SCAN_TIMEOUT ]; do
+  ALL_DONE=true
+  for ENDPOINT in $ENDPOINTS; do
+    SVC="${ENDPOINT%%:*}"
+    PORT="${ENDPOINT##*:}"
+    POD_NAME="testssl-scanner-${SVC}-${PORT}"
+    PHASE=$($KUBECTL get pod "$POD_NAME" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
+    case "$PHASE" in
+      Succeeded|Failed) ;;
+      *) ALL_DONE=false ;;
+    esac
+  done
+  if [ "$ALL_DONE" = true ]; then
+    echo "  All pods completed after ${ELAPSED}s"
+    break
+  fi
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+
+  STILL_RUNNING=""
+  for ENDPOINT in $ENDPOINTS; do
+    SVC="${ENDPOINT%%:*}"
+    PORT="${ENDPOINT##*:}"
+    POD_NAME="testssl-scanner-${SVC}-${PORT}"
+    PHASE=$($KUBECTL get pod "$POD_NAME" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
+    case "$PHASE" in
+      Succeeded|Failed) ;;
+      *) STILL_RUNNING="$STILL_RUNNING $SVC:$PORT" ;;
+    esac
+  done
+  echo "  ${ELAPSED}s elapsed - still running:${STILL_RUNNING}"
+done
+
+# --- Phase 3: Collect results from all pods ---
+echo ""
+echo "Collecting results..."
+for ENDPOINT in $ENDPOINTS; do
+  SVC="${ENDPOINT%%:*}"
+  PORT="${ENDPOINT##*:}"
+  POD_NAME="testssl-scanner-${SVC}-${PORT}"
+
+  EP_TLS13="NO_DATA"
+  EP_HYBRID="NO_DATA"
+
+  PHASE=$($KUBECTL get pod "$POD_NAME" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
+
+  if [ "$PHASE" = "Succeeded" ] || [ "$PHASE" = "Failed" ]; then
+    RAW_OUTPUT=$($KUBECTL logs "$POD_NAME" -n "$NAMESPACE" 2>/dev/null)
+    echo "$RAW_OUTPUT" | sed -n '/^\[/,/^\]/p' > "temp_${SVC}_${PORT}.json"
+
+    if [ -s "temp_${SVC}_${PORT}.json" ] && jq empty "temp_${SVC}_${PORT}.json" 2>/dev/null; then
+      echo "  Got results for $SVC:$PORT"
+      jq -s 'add' "$OUTPUT_FILE" "temp_${SVC}_${PORT}.json" > "${OUTPUT_FILE}.tmp" && mv "${OUTPUT_FILE}.tmp" "$OUTPUT_FILE"
+
+      if jq -e '[.[] | select(.id | test("tls1_3"; "i")) | select(.finding | test("offered"))] | length > 0' "temp_${SVC}_${PORT}.json" > /dev/null 2>&1; then
+        EP_TLS13="YES"
+      else
+        EP_TLS13="NO"
+      fi
+
+      if jq -e '[.[] | select(.finding | test("X25519MLKEM|MLKEM"; "i"))] | length > 0' "temp_${SVC}_${PORT}.json" > /dev/null 2>&1; then
+        EP_HYBRID="YES"
+      else
+        EP_HYBRID="NO"
+      fi
+    else
+      echo "  WARNING: No valid JSON results for $SVC:$PORT (pod phase: $PHASE)"
+      if [ "$PHASE" = "Failed" ]; then
+        echo "  Pod logs:"
+        echo "$RAW_OUTPUT" | head -20
+      fi
+    fi
+    rm -f "temp_${SVC}_${PORT}.json"
+  else
+    echo "  ERROR: Scan timed out for $SVC:$PORT after ${SCAN_TIMEOUT}s"
+  fi
+
+  SUMMARY="${SUMMARY}$(printf '%-32s %-12s %-20s\n' "$SVC:$PORT" "$EP_TLS13" "$EP_HYBRID")\n"
+  SUMMARY_JSON="${SUMMARY_JSON:+$SUMMARY_JSON,}{\"service\":\"$SVC\",\"port\":$PORT,\"tls_1_3\":\"$EP_TLS13\",\"hybrid_key_exchange\":\"$EP_HYBRID\"}"
+  if [ "$EP_TLS13" != "YES" ] || [ "$EP_HYBRID" != "YES" ]; then
+    ALL_PASS=false
+  fi
+
+  $KUBECTL delete pod "$POD_NAME" -n "$NAMESPACE" --ignore-not-found 2>/dev/null
+done
+
+# Add HTTP endpoints to the summary (not scanned)
+for ENDPOINT in $HTTP_ENDPOINTS; do
+  SVC="${ENDPOINT%%:*}"
+  PORT="${ENDPOINT##*:}"
+  SUMMARY="${SUMMARY}$(printf '%-32s %-12s %-20s\n' "$SVC:$PORT" "HTTP" "N/A (plaintext)")\n"
+  SUMMARY_JSON="${SUMMARY_JSON:+$SUMMARY_JSON,}{\"service\":\"$SVC\",\"port\":$PORT,\"tls_1_3\":\"HTTP\",\"hybrid_key_exchange\":\"N/A\"}"
+done
+
+echo ""
+echo "================================================================"
+echo "                 NooBaa TLS Security Summary"
+echo "================================================================"
+printf "%-32s %-12s %-20s\n" "ENDPOINT" "TLS 1.3" "HYBRID KEY EXCHANGE"
+echo "----------------------------------------------------------------"
+echo -e "$SUMMARY"
+echo "================================================================"
+RESULT_TEXT="PASS"
+if [ "$ALL_PASS" != true ]; then
+  RESULT_TEXT="FAIL"
+fi
+
+jq --argjson summary "[${SUMMARY_JSON}]" --arg result "$RESULT_TEXT" \
+  '. + [{"id":"pqc_readiness_summary","result":$result,"endpoints":$summary}]' \
+  "$OUTPUT_FILE" > "${OUTPUT_FILE}.tmp" && mv "${OUTPUT_FILE}.tmp" "$OUTPUT_FILE"
+
+echo "Full results saved to $OUTPUT_FILE"
+echo ""
+if [ "$ALL_PASS" = true ]; then
+  echo "RESULT: PASS - All endpoints support TLS 1.3 and hybrid (PQC) key exchange"
+  exit 0
+else
+  echo "RESULT: FAIL - One or more endpoints missing TLS 1.3 or hybrid key exchange" >&2
+  exit 1
+fi


### PR DESCRIPTION
### Explain the changes
1. Add a pqc scanner for NooBaa services.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added TLS PQC (Post-Quantum Cryptography) readiness checks to automatically scan NooBaa services for TLS 1.3 and hybrid PQC key exchange support (`X25519MLKEM768`).
  * New CI workflow that runs automated scans and generates detailed readiness reports.

* **Documentation**
  * Added comprehensive guide documenting how to run TLS PQC readiness checks, including configuration options, expected outputs, and pass/fail criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->