### PR TITLE
Add Documentation on OBC - Related to Epic and CRDs

### DIFF
--- a/doc/obc-provisioner.md
+++ b/doc/obc-provisioner.md
@@ -269,3 +269,9 @@ spec:
 The scope of bucket permissions is at the claim scope - this means that the credentials of the OBC are confined to access only that single OBC bucket. Notice that also listing buckets with these S3 credentials will return only that one bucket.
 
 Going forward we would like to have an option to create a single account per application namespace so that all buckets claimed by an application will be visible and accessible to that application.
+
+# OBC in Hub Spoke Model
+
+As part of [RHSTOR-6230](https://redhat.atlassian.net/browse/RHSTOR-6230) in 4.22 version - the setup is of provider cluster that is connected to storage including NooBaa (storage hub) and client cluster that can consume the storage (spoke).  
+The OBC is created on client cluster that does not have NooBaa installed on it and the OBC object is marshaled from the client cluster to the provider cluster, where it is unmarshaled, created and provisioned.  
+As part of this effort the OB and OBC CRDs are installed manually using ODF-CLI (see [CRDs files](https://github.com/red-hat-storage/odf-cli/tree/release-4.22/pkg/noobaa/crds) in 4.22 version [OB](https://github.com/red-hat-storage/odf-cli/blob/release-4.22/pkg/noobaa/crds/objectbucket.io_objectbuckets_crd.yaml) and [OBC](https://github.com/red-hat-storage/odf-cli/blob/release-4.22/pkg/noobaa/crds/objectbucket.io_objectbucketclaims_crd.yaml)). If those CRDs change in this repo, update the ODF-CLI copy to match.

--- a/doc/obc-provisioner.md
+++ b/doc/obc-provisioner.md
@@ -273,5 +273,5 @@ Going forward we would like to have an option to create a single account per app
 # OBC in Hub Spoke Model
 
 As part of [RHSTOR-6230](https://redhat.atlassian.net/browse/RHSTOR-6230) in 4.22 version - the setup is of provider cluster that is connected to storage including NooBaa (storage hub) and client cluster that can consume the storage (spoke).  
-The OBC is created on client cluster that does not have NooBaa installed on it and the OBC object is marshaled from the client cluster to the provider cluster, where it is unmarshaled, created and provisioned.  
+The OBC is created on the client cluster, which does not have NooBaa installed, and propagated to the provider cluster, where it is created and provisioned.  
 As part of this effort the OB and OBC CRDs are installed manually using ODF-CLI (see [CRDs files](https://github.com/red-hat-storage/odf-cli/tree/release-4.22/pkg/noobaa/crds) in 4.22 version [OB](https://github.com/red-hat-storage/odf-cli/blob/release-4.22/pkg/noobaa/crds/objectbucket.io_objectbuckets_crd.yaml) and [OBC](https://github.com/red-hat-storage/odf-cli/blob/release-4.22/pkg/noobaa/crds/objectbucket.io_objectbucketclaims_crd.yaml)). If those CRDs change in this repo, update the ODF-CLI copy to match.


### PR DESCRIPTION
### Explain the problem
1. Since most of the changes related to [RHSTOR-6230](https://redhat.atlassian.net/browse/RHSTOR-6230) were implemented in [ocs-operator](https://github.com/red-hat-storage/ocs-operator), [ocs-client-operator](https://github.com/red-hat-storage/ocs-client-operator), and [odf-cli](https://github.com/red-hat-storage/odf-cli), I added a small paragraph for future developers (or AI tools) to raise awareness that expanded to the noobaa-operator context.

### Explain the changes
1. Add basic details about the OB and OBC CRDs copied to ODF CLI.

### Issues:
1. none

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for OBC in a hub-and-spoke deployment: how the provider (storage hub) and client (spoke) clusters interact and how ObjectBucketClaims created on the client are propagated and provisioned on the provider.
  * Added instructions for manual installation of OB/OBC CRDs and keeping local CRD copies in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->