### PR TITLE
ObjectBucketName in OBC spec is missing

### DIFF
--- a/pkg/controller/obc/obc_controller.go
+++ b/pkg/controller/obc/obc_controller.go
@@ -2,6 +2,7 @@ package obc
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
@@ -28,6 +29,20 @@ func Add(mgr manager.Manager) error {
 			newOBC, okNew := newObj.(*nbv1.ObjectBucketClaim)
 			if !okOld || !okNew {
 				return
+			}
+
+			// Restore missing objectBucketName if OBC is bound
+			if newOBC.Status.Phase == "Bound" && newOBC.Spec.ObjectBucketName == "" {
+				// Find the corresponding ObjectBucket
+				obName := fmt.Sprintf("obc-%s-%s", newOBC.Namespace, newOBC.Name)
+				ob := &nbv1.ObjectBucket{}
+				ob.Name = obName
+				if util.KubeCheck(ob) {
+					newOBC.Spec.ObjectBucketName = obName
+					if !util.KubeUpdate(newOBC) {
+						util.Logger().Errorf("Failed to restore objectBucketName for OBC %s: %v", newOBC.Name, err)
+					}
+				}
 			}
 
 			// supports only updating of bucket tagging with OBC labels


### PR DESCRIPTION
### Explain the changes
1. Restore missing objectBucketName if OBC is bound and objectBucketName is empty

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-2323

### Testing Instructions:
1. Create an OBC backed by NooBaa
2. Wait for it to be Bound
3. Remove `objectBucketName` from OBC spec and verify

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the objectBucketName field could remain missing in Bound ObjectBucketClaim resources. The system now automatically restores this missing spec field during update operations when a claim is in Bound status, ensuring consistent and complete claim configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->