### PR TITLE
STS | Azure env updated to uppercase

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -41,10 +41,10 @@ const (
 	falseStr                string = "false"
 	notificationsVolume     string = "notif-vol"
 	postgresSecretMountPath string = "/etc/postgres-secret"
-	clientIDEnvVar          string = "ClientId"
-	tenantIDEnvVar          string = "TenantId"
-	subscriptionIDEnvVar    string = "SubscriptionId"
-	resourcegroupIDEnvVar   string = "ResourcegroupId"
+	clientIDEnvVar          string = "CLIENTID"
+	tenantIDEnvVar          string = "TENANTID"
+	subscriptionIDEnvVar    string = "SUBSCRIPTIONID"
+	resourcegroupIDEnvVar   string = "RESOURCEGROUP"
 )
 
 // ReconcilePhaseCreating runs the reconcile phase


### PR DESCRIPTION
### Explain the changes
1. odf-operator propagates env vars as ALL CAPS (CLIENTID, TENANTID, "SUBSCRIPTIONID", "RESOURCEGROUP") But noobaa-operator reads them as camelCase(ClientId, TenantId etc)
Updated noobaa-operator with ALL CAPS

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6456

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure STS environment variable names were standardized to uppercase. The operator now reads CLIENTID, TENANTID, SUBSCRIPTIONID, and RESOURCEGROUP for Azure credential detection and validation. Update environment settings—previous lowercase names are no longer recognized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->