### PR TITLE
Remove Hosted OBC Previous Design Code

### DIFF
--- a/pkg/noobaaaccount/reconciler.go
+++ b/pkg/noobaaaccount/reconciler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
@@ -23,10 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-)
-
-const (
-	strTrue string = "true"
 )
 
 // Reconciler is the context for loading or reconciling a noobaa system
@@ -357,50 +352,24 @@ func (r *Reconciler) CreateNooBaaAccount() error {
 			fmt.Sprintf("%v", err.Error()))
 	}
 
-	annotationValue, exists := util.GetAnnotationValue(r.NooBaaAccount.Annotations, "remote-operator")
-	if exists {
-		if strings.ToLower(annotationValue) == strTrue {
-			// create join secret conatining auth token for remote noobaa account
-			secretServer := util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret)
-			secretServer.Namespace = r.Request.Namespace
-			secretServer.Name = options.SystemName
-			if !util.KubeCheck(secretServer) {
-				return fmt.Errorf("cannot create an auth token for remote operator - server secret not found")
-			}
-
-			token, err := util.MakeAuthToken(map[string]any{
-				"system": r.NooBaa.Name,
-				"role":   "operator",
-				"email":  options.OperatorAccountEmail,
-			}, []byte(secretServer.StringData["jwt"]))
-			if err != nil {
-				return fmt.Errorf("cannot create an auth token for remote operator, error: %v", err)
-			}
-			accessKeys := accountInfo.AccessKeys[0]
-			r.Secret.StringData["auth_token"] = token
-			r.Secret.StringData["AWS_ACCESS_KEY_ID"] = string(accessKeys.AccessKey)
-			r.Secret.StringData["AWS_SECRET_ACCESS_KEY"] = string(accessKeys.SecretKey)
-			r.Secret.StringData["ARN"] = string(accountInfo.ARN)
+	var accessKeys nb.S3AccessKeys
+	// if we didn't get the access keys in the create_account reply we might be talking to an older noobaa version (prior to 5.1)
+	// in that case try to get it using read account
+	if len(accountInfo.AccessKeys) == 0 {
+		log.Info("CreateAccountAPI did not return access keys. calling ReadAccountAPI to get keys..")
+		readAccountReply, err := r.NBClient.ReadAccountAPI(nb.ReadAccountParams{Email: r.NooBaaAccount.Name})
+		if err != nil {
+			return err
 		}
+		accessKeys = readAccountReply.AccessKeys[0]
 	} else {
-		var accessKeys nb.S3AccessKeys
-		// if we didn't get the access keys in the create_account reply we might be talking to an older noobaa version (prior to 5.1)
-		// in that case try to get it using read account
-		if len(accountInfo.AccessKeys) == 0 {
-			log.Info("CreateAccountAPI did not return access keys. calling ReadAccountAPI to get keys..")
-			readAccountReply, err := r.NBClient.ReadAccountAPI(nb.ReadAccountParams{Email: r.NooBaaAccount.Name})
-			if err != nil {
-				return err
-			}
-			accessKeys = readAccountReply.AccessKeys[0]
-		} else {
-			accessKeys = accountInfo.AccessKeys[0]
-		}
-		r.Secret.StringData = map[string]string{}
-		r.Secret.StringData["AWS_ACCESS_KEY_ID"] = string(accessKeys.AccessKey)
-		r.Secret.StringData["AWS_SECRET_ACCESS_KEY"] = string(accessKeys.SecretKey)
-		r.Secret.StringData["ARN"] = string(accountInfo.ARN)
+		accessKeys = accountInfo.AccessKeys[0]
 	}
+	r.Secret.StringData = map[string]string{}
+	r.Secret.StringData["AWS_ACCESS_KEY_ID"] = string(accessKeys.AccessKey)
+	r.Secret.StringData["AWS_SECRET_ACCESS_KEY"] = string(accessKeys.SecretKey)
+	r.Secret.StringData["ARN"] = string(accountInfo.ARN)
+
 	r.Own(r.Secret)
 	err = r.Client.Create(r.Ctx, r.Secret)
 	if err != nil {

--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -200,20 +200,17 @@ func (r *Reconciler) CheckJoinSecret() error {
 		return util.NewPersistentError("InvalidJoinSecert",
 			"JoinSecret is missing auth_token")
 	}
-
-	if !util.IsRemoteClientNoobaa(r.NooBaa.GetAnnotations()) {
-		if r.JoinSecret.StringData["bg_addr"] == "" {
-			return util.NewPersistentError("InvalidJoinSecert",
-				"JoinSecret is missing bg_addr")
-		}
-		if r.JoinSecret.StringData["md_addr"] == "" {
-			return util.NewPersistentError("InvalidJoinSecert",
-				"JoinSecret is missing md_addr")
-		}
-		if r.JoinSecret.StringData["hosted_agents_addr"] == "" {
-			return util.NewPersistentError("InvalidJoinSecert",
-				"JoinSecret is missing hosted_agents_addr")
-		}
+	if r.JoinSecret.StringData["bg_addr"] == "" {
+		return util.NewPersistentError("InvalidJoinSecert",
+			"JoinSecret is missing bg_addr")
+	}
+	if r.JoinSecret.StringData["md_addr"] == "" {
+		return util.NewPersistentError("InvalidJoinSecert",
+			"JoinSecret is missing md_addr")
+	}
+	if r.JoinSecret.StringData["hosted_agents_addr"] == "" {
+		return util.NewPersistentError("InvalidJoinSecert",
+			"JoinSecret is missing hosted_agents_addr")
 	}
 	return nil
 }

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -77,15 +77,12 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 	if err := r.reconcileAdmissionTLSConf(); err != nil {
 		return err
 	}
-	// No endpoint creation is required for remote noobaa client
-	if !util.IsRemoteClientNoobaa(r.NooBaa.GetAnnotations()) {
-		util.KubeCreateOptional(util.KubeObject(bundle.File_deploy_scc_endpoint_yaml).(*secv1.SecurityContextConstraints))
-		if err := r.ReconcileObject(r.DeploymentEndpoint, r.SetDesiredDeploymentEndpoint); err != nil {
-			return err
-		}
-		if err := r.ReconcileHPAEndpoint(); err != nil {
-			return err
-		}
+	util.KubeCreateOptional(util.KubeObject(bundle.File_deploy_scc_endpoint_yaml).(*secv1.SecurityContextConstraints))
+	if err := r.ReconcileObject(r.DeploymentEndpoint, r.SetDesiredDeploymentEndpoint); err != nil {
+		return err
+	}
+	if err := r.ReconcileHPAEndpoint(); err != nil {
+		return err
 	}
 
 	if err := r.RegisterToCluster(); err != nil {
@@ -1908,9 +1905,6 @@ func (r *Reconciler) UpdateBucketClassesPhase(Buckets []nb.BucketInfo) {
 
 // ReconcileDeploymentEndpointStatus creates/updates the endpoints deployment
 func (r *Reconciler) ReconcileDeploymentEndpointStatus() error {
-	if util.IsRemoteClientNoobaa(r.NooBaa.GetAnnotations()) {
-		return nil
-	}
 	if !util.KubeCheck(r.DeploymentEndpoint) {
 		return fmt.Errorf("Could not load endpoint deployment")
 	}
@@ -2077,7 +2071,6 @@ func derefAzureBlobString(p *string) string {
 	}
 	return *p
 }
-
 
 // lastAdmissionTLSSpec caches the most recently applied APIServerSecurity spec
 // so that we only trigger a TLS reload when the settings actually change.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1600,17 +1600,6 @@ func GetAnnotationValue(annotations map[string]string, name string) (string, boo
 	return "", false
 }
 
-// IsRemoteClientNoobaa checks for the existance and value of the remote-client-noobaa annotation
-// within an annotation map, if the annotation doesnt exist it's the same as if its value is false.
-func IsRemoteClientNoobaa(annotations map[string]string) bool {
-	annotationValue, exists := GetAnnotationValue(annotations, "remote-client-noobaa")
-	annotationBoolVal := false
-	if exists {
-		annotationBoolVal = strings.ToLower(annotationValue) == trueStr
-	}
-	return annotationBoolVal
-}
-
 // IsRemoteObcAnnotation checks for the existance and value of the remote-obc-creation annotation
 // within an annotation map, if the annotation doesnt exist it's the same as if its value is false.
 // this annotation is added to OBC that were created for client clusters when using the setup of provider-client


### PR DESCRIPTION
### Explain the problem
In version 4.22 we plan to have the Hosted OBC using the design in [RHSTOR-6230](https://redhat.atlassian.net/browse/RHSTOR-6230) instead of the previous that was implemented in [RHSTOR-5187](https://redhat.atlassian.net/browse/RHSTOR-5187).
It reverted the changes that were added in PR #1405 .

### Explain the changes
1. Remove the check for annotation of remote noobaa-operator and the related functions.

### Issues:
1. none

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently validate cluster join fields that were previously skipped for some deployments, preventing misconfigured joins.

* **Refactor**
  * Unified endpoint lifecycle and status reporting across all deployment types so endpoints report readiness and virtual-hosts uniformly.
  * Simplified account secret and credential population to always provide required access keys and identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->