### PR TITLE
Add Azure STS namespace store CLI support

### DIFF
--- a/doc/namespace-store-crd.md
+++ b/doc/namespace-store-crd.md
@@ -168,6 +168,34 @@ spec:
   type: azure-blob
 ```
 
+## Azure Blob Security Token Service (STS)
+Similarly to `Azure Blob`, this namespacestore uses the Azure Blob API for storing plain data in Azure containers.
+However, the difference between the two namespacestore types lies in the authentication method. Azure Blob uses a pair of static, user-provided account keys, while Azure Blob STS uses Azure Workload Identity with a Client ID and Tenant ID to obtain short-lived access tokens for every interaction with Azure by utilizing [Azure Workload Identity](https://azure.github.io/azure-workload-identity/).
+This type of namespacestore is useful in cases where the user wishes to use short-lived credentials instead of long-lived storage account keys, and for easier management of the cloud's security.
+
+Prior to using this namespacestore, Azure Workload Identity needs to be set up on the AKS cluster, which is outside the scope of these docs.
+
+```shell
+noobaa namespacestore create azure-sts-blob <NAMESPACESTORE NAME> --target-blob-container <> --tenant-id <> --client-id <>
+```
+```yaml
+apiVersion: noobaa.io/v1alpha1
+kind: NamespaceStore
+metadata:
+  finalizers:
+  - noobaa.io/finalizer
+  name: <>
+  namespace: <>
+spec:
+  azureBlob:
+    clientId: <>
+    targetBlobContainer: <>
+    secret:
+      name: <>
+      namespace: <>
+  type: azure-blob
+```
+
 ## Examples
 ### AWS S3
 Note that the keys below are example keys from the AWS documentation, and will not work.


### PR DESCRIPTION
## Summary
- Added Azure STS namespace store CLI command: `azure-sts-blob`
- Implemented Azure Workload Identity support for namespace stores
- Added utility function `IsAzureSTSClusterNS()` to detect Azure STS namespace stores
- Added validation for Azure STS namespace store creation
- Updated documentation in namespace-store-crd.md following AWS STS format

## Implementation Details
- CLI command accepts `--tenant-id`, `--client-id`, and `--target-blob-container` flags
- Credentials stored in secret (tenant-id, client-id) and spec (client-id)
- Short-lived tokens via Azure Workload Identity instead of long-lived account keys
- Reconciler skips secret loading for Azure STS namespace stores
- Validation ensures required fields are present for STS path

## Related
- RHSTOR-8557: Standardized Azure Identity / Azure STS for NooBaa Namespace Store

## Test plan
- [ ] Verify CLI command creates namespace store with correct spec
- [ ] Verify Azure STS credentials are properly stored
- [ ] Verify namespace store reconciles successfully
- [ ] Verify validation rejects invalid configurations