### PR TITLE
Default to loading the endpoints system store from the core instead of the DB

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -46,7 +46,7 @@ spec:
             secretName: noobaa-vectors-serving-cert
             optional: true
         # This service account token can be used to provide identity outside the cluster.
-        # For example, this token can be used with AWS(AssumeRoleWithWebIdentity)/Azure(WorkloadIdentityCredential) 
+        # For example, this token can be used with AWS(AssumeRoleWithWebIdentity)/Azure(WorkloadIdentityCredential)
         # to authenticate with AWS/Azure using IAM OIDC provider and STS.
         - name: bound-sa-token
           projected:
@@ -123,6 +123,11 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_VERSION_AUTH_ENABLED
+            - name: SYSTEM_STORE_SOURCE
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: ENDPOINT_SYSTEM_STORE_SOURCE
             - name: MGMT_ADDR
             - name: SYSLOG_ADDR
             - name: BG_ADDR

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4322,7 +4322,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "0b27c64555dcf8b21934c3b58419ca0d40a69868fe0764028edf07f0217195e0"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "558ec22578b22c3ac3a6d6b72fa95a7122739014ded0a73adbac319aa4457aed"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4372,7 +4372,7 @@ spec:
             secretName: noobaa-vectors-serving-cert
             optional: true
         # This service account token can be used to provide identity outside the cluster.
-        # For example, this token can be used with AWS(AssumeRoleWithWebIdentity)/Azure(WorkloadIdentityCredential) 
+        # For example, this token can be used with AWS(AssumeRoleWithWebIdentity)/Azure(WorkloadIdentityCredential)
         # to authenticate with AWS/Azure using IAM OIDC provider and STS.
         - name: bound-sa-token
           projected:
@@ -4449,6 +4449,11 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_VERSION_AUTH_ENABLED
+            - name: SYSTEM_STORE_SOURCE
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: ENDPOINT_SYSTEM_STORE_SOURCE
             - name: MGMT_ADDR
             - name: SYSLOG_ADDR
             - name: BG_ADDR

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -1609,12 +1609,13 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 	// When adding a new env var, make sure to add it to the sts/deployment as well
 	// see "NOOBAA_DISABLE_COMPRESSION" as an example
 	DefaultConfigMapData := map[string]string{
-		"NOOBAA_DISABLE_COMPRESSION":  "false",
-		"DISABLE_DEV_RANDOM_SEED":     "true",
-		"NOOBAA_LOG_LEVEL":            "default_level",
-		"NOOBAA_LOG_COLOR":            "true",
-		"NOOBAA_METRICS_AUTH_ENABLED": "true",
-		"NOOBAA_VERSION_AUTH_ENABLED": "true",
+		"NOOBAA_DISABLE_COMPRESSION":   "false",
+		"DISABLE_DEV_RANDOM_SEED":      "true",
+		"NOOBAA_LOG_LEVEL":             "default_level",
+		"NOOBAA_LOG_COLOR":             "true",
+		"NOOBAA_METRICS_AUTH_ENABLED":  "true",
+		"NOOBAA_VERSION_AUTH_ENABLED":  "true",
+		"ENDPOINT_SYSTEM_STORE_SOURCE": "core", // by default, load the system store in the endpoint from the core instead of the DB
 	}
 	for key, value := range DefaultConfigMapData {
 		if _, ok := r.CoreAppConfig.Data[key]; !ok {


### PR DESCRIPTION
### Explain the changes
1. Set the env `SYSTEM_STORE_SOURCE='core'` in the endpoint deployemnt. 
2. This is set through the `noobaa-config` config map under the key `ENDPOINT_SYSTEM_STORE_SOURCE`, to allow changing it back to DB if necessary. 
3. Setting this env will cause the endpoints to load the system store data from noobaa-core via RPC instead of querying the DB, and is meant to reduce the load on the DB when there is a high number of endpoints. 

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8816

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable system store source for endpoints, with default loading from core storage.

* **Chores**
  * Minor formatting cleanup in deployment configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->