### PR TITLE
Fixed negative reporting of quota metrics 

### DIFF
--- a/pkg/bucket/bucket.go
+++ b/pkg/bucket/bucket.go
@@ -242,8 +242,8 @@ func RunStatus(cmd *cobra.Command, args []string) {
 		} else {
 			fmt.Printf("  %-22s : %s\n", "Data Size", nb.BigIntToHumanBytes(b.DataCapacity.Size))
 			fmt.Printf("  %-22s : %s\n", "Data Size Reduced", nb.BigIntToHumanBytes(b.DataCapacity.SizeReduced))
-			fmt.Printf("  %-22s : %s\n", "Data Space Avail", nb.BigIntToHumanBytes(b.DataCapacity.AvailableSizeToUpload))
-			fmt.Printf("  %-22s : %s\n", "Num Objects Avail", b.DataCapacity.AvailableQuantityToUpload.ToString())
+			fmt.Printf("  %-22s : %s\n", "Data Space Avail", nb.BigIntToNonNegativeHumanBytes(b.DataCapacity.AvailableSizeToUpload))
+			fmt.Printf("  %-22s : %s\n", "Num Objects Avail", nb.BigIntToNonNegativeString(b.DataCapacity.AvailableQuantityToUpload))
 		}
 	}
 	fmt.Printf("\n")

--- a/pkg/cosi/cosi_bucket_claim.go
+++ b/pkg/cosi/cosi_bucket_claim.go
@@ -246,8 +246,8 @@ func RunStatusBucketClaim(cmd *cobra.Command, args []string) {
 		if b.DataCapacity != nil {
 			fmt.Printf("  %-22s : %s\n", "Data Size", nb.BigIntToHumanBytes(b.DataCapacity.Size))
 			fmt.Printf("  %-22s : %s\n", "Data Size Reduced", nb.BigIntToHumanBytes(b.DataCapacity.SizeReduced))
-			fmt.Printf("  %-22s : %s\n", "Data Space Avail", nb.BigIntToHumanBytes(b.DataCapacity.AvailableSizeToUpload))
-			fmt.Printf("  %-22s : %s\n", "Num Objects Avail", b.DataCapacity.AvailableQuantityToUpload.ToString())
+			fmt.Printf("  %-22s : %s\n", "Data Space Avail", nb.BigIntToNonNegativeHumanBytes(b.DataCapacity.AvailableSizeToUpload))
+			fmt.Printf("  %-22s : %s\n", "Num Objects Avail", nb.BigIntToNonNegativeString(b.DataCapacity.AvailableQuantityToUpload))
 		}
 		fmt.Printf("\n")
 	}

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -792,6 +792,30 @@ func BigIntToHumanBytes(bi *BigInt) string {
 	return IntToHumanBytes(bi.N + (bi.Peta * petaInBytes))
 }
 
+// BigIntToNonNegativeHumanBytes is like BigIntToHumanBytes, but clamps negative values to 0.
+// This is intended for user-facing "available to upload" reporting where negative values are not meaningful.
+func BigIntToNonNegativeHumanBytes(bi *BigInt) string {
+	if bi == nil {
+		return IntToHumanBytes(0)
+	}
+	if bi.ToBig().Sign() < 0 {
+		return IntToHumanBytes(0)
+	}
+	return BigIntToHumanBytes(bi)
+}
+
+// BigIntToNonNegativeString is like (*BigInt).ToString(), but clamps negative values to "0".
+// This is intended for user-facing "available quantity" reporting where negative values are not meaningful.
+func BigIntToNonNegativeString(bi *BigInt) string {
+	if bi == nil {
+		return "0"
+	}
+	if bi.ToBig().Sign() < 0 {
+		return "0"
+	}
+	return bi.ToString()
+}
+
 // IntToHumanBytes returns a human readable bytes string
 func IntToHumanBytes(bi int64) string {
 	f, u := GetBytesAndUnits(bi, -1)

--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -520,8 +520,8 @@ func RunStatus(cmd *cobra.Command, args []string) {
 		if b.DataCapacity != nil {
 			fmt.Printf("  %-22s : %s\n", "Data Size", nb.BigIntToHumanBytes(b.DataCapacity.Size))
 			fmt.Printf("  %-22s : %s\n", "Data Size Reduced", nb.BigIntToHumanBytes(b.DataCapacity.SizeReduced))
-			fmt.Printf("  %-22s : %s\n", "Data Space Avail", nb.BigIntToHumanBytes(b.DataCapacity.AvailableSizeToUpload))
-			fmt.Printf("  %-22s : %s\n", "Num Objects Avail", b.DataCapacity.AvailableQuantityToUpload.ToString())
+			fmt.Printf("  %-22s : %s\n", "Data Space Avail", nb.BigIntToNonNegativeHumanBytes(b.DataCapacity.AvailableSizeToUpload))
+			fmt.Printf("  %-22s : %s\n", "Num Objects Avail", nb.BigIntToNonNegativeString(b.DataCapacity.AvailableQuantityToUpload))
 		}
 		nb.WarnIfQuotaCappedByFree(b.Name, b, nil, b.Quota, func(format string, args ...interface{}) {
 			fmt.Fprintf(os.Stderr, "Warning: "+format+"\n", args...)


### PR DESCRIPTION
### Explain the changes
1. We added small helpers that treats negatives as zero, and the bucket status output now uses them for Data Space Avail and Num Objects Avail. 
2. Nothing else changes—only what the CLI prints so users do not see negative numbers when the bucket is already over quota.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-5264

### Testing Instructions:
1.  Define max_size  quota and upload  a file greater than the available space .
2. After the file is uploaded, check bucket status : 
    Data Space Avail should show 0.000 B

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status displays for buckets and claims now show available data space and object counts as non-negative values (clamping negative/unknown metrics to zero) so capacity metrics are clearer and consistent across CLI outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->