### PR TITLE
Add description clarifying that dbPriorityClassName takes effect on next pod restart

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1153,8 +1153,11 @@ spec:
                   db container
                 type: string
               dbPriorityClassName:
-                description: DBPriorityClassName (optional) overrides the priority
-                  class for the db pod
+                description: |-
+                  DBPriorityClassName (optional) overrides the priority class for the db pod.
+                  Takes effect on next pod restart (e.g. upgrade, node drain, crash); does not trigger a rolling restart of CNPG-managed pods.
+                  To apply immediately, restart the DB pods manually after reviewing CNPG documentation.
+                  https://cloudnative-pg.io/docs
                 type: string
               dbResources:
                 description: DBResources (optional) overrides the default resource

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -113,7 +113,10 @@ type NooBaaSpec struct {
 	// +optional
 	DBResources *corev1.ResourceRequirements `json:"dbResources,omitempty"`
 
-	// DBPriorityClassName (optional) overrides the priority class for the db pod
+	// DBPriorityClassName (optional) overrides the priority class for the db pod.
+	// Takes effect on next pod restart (e.g. upgrade, node drain, crash); does not trigger a rolling restart of CNPG-managed pods.
+	// To apply immediately, restart the DB pods manually after reviewing CNPG documentation.
+	// https://cloudnative-pg.io/docs
 	// +optional
 	DBPriorityClassName string `json:"dbPriorityClassName,omitempty"`
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1492,7 +1492,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "e49d45bfee6697fb025e759584262d04791477979fb9d572fed2c1a80a3e7d90"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "c94929c02dc22efe29d4317da49bc6111d6ba26430e00b0cc5325189324372f9"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -2649,8 +2649,11 @@ spec:
                   db container
                 type: string
               dbPriorityClassName:
-                description: DBPriorityClassName (optional) overrides the priority
-                  class for the db pod
+                description: |-
+                  DBPriorityClassName (optional) overrides the priority class for the db pod.
+                  Takes effect on next pod restart (e.g. upgrade, node drain, crash); does not trigger a rolling restart of CNPG-managed pods.
+                  To apply immediately, restart the DB pods manually after reviewing CNPG documentation.
+                  https://cloudnative-pg.io/docs
                 type: string
               dbResources:
                 description: DBResources (optional) overrides the default resource


### PR DESCRIPTION
### Explain the changes
1.  Updated `dbPriorityClassName` field description to clarify it takes effect on next pod restart and does not trigger a rolling restart of CNPG-managed DB pods.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: https://redhat.atlassian.net/browse/DFBUGS-6243

### Testing Instructions:
1. Run `oc explain noobaa.spec.dbPriorityClassName` and verify the updated description is shown.

- [ ] Doc added/updated
- [ ] Tests added
