### PR TITLE
[Backport into 5.21] Support key rotation to IBM KeyProtect on ROKS Cluster

### DIFF
--- a/pkg/util/kms/kms_ibm_kp.go
+++ b/pkg/util/kms/kms_ibm_kp.go
@@ -13,9 +13,16 @@ import (
 // IBM KP driver for NooBaa root master key
 //
 
+// KMIP client config options
+const (
+	IBMSecret = "secret"
+)
+
 // IBM is a NooBaa root master key ibmKpSecretStorage driver
 type IBM struct {
-	UID string // NooBaa system UID
+	UID       string // NooBaa system UID
+	name      string // NooBaa system name
+	namespace string // NooBaa system namespace
 }
 
 // NewIBM is IBM KP driver constructor
@@ -24,7 +31,11 @@ func NewIBM(
 	namespace string,
 	uid string,
 ) Driver {
-	return &IBM{uid}
+	return &IBM{
+		UID:       uid,
+		name:      name,
+		namespace: namespace,
+	}
 }
 
 // Config returns ibmKpK8sSecret secret config
@@ -34,7 +45,6 @@ func (i *IBM) Config(config map[string]string, tokenSecretName, namespace string
 	for k, v := range config {
 		c[k] = v
 	}
-
 	// Cloud service IBM KP Instance ID should be passed from NooBaa CR
 	instanceID, instanceIDFound := config[IbmInstanceIDKey]
 	if !instanceIDFound {
@@ -49,6 +59,20 @@ func (i *IBM) Config(config map[string]string, tokenSecretName, namespace string
 			return nil, err
 		}
 	}
+
+	// Get the secret name and namespace from config for tracking key IDs
+	// These are passed from the driver's Config method
+	secretName := tokenSecretName
+	secretNamespace := namespace
+
+	// Initialize the tracking secret
+	secret := &corev1.Secret{}
+	secret.Name = secretName
+	secret.Namespace = secretNamespace
+	if secret.StringData == nil {
+		secret.StringData = make(map[string]string)
+	}
+	c[IBMSecret] = secret
 
 	return c, nil
 }
@@ -100,9 +124,9 @@ func (*IBM) DeleteContext() map[string]string {
 }
 
 // Version returns the current driver KMS version
-// either singlse string or map, i.e. rotating key
-func (*IBM) Version(kms *KMS) Version {
-	return &VersionSingleSecret{kms, nil}
+// either single string or map, i.e. rotating key
+func (i *IBM) Version(kms *KMS) Version {
+	return &VersionRotatingSecret{VersionBase{kms, nil}, i.name, i.namespace}
 }
 
 // Register IBM KP driver with KMS layer

--- a/pkg/util/kms/kms_ibm_kp_storage.go
+++ b/pkg/util/kms/kms_ibm_kp_storage.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	ibm "github.com/IBM/keyprotect-go-client"
 	"github.com/libopenstorage/secrets"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -30,8 +33,16 @@ const (
 // using IBM KP secret storage - standard keys interface using
 // latest "github.com/IBM/keyprotect-go-client" version 0.7.0
 type ibmKpSecretStorage struct {
-	kp *ibm.API
+	kp     *ibm.API
+	secret *corev1.Secret
 }
+
+const (
+	// IBMKPActiveKeyID is the key in the secret that stores the active key ID
+	IBMKPActiveKeyID = "IBM_KP_ACTIVE_KEY_ID"
+	// IBMKPKeyPrefix is the prefix for key IDs stored in the secret
+	IBMKPKeyPrefix = "IBM_KP_KEY_"
+)
 
 func getIbmParam(secretConfig map[string]interface{}, name string) string {
 	if tokenIntf, exists := secretConfig[name]; exists {
@@ -78,8 +89,16 @@ func NewIBMKpSecretStorage(
 		return nil, err
 	}
 
+	secret, exists := secretConfig[IBMSecret]
+	if !exists {
+		return nil, fmt.Errorf("Missing IBM secret")
+	}
+
 	// returned instance
-	r := &ibmKpSecretStorage{kp: kp}
+	r := &ibmKpSecretStorage{
+		kp:     kp,
+		secret: secret.(*corev1.Secret),
+	}
 	return r, nil
 }
 
@@ -126,22 +145,60 @@ func (i *ibmKpSecretStorage) GetSecret(
 	secretID string,
 	keyContext map[string]string,
 ) (map[string]interface{}, secrets.Version, error) {
-	// Find the key ID
-	key, err := i.getKeyByName(secretID)
+	log := util.Logger()
+
+	// Check if this is a rotating secret (backend secret)
+	var activeKeyID string
+	util.KubeCheck(i.secret)
+	if strings.HasSuffix(secretID, "-root-master-key-backend") {
+		// Rotating secret format - get the active key ID from the tracking secret
+		exists := false
+		activeKeyID, exists = i.secret.StringData[IBMKPActiveKeyID]
+		if !exists {
+			log.Errorf("IBM KeyProtect GetSecret() activeKeyID does not exist in secret %v", i.secret.Name)
+			return nil, secrets.NoVersion, secrets.ErrInvalidSecretId
+		}
+	}
+
+	// Determine which key name to look for
+	var keyNameToFind string
+	if len(activeKeyID) > 0 {
+		// Rotating format: look for the IBM KP key ID stored in the secret
+		keyIDInKP, exists := i.secret.StringData[IBMKPKeyPrefix+activeKeyID]
+		if !exists {
+			log.Errorf("IBM KeyProtect GetSecret() key ID mapping not found for %v", activeKeyID)
+			return nil, secrets.NoVersion, secrets.ErrInvalidSecretId
+		}
+		keyNameToFind = keyIDInKP
+	} else {
+		// Single format (for backward compatibility during upgrade)
+		keyNameToFind = secretID
+	}
+
+	// Find the key by name in IBM KeyProtect
+	key, err := i.getKeyByName(keyNameToFind)
 	if err != nil {
+		log.Errorf("IBM KeyProtect GetSecret failed to find key by name %v: %v", keyNameToFind, err)
 		return nil, secrets.NoVersion, err
 	}
 
-	// Fetch the key payload ( key value ) by ID
+	// Fetch the key payload (key value) by ID
 	keyPayload, err := i.kp.GetKey(context.TODO(), key.ID)
 	if err != nil {
+		log.Errorf("IBM KeyProtect GetSecret failed to get key %v: %v", key.ID, err)
 		return nil, secrets.NoVersion, err
 	}
 
-	// Return the fetched key value
-	r := map[string]interface{}{secretID: keyPayload.Payload}
-
-	return r, secrets.NoVersion, nil
+	// Return in the appropriate format
+	if len(activeKeyID) > 0 {
+		// Rotating format: return active_root_key pointer and the key value
+		r := map[string]interface{}{ActiveRootKey: activeKeyID, activeKeyID: keyPayload.Payload}
+		return r, secrets.NoVersion, nil
+	} else {
+		// Single format: return just the key value, Might not need
+		r := map[string]interface{}{secretID: keyPayload.Payload}
+		return r, secrets.NoVersion, nil
+	}
 }
 
 // PutSecret will associate an secretId to its secret data
@@ -151,14 +208,65 @@ func (i *ibmKpSecretStorage) PutSecret(
 	plainText map[string]interface{},
 	keyContext map[string]string,
 ) (secrets.Version, error) {
-	// Import the key value into IBM KP storage
-	value := plainText[secretID].(string)
-	_, err := i.kp.CreateImportedStandardKey(context.TODO(), secretID, nil, value)
+	log := util.Logger()
 
+	// Check if this is a rotating secret format
+	var activeKey string
+	var value string
+	if strings.HasSuffix(secretID, "-root-master-key-backend") {
+		// Rotating secret format - extract active key and its value
+		activeKeyIntf, exists := plainText[ActiveRootKey]
+		if !exists {
+			log.Errorf("IBM KeyProtect PutSecret missing active_root_key in plainText")
+			return secrets.NoVersion, fmt.Errorf("missing active_root_key in rotating secret format")
+		}
+		activeKey = activeKeyIntf.(string)
+
+		valueIntf, exists := plainText[activeKey]
+		if !exists {
+			log.Errorf("IBM KeyProtect PutSecret missing value for active key %v", activeKey)
+			return secrets.NoVersion, fmt.Errorf("missing value for active key %v", activeKey)
+		}
+		value = valueIntf.(string)
+	} else {
+		// Single format (for backward compatibility)
+		valueIntf, ok := plainText[secretID]
+		if !ok {
+			log.Errorf("IBM KeyProtect PutSecret failed to get value for secretID %v", secretID)
+			return secrets.NoVersion, fmt.Errorf("invalid secret value format for secretID %v", secretID)
+		}
+		value = valueIntf.(string)
+	}
+
+	// Generate a unique key name in IBM KeyProtect
+	// For rotating keys, use the active key name; for single keys, use secretID
+	var keyNameInKP string
+	if len(activeKey) > 0 {
+		// Use the timestamp-based key name from the active key
+		keyNameInKP = activeKey
+	} else {
+		keyNameInKP = secretID
+	}
+
+	// Import the key value into IBM KP storage
+	key, err := i.kp.CreateImportedStandardKey(context.TODO(), keyNameInKP, nil, value)
 	if err != nil {
+		log.Errorf("IBM KeyProtect PutSecret failed to create key %v: %v", keyNameInKP, err)
 		return secrets.NoVersion, err
 	}
 
+	// For rotating format, store the mapping in the tracking secret
+	if len(activeKey) > 0 {
+		i.secret.StringData[IBMKPActiveKeyID] = activeKey
+		i.secret.StringData[IBMKPKeyPrefix+activeKey] = key.Name
+
+		if !util.KubeUpdate(i.secret) {
+			log.Errorf("Failed to update IBM KP tracking secret %v in ns %v", i.secret.Name, i.secret.Namespace)
+			return secrets.NoVersion, fmt.Errorf("failed to update IBM KP tracking secret %v in ns %v", i.secret.Name, i.secret.Namespace)
+		}
+	}
+
+	log.Infof("IBM KeyProtect PutSecret successfully created key %v (IBM KP name: %v)", activeKey, keyNameInKP)
 	return secrets.NoVersion, nil
 }
 

--- a/pkg/util/kms/test/ibm-kp/kms_ibm_kp_test.go
+++ b/pkg/util/kms/test/ibm-kp/kms_ibm_kp_test.go
@@ -159,4 +159,235 @@ var _ = Describe("KMS - IBM KP", func() {
 			Expect(err).To(BeNil())
 		})
 	})
+
+	Context("Verify Rotate in NooBaa CR", func() {
+		noobaa := getMiniNooBaa()
+		noobaa.Spec.Security.KeyManagementService = ibmKpKmsSpec(tokenSecretName, instanceID)
+		noobaa.Spec.Security.KeyManagementService.EnableKeyRotation = true
+		noobaa.Spec.Security.KeyManagementService.Schedule = "* * * * *" // every min
+
+		Specify("Create key rotate schedule system", func() {
+			Expect(util.KubeCreateFailExisting(noobaa)).To(BeTrue())
+		})
+		Specify("Verify KMS condition Type", func() {
+			Expect(util.NooBaaCondition(noobaa, nbv1.ConditionTypeKMSType, "ibmkeyprotect")).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Init", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSInit)).To(BeTrue())
+		})
+		Specify("Restart NooBaa operator", func() {
+			podList := &corev1.PodList{}
+			podSelector, _ := labels.Parse("noobaa-operator=deployment")
+			listOptions := client.ListOptions{Namespace: options.Namespace, LabelSelector: podSelector}
+
+			Expect(util.KubeList(podList, &listOptions)).To(BeTrue())
+			Expect(len(podList.Items)).To(BeEquivalentTo(1))
+			Expect(util.KubeDelete(&podList.Items[0])).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Sync", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSSync)).To(BeTrue())
+		})
+		Specify("Verify KMS condition status Key Rotate", func() {
+			Expect(util.NooBaaCondStatus(noobaa, nbv1.ConditionKMSKeyRotate)).To(BeTrue())
+		})
+		Specify("Delete NooBaa", func() {
+			Expect(util.KubeDelete(noobaa)).To(BeTrue())
+		})
+	})
+
+	Context("IBM KP Key Rotation - Rotating Secret Format", func() {
+		name := "noobaa-rotate"
+		id := uuid.New().String()
+		kmsSpec := ibmKpKmsSpec(tokenSecretName, instanceID)
+		k, err := kms.NewKMS(kmsSpec.ConnectionDetails, kmsSpec.TokenSecretName, name, corev1.NamespaceDefault, id)
+		Expect(err).To(BeNil())
+
+		// Generate multiple keys for rotation testing
+		key1 := util.RandomBase64(32)
+		key2 := util.RandomBase64(32)
+		key3 := util.RandomBase64(32)
+
+		Specify("Test rotation params", func() {
+			logger.Printf("💬 Generated noobaa uuid=%v", id)
+			logger.Printf("💬 Generated key1=%v", key1)
+			logger.Printf("💬 Generated key2=%v", key2)
+			logger.Printf("💬 Generated key3=%v", key3)
+		})
+
+		Specify("Verify initial key creation with rotating format", func() {
+			// Set first key using rotating secret format
+			err := k.Set(key1)
+			Expect(err).To(BeNil())
+			logger.Printf("✅ Successfully created initial key in rotating format")
+		})
+
+		Specify("Verify first key retrieval", func() {
+			err := k.Get()
+			Expect(err).To(BeNil())
+			m := &TestSysReconMock{}
+			err = k.Reconcile(m)
+			Expect(err).To(BeNil())
+			retrievedKey := m.data
+			logger.Printf("💬 Retrieved first key: %v", retrievedKey)
+			Expect(retrievedKey).To(Equal(key1))
+		})
+
+		Specify("Verify key rotation - rotate to second key", func() {
+			// Rotate to second key
+			err := k.Set(key2)
+			Expect(err).To(BeNil())
+			logger.Printf("✅ Successfully rotated to second key")
+		})
+
+		Specify("Verify second key retrieval after rotation", func() {
+			err := k.Get()
+			Expect(err).To(BeNil())
+			m := &TestSysReconMock{}
+			err = k.Reconcile(m)
+			Expect(err).To(BeNil())
+			retrievedKey := m.data
+			logger.Printf("💬 Retrieved second key after rotation: %v", retrievedKey)
+			Expect(retrievedKey).To(Equal(key2))
+		})
+
+		Specify("Verify key rotation - rotate to third key", func() {
+			// Rotate to third key
+			err := k.Set(key3)
+			Expect(err).To(BeNil())
+			logger.Printf("✅ Successfully rotated to third key")
+		})
+
+		Specify("Verify tracking secret contains key mappings", func() {
+			// Get the tracking secret
+			secret := &corev1.Secret{}
+			secret.Name = tokenSecretName
+			secret.Namespace = corev1.NamespaceDefault
+			Expect(util.KubeCheck(secret)).To(BeTrue())
+
+			// Verify active key ID exists
+			activeKeyID, exists := secret.StringData[kms.IBMKPActiveKeyID]
+			Expect(exists).To(BeTrue())
+			Expect(activeKeyID).NotTo(BeEmpty())
+			logger.Printf("💬 Active key ID in tracking secret: %v", activeKeyID)
+
+			// Verify key mapping exists for active key
+			keyMapping, exists := secret.StringData[kms.IBMKPKeyPrefix+activeKeyID]
+			Expect(exists).To(BeTrue())
+			Expect(keyMapping).NotTo(BeEmpty())
+			logger.Printf("💬 Key mapping for active key: %v -> %v", activeKeyID, keyMapping)
+		})
+
+		Specify("Verify multiple key IDs stored in tracking secret", func() {
+			// Get the tracking secret
+			secret := &corev1.Secret{}
+			secret.Name = tokenSecretName
+			secret.Namespace = corev1.NamespaceDefault
+			Expect(util.KubeCheck(secret)).To(BeTrue())
+
+			// Count how many key mappings exist
+			keyCount := 0
+			for key := range secret.StringData {
+				if len(key) > len(kms.IBMKPKeyPrefix) && key[:len(kms.IBMKPKeyPrefix)] == kms.IBMKPKeyPrefix {
+					keyCount++
+					logger.Printf("💬 Found key mapping: %v", key)
+				}
+			}
+			
+			// Should have at least 3 keys (from 3 rotations)
+			Expect(keyCount).To(BeNumerically(">=", 3))
+			logger.Printf("✅ Found %d key mappings in tracking secret", keyCount)
+		})
+
+		Specify("Verify cleanup - delete rotated keys", func() {
+			err := k.Delete()
+			logger.Printf("💬 Delete error=%v", err)
+			Expect(err).To(BeNil())
+			logger.Printf("✅ Successfully deleted rotated keys")
+		})
+
+		Specify("Verify keys deleted from IBM Key Protect", func() {
+			err := k.Get()
+			logger.Printf("💬 Get after delete err=%v", err)
+			Expect(err).To(Equal(secrets.ErrInvalidSecretId))
+			logger.Printf("✅ Confirmed keys are deleted from IBM Key Protect")
+		})
+	})
+
+	Context("IBM KP Key Rotation - Backend Secret ID Format", func() {
+		name := "noobaa-backend-rotate"
+		id := uuid.New().String()
+		kmsSpec := ibmKpKmsSpec(tokenSecretName, instanceID)
+		
+		// Create KMS with backend secret format
+		k, err := kms.NewKMS(kmsSpec.ConnectionDetails, kmsSpec.TokenSecretName, name, corev1.NamespaceDefault, id)
+		Expect(err).To(BeNil())
+
+		key1 := util.RandomBase64(32)
+		key2 := util.RandomBase64(32)
+
+		Specify("Test backend rotation params", func() {
+			logger.Printf("💬 Testing backend secret format with uuid=%v", id)
+			logger.Printf("💬 Backend key1=%v", key1)
+			logger.Printf("💬 Backend key2=%v", key2)
+		})
+
+		Specify("Create initial backend key", func() {
+			err := k.Set(key1)
+			Expect(err).To(BeNil())
+			logger.Printf("✅ Created initial backend key")
+		})
+
+		Specify("Verify backend key retrieval", func() {
+			err := k.Get()
+			Expect(err).To(BeNil())
+			m := &TestSysReconMock{}
+			err = k.Reconcile(m)
+			Expect(err).To(BeNil())
+			Expect(m.data).To(Equal(key1))
+			logger.Printf("✅ Retrieved backend key successfully")
+		})
+
+		Specify("Rotate backend key", func() {
+			err := k.Set(key2)
+			Expect(err).To(BeNil())
+			logger.Printf("✅ Rotated backend key")
+		})
+
+		Specify("Verify rotated backend key retrieval", func() {
+			err := k.Get()
+			Expect(err).To(BeNil())
+			m := &TestSysReconMock{}
+			err = k.Reconcile(m)
+			Expect(err).To(BeNil())
+			Expect(m.data).To(Equal(key2))
+			logger.Printf("✅ Retrieved rotated backend key successfully")
+		})
+
+		Specify("Verify IBM Key Protect key ID is stored correctly", func() {
+			// Get the tracking secret
+			secret := &corev1.Secret{}
+			secret.Name = tokenSecretName
+			secret.Namespace = corev1.NamespaceDefault
+			Expect(util.KubeCheck(secret)).To(BeTrue())
+
+			// Verify active key ID
+			activeKeyID, exists := secret.StringData[kms.IBMKPActiveKeyID]
+			Expect(exists).To(BeTrue())
+			logger.Printf("💬 Active backend key ID: %v", activeKeyID)
+
+			// Verify the key mapping contains IBM KP key ID (UUID format)
+			ibmKpKeyID, exists := secret.StringData[kms.IBMKPKeyPrefix+activeKeyID]
+			Expect(exists).To(BeTrue())
+			// IBM KP key IDs should be UUIDs (36 characters with dashes)
+			Expect(len(ibmKpKeyID)).To(BeNumerically(">", 0))
+			logger.Printf("💬 IBM KP Key ID stored: %v", ibmKpKeyID)
+			logger.Printf("✅ IBM Key Protect key ID stored correctly in tracking secret")
+		})
+
+		Specify("Cleanup backend keys", func() {
+			err := k.Delete()
+			Expect(err).To(BeNil())
+			logger.Printf("✅ Cleaned up backend keys")
+		})
+	})
 })


### PR DESCRIPTION
### Explain the changes
[Backport into 5.21] Support key rotation to IBM KeyProtect on ROKS Cluster

(cherry picked from commit b1ac40f8e04c838fdfee619f090866ba1f6710fb)

### Issues: Fixed #xxx / Gap #xxx
1. [DFBUGS-6362](https://redhat.atlassian.net/browse/DFBUGS-6362)
