### PR TITLE
Fix TLS feature gaps

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -139,6 +139,9 @@ spec:
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
             - name: NODE_EXTRA_CA_CERTS
+            - name: TLS_MIN_VERSION
+            - name: TLS_CIPHERS
+            - name: TLS_GROUPS
             - name: AGENT_PROFILE
               value: VALUE_AGENT_PROFILE
             - name: OAUTH_AUTHORIZATION_ENDPOINT

--- a/doc/tls-configuration.md
+++ b/doc/tls-configuration.md
@@ -31,7 +31,7 @@ spec:
 |---|---|---|---|
 | `tlsMinVersion` | string (optional, nullable) | `VersionTLS12`, `VersionTLS13` | Minimum TLS protocol version negotiated during handshake. |
 | `tlsCiphers` | []string (optional) | OpenSSL cipher names | Cipher algorithms negotiated during the TLS handshake. |
-| `tlsGroups` | []TLSGroup (optional) | `X25519`, `secp256r1`, `secp384r1`, `secp521r1`, `X25519MLKEM768` | Key exchange group preferences WIP - waiting for final list from DF |
+| `tlsGroups` | []TLSGroup (optional) | `X25519`, `secp256r1`, `secp384r1`, `secp521r1`, `X25519MLKEM768`, `SecP256r1MLKEM768`*, `SecP384r1MLKEM1024`* | Key exchange group preferences. Groups marked * have `InDefaultClients=false` and must be paired with at least one standard group — see [PQC Groups Without Default Client Support](#pqc-groups-without-default-client-support). |
 
 ### Defaults
 
@@ -117,6 +117,191 @@ When TLS configuration is removed from the CR, the variables will be present but
 
 ## Manual Testing
 
+### Applying TLS config and verifying via pod logs
+
+#### 1. Patch the NooBaa CR
+
+```bash
+kubectl patch noobaa noobaa -n <namespace> --type=merge -p '{
+  "spec": {
+    "security": {
+      "apiServerSecurity": {
+        "tlsMinVersion": "TLSv1.3",
+        "tlsCiphers": [
+          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+          "BLALALA",
+          "TLS_CHACHA20_POLY1305_SHA256"
+        ],
+        "tlsGroups": ["X25519"]
+      }
+    }
+  }
+}'
+```
+
+> **Note:** Unrecognised cipher names (e.g. `BLALALA`) are skipped with a warning and do not cause an error.
+
+#### 2. Verify endpoint pod logs
+
+```bash
+kubectl logs noobaa-endpoint-<suffix> -n <namespace> | grep "Updating TLS config for service"
+```
+
+Expected output:
+
+```
+Apr-30 12:42:23.447 [Endpoint/13]    [L0] core.util.ssl_utils:: Updating TLS config for service S3 config.TLS_MIN_VERSION=TLSv1.3, config.TLS_CIPHERS=ECDHE-RSA-AES128-GCM-SHA256:TLS_CHACHA20_POLY1305_SHA256 config.TLS_GROUPS=X25519
+Apr-30 12:42:23.544 [Endpoint/13]    [L0] core.util.ssl_utils:: Updating TLS config for service STS config.TLS_MIN_VERSION=TLSv1.3, config.TLS_CIPHERS=ECDHE-RSA-AES128-GCM-SHA256:TLS_CHACHA20_POLY1305_SHA256 config.TLS_GROUPS=X25519
+Apr-30 12:42:23.723 [Endpoint/13]    [L0] core.util.ssl_utils:: Updating TLS config for service IAM config.TLS_MIN_VERSION=TLSv1.3, config.TLS_CIPHERS=ECDHE-RSA-AES128-GCM-SHA256:TLS_CHACHA20_POLY1305_SHA256 config.TLS_GROUPS=X25519
+Apr-30 12:42:23.855 [Endpoint/13]    [L0] core.util.ssl_utils:: Updating TLS config for service VECTOR config.TLS_MIN_VERSION=TLSv1.3, config.TLS_CIPHERS=ECDHE-RSA-AES128-GCM-SHA256:TLS_CHACHA20_POLY1305_SHA256 config.TLS_GROUPS=X25519
+Apr-30 12:42:24.007 [Endpoint/13]    [L0] core.util.ssl_utils:: Updating TLS config for service METRICS config.TLS_MIN_VERSION=TLSv1.3, config.TLS_CIPHERS=ECDHE-RSA-AES128-GCM-SHA256:TLS_CHACHA20_POLY1305_SHA256 config.TLS_GROUPS=X25519
+```
+
+#### 3. Verify core pod logs
+
+```bash
+kubectl logs noobaa-core-0 -n <namespace> | grep "Updating TLS config for service"
+```
+
+Expected output:
+
+```
+Apr-30 12:42:39.418 [WebServer/34]    [L0] core.util.ssl_utils:: Updating TLS config for service MGMT config.TLS_MIN_VERSION=TLSv1.3, config.TLS_CIPHERS=ECDHE-RSA-AES128-GCM-SHA256:TLS_CHACHA20_POLY1305_SHA256 config.TLS_GROUPS=X25519
+```
+
+#### 4. Verify operator logs (admission server)
+
+```bash
+kubectl logs deploy/noobaa-operator -n <namespace> | grep TLS
+```
+
+Expected output:
+
+```
+time="..." level=info msg="Admission server TLS min version set to TLSv1.3"
+time="..." level=info msg="MapCipherSuites: TLS config cipher suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256"
+time="..." level=info msg="MapGroupPreferences: TLS group preferences set to X25519"
+time="..." level=info msg="Admission server TLS configuration reloaded"
+```
+
+---
+
+### Disabling TLS security config
+
+Setting `DISABLE_TLS_SECURITY_CONFIG=true` on the operator deployment causes the operator to clear all TLS environment variables on the next reconciliation, reverting every configurable server to Node.js defaults. The operator pod, core pod, and endpoint pods all restart.
+
+#### 1. Set the flag
+
+```bash
+kubectl set env deployment/noobaa-operator \
+  DISABLE_TLS_SECURITY_CONFIG=true \
+  -n <namespace>
+```
+
+#### 2. Watch pods restart
+
+```
+NAME                                READY   STATUS              RESTARTS   AGE
+noobaa-core-0                       1/2     Running             0          11s
+noobaa-operator-<suffix>            1/1     Running             0          17s
+noobaa-core-0                       2/2     Running             0          22s
+noobaa-endpoint-<new-suffix>        0/1     ContainerCreating   0          0s
+noobaa-endpoint-<new-suffix>        1/1     Running             0          1s
+```
+
+#### 3. Verify core pod logs show empty TLS config
+
+```bash
+kubectl logs noobaa-core-0 -n <namespace> | grep "Updating TLS config for service"
+```
+
+Expected output (all values empty — Node.js defaults):
+
+```
+core.util.ssl_utils:: Updating TLS config for service MGMT config.TLS_MIN_VERSION=, config.TLS_CIPHERS= config.TLS_GROUPS=
+```
+
+#### 4. Verify endpoint pod logs show empty TLS config
+
+```bash
+kubectl logs noobaa-endpoint-<suffix> -n <namespace> | grep "Updating TLS config for service"
+```
+
+Expected output:
+
+```
+core.util.ssl_utils:: Updating TLS config for service S3 config.TLS_MIN_VERSION=, config.TLS_CIPHERS= config.TLS_GROUPS=
+core.util.ssl_utils:: Updating TLS config for service STS config.TLS_MIN_VERSION=, config.TLS_CIPHERS= config.TLS_GROUPS=
+core.util.ssl_utils:: Updating TLS config for service IAM config.TLS_MIN_VERSION=, config.TLS_CIPHERS= config.TLS_GROUPS=
+core.util.ssl_utils:: Updating TLS config for service VECTOR config.TLS_MIN_VERSION=, config.TLS_CIPHERS= config.TLS_GROUPS=
+core.util.ssl_utils:: Updating TLS config for service METRICS config.TLS_MIN_VERSION=, config.TLS_CIPHERS= config.TLS_GROUPS=
+```
+
+#### 5. Verify operator logs show the flag is active
+
+```bash
+kubectl logs deploy/noobaa-operator -n <namespace> | grep TLS
+```
+
+Expected output:
+
+```
+time="..." level=info msg="TLS security config disabled via DISABLE_TLS_SECURITY_CONFIG, using default TLS config for admission server"
+time="..." level=info msg="Admission server TLS configuration reloaded"
+```
+
+---
+
+### Re-enabling TLS security config
+
+Remove the env var override to restore normal operator behaviour. On the next reconciliation the operator re-applies `apiServerSecurity` from the NooBaa CR to all pods.
+
+```bash
+kubectl set env deployment/noobaa-operator \
+  DISABLE_TLS_SECURITY_CONFIG- \
+  -n <namespace>
+```
+
+The operator, core, and endpoint pods restart and log the configured TLS values as shown in [Applying TLS config and verifying via pod logs](#applying-tls-config-and-verifying-via-pod-logs).
+
+---
+
+## NooBaa TLS Security Summary
+
+The table below shows the TLS posture for all NooBaa endpoints as reported by a PQC readiness scan. Ports that carry HTTPS support configurable TLS via `spec.security.apiServerSecurity`.
+
+```
+================================================================
+                 NooBaa TLS Security Summary
+================================================================
+ENDPOINT                         TLS 1.3      HYBRID KEY EXCHANGE
+----------------------------------------------------------------
+admission-webhook-service:443    YES          NO
+iam:443                          YES          NO
+noobaa-mgmt:443                  YES          NO
+noobaa-mgmt:8445                 YES          YES
+noobaa-mgmt:8446                 YES          YES
+s3:443                           YES          NO
+s3:8444                          YES          YES
+s3:9443                          YES          NO
+sts:443                          YES          NO
+vectors:443                      YES          NO
+noobaa-db-pg-cluster-r:5432      HTTP         N/A (plaintext)
+noobaa-db-pg-cluster-ro:5432     HTTP         N/A (plaintext)
+noobaa-db-pg-cluster-rw:5432     HTTP         N/A (plaintext)
+noobaa-mgmt:80                   HTTP         N/A (plaintext)
+noobaa-syslog:514                HTTP         N/A (plaintext)
+s3:80                            HTTP         N/A (plaintext)
+================================================================
+Full results saved to noobaa_pqc_readiness_report.json
+```
+
+**Configurable endpoints** — all ports listed as `YES` for TLS 1.3 above honour the `tlsMinVersion`, `tlsCiphers`, and `tlsGroups` fields from the NooBaa CR. This includes `noobaa-mgmt:443`, which is externally accessible and was added to the configurable set alongside the other HTTPS ports.
+
+**Hybrid key exchange** — ports marked `YES` in the HYBRID KEY EXCHANGE column already negotiate X25519MLKEM768 with supporting clients out of the box (Node.js v24 + OpenSSL 3.5+). Explicitly setting `tlsGroups: [X25519MLKEM768, ...]` in the CR forces this preference even on clusters that do not default to it.
+
+---
+
 ### Using openssl
 
 Verify TLS 1.3 with PQC group negotiation (requires OpenSSL 3.5+ with ML-KEM support):
@@ -162,6 +347,139 @@ TLS1_3: OK offered
 FS_KEMs: OK X25519MLKEM768
 ```
 
+
+---
+
+## Internal Connectivity Analysis
+
+This section analyses the TLS settings used on each internal connection path and evaluates whether any server-side TLS configuration set via the NooBaa CR could break internal connectivity.
+
+### Connection Paths
+
+```
+noobaa-operator  ──WSS/HTTPS──►  noobaa-core (MGMT :5443)
+noobaa-operator  ──HTTPS──►      noobaa-endpoint (S3/STS/IAM)
+noobaa-core      ──WSS──►        noobaa-core (MGMT :5443)   [self, via server_rpc]
+noobaa-core      ──HTTPS──►      noobaa-endpoint (S3/STS/IAM)
+```
+
+### TLS Client Behaviour
+
+#### noobaa-operator (Go)
+
+The operator connects to the MGMT server over WSS and to endpoint servers over HTTPS.
+Its HTTP/WS client uses `InsecureHTTPTransport` — a plain `tls.Config` with `InsecureSkipVerify: true` and **no custom MinVersion, CipherSuites, or CurvePreferences**:
+
+```go
+// pkg/util/util.go
+InsecureHTTPTransport = &http.Transport{
+    TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+}
+```
+
+The operator **propagates** TLS settings (from the NooBaa CR) as environment variables to the NooBaa pods, but it does **not** apply those settings to its own outgoing TLS connections. The operator always uses Go runtime defaults.
+
+**Go 1.24+ defaults (as client):**
+
+| Parameter | Default |
+|---|---|
+| Min version | TLS 1.2 |
+| Max version | TLS 1.3 |
+| Key exchange groups | `X25519MLKEM768`, `X25519`, `P-256`, `P-384`, `P-521` (Go 1.24+) |
+| TLS 1.3 ciphers | `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, `TLS_CHACHA20_POLY1305_SHA256` |
+| TLS 1.2 ciphers | All ECDHE-RSA/ECDSA AES-GCM, ChaCha20, AES-CBC suites; RSA-kex and 3DES disabled by default |
+
+#### noobaa-core / noobaa-endpoint (Node.js 24.13.0)
+
+Internal client connections (e.g. core → endpoint, core → MGMT) use `get_unsecured_agent()` which returns an `https.Agent({ rejectUnauthorized: false })` with **no custom TLS parameters** — pure Node.js / OpenSSL 3.5 defaults.
+
+**Node.js 24.13.0 (OpenSSL 3.5) defaults (as client):**
+
+| Parameter | Default |
+|---|---|
+| Min version (`tls.DEFAULT_MIN_VERSION`) | `TLSv1.2` |
+| Max version (`tls.DEFAULT_MAX_VERSION`) | `TLSv1.3` |
+| `ecdhCurve` (`tls.DEFAULT_ECDH_CURVE`) | `'auto'` — OpenSSL 3.5 advertises `X25519MLKEM768` and `X25519` as preferred keyshares; all other standard curves also included |
+| Ciphers (`tls.DEFAULT_CIPHERS`) | OpenSSL 3.5 compiled-in default list; includes all standard TLS 1.3 suites and ECDHE-RSA/ECDSA TLS 1.2 suites |
+
+### Operator Input Validation
+
+Before writing TLS settings to the pod environment variables, `ApplyTLSEnvVars` (and the admission server) validate each field via helper functions in `pkg/util/tls.go`. Unknown values are **skipped with a warning** and never reach the pod.
+
+| Field | Validator | Behaviour on unknown value |
+|---|---|---|
+| `tlsMinVersion` | `MapMinVersion()` | Warns and writes `""` (Node.js falls back to default) |
+| `tlsCiphers` | `MapCiphersToOpenSSL()` / `MapCipherSuites()` | Warns and skips the unknown entry; known entries still applied |
+| `tlsGroups` | `TLSGroupMap` lookup in `ApplyTLSEnvVars` / `MapGroupPreferences()` | Warns and skips the unknown entry; known entries still applied |
+
+Example warning messages:
+
+```
+MapMinVersion: skipping unsupported TLS min version "TLSv1.5"
+MapCiphersToOpenSSL: skipping unrecognized/unsupported IANA cipher suite "FAKE_CIPHER"
+ApplyTLSEnvVars: skipping unsupported TLS group "TLSGroupSecP384r1MLKEM10241irewr"
+```
+
+#### PQC Groups Without Default Client Support
+
+Each entry in `TLSGroupMap` carries an `InDefaultClients` boolean that records whether the group is included in the default group lists of both Node.js 24 and Go 1.24+ clients.
+
+`SecP256r1MLKEM768` and `SecP384r1MLKEM1024` have `InDefaultClients=false` for two reasons:
+
+1. **Node.js 24 does not include them in its default group list.** A server restricted to only those groups cannot be reached by any standard client (Node.js or Go), breaking all connections including operator→core, core→endpoint, and internal RPC.
+2. **Go < 1.26 `crypto/tls` cannot negotiate key exchange with their CurveIDs** (4587 / 4589), which also breaks the admission server and any Go-based client.
+
+`ValidateTLSSpec` enforces this at admission time: if `tlsGroups` contains no entry with `InDefaultClients=true`, the CR is **rejected** with an error. Pairing either group with any standard group (e.g. `X25519`) satisfies the check.
+
+```yaml
+# rejected — SecP256r1MLKEM768 has InDefaultClients=false and there is no fallback
+tlsGroups: [SecP256r1MLKEM768]
+
+# accepted — X25519 has InDefaultClients=true and acts as the fallback
+tlsGroups: [SecP256r1MLKEM768, X25519]
+```
+
+### Breakage Analysis
+
+Given that:
+- The operator client uses Go defaults (very broad)
+- The core/endpoint client uses Node.js 24 + OpenSSL 3.5 defaults (very broad)
+- The operator validates and drops unknown values for all three TLS fields before propagating them
+
+| Configuration | Operator→MGMT | Core→Endpoint | Reason |
+|---|---|---|---|
+| `TLS_MIN_VERSION=TLSv1.3` | ✅ No breakage | ✅ No breakage | Both Go and Node.js 24 support TLS 1.3 |
+| `TLS_CIPHERS=<ECDSA-only>` with RSA cert | ✅ No breakage | ✅ No breakage | `TLS_CIPHERS` only restricts TLS 1.2 in Node.js; both clients negotiate TLS 1.3 where ciphers are fixed |
+| `TLS_CIPHERS=<TLS 1.2 suite>` + `TLS_MIN_VERSION=TLSv1.3` | ✅ No breakage | ✅ No breakage | TLS 1.3 is forced; the `TLS_CIPHERS` value is irrelevant for TLS 1.3 |
+| `TLS_GROUPS=X25519MLKEM768` | ✅ No breakage | ✅ No breakage | Both Go 1.24+ and Node.js 24.5+ (OpenSSL 3.5) support this group |
+| `TLS_GROUPS=SecP256r1MLKEM768` (alone) | ❌ Blocked at admission | ❌ Blocked at admission | `ValidateTLSSpec` rejects the CR — no group with `InDefaultClients=true` present |
+| `TLS_GROUPS=SecP384r1MLKEM1024` (alone) | ❌ Blocked at admission | ❌ Blocked at admission | `ValidateTLSSpec` rejects the CR — no group with `InDefaultClients=true` present |
+| `TLS_GROUPS=SecP256r1MLKEM768 + X25519` | ✅ No breakage | ✅ No breakage | X25519 has `InDefaultClients=true`; clients always fall back to it |
+| `TLS_GROUPS=<unknown group>` | ✅ No breakage | ✅ No breakage | Operator drops unknown groups — they never reach the server |
+| `TLS_MIN_VERSION=<unknown version>` | ✅ No breakage | ✅ No breakage | `MapMinVersion()` drops it; server falls back to Node.js default (TLSv1.2 min) |
+| `TLS_CIPHERS=<unknown cipher>` | ✅ No breakage | ✅ No breakage | `MapCiphersToOpenSSL()` drops unknown entries; remaining known entries still applied |
+
+**Conclusion:** No TLS configuration that passes admission will break connectivity between the operator and NooBaa servers, or between internal NooBaa components. Unknown values are dropped with a warning, and `ValidateTLSSpec` blocks any group list that contains no `InDefaultClients=true` entry at the admission webhook.
+
+### Most Common Negotiated Parameters (No Custom Config)
+
+With NooBaa running Node.js 24.13.0 (OpenSSL 3.5) and no TLS settings in the CR, the typical outcome on modern x86-64 hardware (AES-NI available) is:
+
+```
+Protocol:   TLS 1.3
+Group:      X25519MLKEM768  (both sides advertise it by default)
+Cipher:     TLS_AES_128_GCM_SHA256  (server preference wins; AES-GCM preferred with AES-NI)
+```
+
+For clients without X25519MLKEM768 support (e.g. Node.js 22 LTS / OpenSSL < 3.5, Go < 1.24):
+
+```
+Protocol:   TLS 1.3
+Group:      X25519  (fallback)
+Cipher:     TLS_AES_128_GCM_SHA256
+```
+
+---
 
 ## TODO
 - Add PQC scanner info

--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -93,7 +93,12 @@ func RunAdmissionServer() {
 
 // applyAPIServerTLS fetches the NooBaa CR and applies APIServerSecurity TLS
 // properties to the given tls.Config when they are set.
+// Has no effect when DISABLE_TLS_SECURITY_CONFIG=true.
 func applyAPIServerTLS(tlsConfig *tls.Config, log *logrus.Entry) {
+	if util.IsTLSConfigDisabled() {
+		log.Infof("TLS security config disabled via %s, using default TLS config for admission server", util.DisableTLSSecurityConfigEnv)
+		return
+	}
 	noobaa := &nbv1.NooBaa{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "noobaa",
@@ -108,6 +113,11 @@ func applyAPIServerTLS(tlsConfig *tls.Config, log *logrus.Entry) {
 	spec := noobaa.Spec.Security.APIServerSecurity
 	if spec == nil {
 		log.Info("APIServerSecurity not configured, using default TLS config for admission server")
+		return
+	}
+
+	if err := util.ValidateTLSSpec(spec); err != nil {
+		log.Warnf("APIServerSecurity contains invalid TLS configuration, using default TLS config for admission server: %v", err)
 		return
 	}
 

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5564,7 +5564,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "950eaab1e58069eec4df071a6020f75914586a5a2b25f56470059cc9c0b7f892"
+const Sha256_deploy_internal_statefulset_core_yaml = "4ef493f94d8f81746f9d8904085de093b4ed37ee15d0767cc563f7aa89c86de8"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5707,6 +5707,9 @@ spec:
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
             - name: NODE_EXTRA_CA_CERTS
+            - name: TLS_MIN_VERSION
+            - name: TLS_CIPHERS
+            - name: TLS_GROUPS
             - name: AGENT_PROFILE
               value: VALUE_AGENT_PROFILE
             - name: OAUTH_AUTHORIZATION_ENDPOINT

--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -78,6 +78,10 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 		}
 	}
 
+	if err := util.ValidateTLSSpec(r.NooBaa.Spec.Security.APIServerSecurity); err != nil {
+		return util.NewPersistentError("InvalidTLSConfiguration", err.Error())
+	}
+
 	return nil
 }
 

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -624,6 +624,7 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 		util.MergeEnvArrays(&c.Env, &[]corev1.EnvVar{envVar})
 	}
 
+	util.ApplyTLSEnvVars(&c.Env, r.NooBaa.Spec.Security.APIServerSecurity)
 }
 
 // SetDesiredCoreApp updates the CoreApp as desired for reconciling

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -375,10 +375,6 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 				r.setDesiredCoreEnv(c)
 			}
 
-			tlsSec := r.NooBaa.Spec.Security.APIServerSecurity
-			if tlsSec == nil {
-				tlsSec = &nbv1.TLSSecuritySpec{}
-			}
 			for j := range c.Env {
 				switch c.Env[j].Name {
 				case "MGMT_ADDR":
@@ -463,22 +459,10 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 					} else {
 						c.Env[j].Value = ""
 					}
-				case "TLS_MIN_VERSION":
-					if tlsSec.TLSMinVersion != nil {
-						c.Env[j].Value = string(*tlsSec.TLSMinVersion)
-					} else {
-						c.Env[j].Value = ""
-					}
-				case "TLS_CIPHERS":
-					c.Env[j].Value = util.MapCiphersToOpenSSL(tlsSec.TLSCiphers)
-				case "TLS_GROUPS":
-					groupNames := make([]string, len(tlsSec.TLSGroups))
-					for i, g := range tlsSec.TLSGroups {
-						groupNames[i] = string(g)
-					}
-					c.Env[j].Value = strings.Join(groupNames, ":")
 				}
 			}
+
+			util.ApplyTLSEnvVars(&c.Env, r.NooBaa.Spec.Security.APIServerSecurity)
 
 			if r.NooBaa.Spec.BucketNotifications.Enabled {
 				envVar := corev1.EnvVar{

--- a/pkg/util/tls.go
+++ b/pkg/util/tls.go
@@ -2,10 +2,24 @@ package util
 
 import (
 	"crypto/tls"
+	"fmt"
+	"os"
 	"strings"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
+
+// DisableTLSSecurityConfigEnv is the name of the environment variable that disables
+// applying TLS security configuration (min version, ciphers, groups) from the NooBaa
+// CR to endpoint, core, and admission server. Set to "true" to disable. Default: enabled.
+const DisableTLSSecurityConfigEnv = "DISABLE_TLS_SECURITY_CONFIG"
+
+// IsTLSConfigDisabled returns true when the DISABLE_TLS_SECURITY_CONFIG env var is set
+// to "true", allowing operators to opt out of the TLS security configuration feature.
+func IsTLSConfigDisabled() bool {
+	return os.Getenv(DisableTLSSecurityConfigEnv) == "true"
+}
 
 // IanaCipherEntry holds the Go numeric ID and OpenSSL-format name for a single
 // IANA/Go cipher suite. Node.js endpoints need the OpenSSL name while Go's
@@ -31,28 +45,37 @@ var IanaCipherMap = map[string]IanaCipherEntry{
 	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   {CipherGoID: 52392, CipherOpenSSLName: "ECDHE-RSA-CHACHA20-POLY1305"},
 }
 
-// TLSGroupToID maps NooBaa TLSGroup constants to Go tls.CurveID values.
-// TODO: When ODF is updated to include the new TLSGroups, we should switch to using the
-// ODF supported tls groups
-var TLSGroupToID = map[nbv1.TLSGroup]tls.CurveID{
-	nbv1.TLSGroupX25519:             tls.X25519,
-	nbv1.TLSGroupSecp256r1:          tls.CurveP256,
-	nbv1.TLSGroupSecp384r1:          tls.CurveP384,
-	nbv1.TLSGroupSecp521r1:          tls.CurveP521,
-	nbv1.TLSGroupX25519MLKEM768:     tls.X25519MLKEM768,
-	nbv1.TLSGroupSecP256r1MLKEM768:  4587, // tls.SecP256r1MLKEM768 in Go 1.26+
-	nbv1.TLSGroupSecP384r1MLKEM1024: 4589, // tls.SecP384r1MLKEM1024 in Go 1.26+
+// TLSGroupEntry holds the Go CurveID for a TLS key exchange group and records
+// whether the group is included in the default group lists of both Node.js 24
+// and Go 1.24+ clients. Groups where InDefaultClients is false must not be used
+// exclusively — a standard group must accompany them as a fallback, otherwise
+// clients that don't advertise the group cannot complete the TLS handshake.
+type TLSGroupEntry struct {
+	CurveID          tls.CurveID
+	InDefaultClients bool
+}
+
+// TLSGroupMap maps NooBaa TLSGroup constants to their Go CurveID and default-client
+// membership. The TLSGroup string values are already valid Node.js/OpenSSL ecdhCurve
+// names and can be used as-is for TLS_GROUPS.
+var TLSGroupMap = map[nbv1.TLSGroup]TLSGroupEntry{
+	nbv1.TLSGroupX25519:             {CurveID: tls.X25519, InDefaultClients: true},
+	nbv1.TLSGroupSecp256r1:          {CurveID: tls.CurveP256, InDefaultClients: true},
+	nbv1.TLSGroupSecp384r1:          {CurveID: tls.CurveP384, InDefaultClients: true},
+	nbv1.TLSGroupSecp521r1:          {CurveID: tls.CurveP521, InDefaultClients: true},
+	nbv1.TLSGroupX25519MLKEM768:     {CurveID: tls.X25519MLKEM768, InDefaultClients: true},
+	nbv1.TLSGroupSecP256r1MLKEM768:  {CurveID: tls.CurveID(4587), InDefaultClients: false}, // tls.SecP256r1MLKEM768 added in Go 1.26
+	nbv1.TLSGroupSecP384r1MLKEM1024: {CurveID: tls.CurveID(4589), InDefaultClients: false}, // tls.SecP384r1MLKEM1024 added in Go 1.26
 }
 
 // MapCiphersToOpenSSL converts IANA cipher suite names to OpenSSL format for
-// Node.js endpoints. Unrecognized/unsupported IANA names are skipped with a warning.
+// Node.js endpoints. The caller is expected to have validated names via ValidateTLSSpec;
+// unrecognized entries are silently skipped.
 func MapCiphersToOpenSSL(names []string) string {
 	var result []string
 	for _, name := range names {
 		if entry, ok := IanaCipherMap[name]; ok {
 			result = append(result, entry.CipherOpenSSLName)
-		} else {
-			log.Warnf("MapCiphersToOpenSSL: skipping unrecognized/unsupported IANA cipher suite %q", name)
 		}
 	}
 	return strings.Join(result, ":")
@@ -80,14 +103,117 @@ func MapCipherSuites(names []string) []uint16 {
 	return ids
 }
 
+// ApplyTLSEnvVars sets TLS_MIN_VERSION, TLS_CIPHERS, and TLS_GROUPS on entries already
+// present in env based on the given TLSSecuritySpec. It is a no-op for containers that
+// do not declare those variable names. When tlsSec is nil, or when DISABLE_TLS_SECURITY_CONFIG=true,
+// all three are cleared to "" so any previously applied values are removed.
+// The caller is responsible for validating tlsSec before calling this function
+// (e.g. via ValidateTLSSpec in phase 1 verifying).
+func ApplyTLSEnvVars(env *[]corev1.EnvVar, tlsSec *nbv1.TLSSecuritySpec) {
+	if IsTLSConfigDisabled() {
+		log.Infof("TLS security config disabled via %s, skipping TLS env var updates", DisableTLSSecurityConfigEnv)
+		tlsSec = nil
+	}
+	if tlsSec == nil {
+		tlsSec = &nbv1.TLSSecuritySpec{}
+	}
+	// TLSGroup string values (e.g. "X25519", "secp256r1") are already valid
+	// Node.js/OpenSSL ecdhCurve names and can be used as-is for TLS_GROUPS.
+	var groupNames []string
+	for _, g := range tlsSec.TLSGroups {
+		groupNames = append(groupNames, string(g))
+	}
+	for i := range *env {
+		switch (*env)[i].Name {
+		case "TLS_MIN_VERSION":
+			if tlsSec.TLSMinVersion != nil {
+				(*env)[i].Value = string(*tlsSec.TLSMinVersion)
+			} else {
+				(*env)[i].Value = ""
+			}
+		case "TLS_CIPHERS":
+			(*env)[i].Value = MapCiphersToOpenSSL(tlsSec.TLSCiphers)
+		case "TLS_GROUPS":
+			(*env)[i].Value = strings.Join(groupNames, ":")
+		}
+	}
+}
+
+// ValidateTLSSpec validates all fields in a TLSSecuritySpec against the values
+// defined in this package (IanaCipherMap, TLSGroupMap, known TLSProtocolVersion
+// constants). All problems are collected and returned as a single error so the
+// caller can surface every issue at once.
+//
+// Rules enforced:
+//   - tlsMinVersion, if set, must be VersionTLS12 or VersionTLS13.
+//   - Every tlsCiphers entry must be a key in IanaCipherMap.
+//   - Every tlsGroups entry must be a key in TLSGroupMap.
+//   - tlsGroups must contain at least one entry with InDefaultClients=true;
+//     groups where InDefaultClients is false (SecP256r1MLKEM768,
+//     SecP384r1MLKEM1024) cannot be used exclusively because they are absent
+//     from the Node.js 24 and Go < 1.26 default group lists and will break
+//     all TLS connections.
+func ValidateTLSSpec(spec *nbv1.TLSSecuritySpec) error {
+	if spec == nil {
+		return nil
+	}
+	if IsTLSConfigDisabled() {
+		log.Infof("TLS security config disabled via %s, using default TLS config", DisableTLSSecurityConfigEnv)
+		return nil
+	}
+	var errs []string
+
+	if spec.TLSMinVersion != nil {
+		switch *spec.TLSMinVersion {
+		case nbv1.VersionTLS12, nbv1.VersionTLS13:
+		default:
+			errs = append(errs, fmt.Sprintf(
+				"tlsMinVersion %q is not valid; allowed values: %q, %q",
+				*spec.TLSMinVersion, nbv1.VersionTLS12, nbv1.VersionTLS13))
+		}
+	}
+
+	for _, c := range spec.TLSCiphers {
+		if _, ok := IanaCipherMap[c]; !ok {
+			errs = append(errs, fmt.Sprintf("tlsCiphers: %q is not a recognized cipher suite", c))
+		}
+	}
+
+	hasDefaultClientGroup := false
+	for _, g := range spec.TLSGroups {
+		entry, ok := TLSGroupMap[g]
+		if !ok {
+			errs = append(errs, fmt.Sprintf("tlsGroups: %q is not a recognized group", g))
+			continue
+		}
+		if entry.InDefaultClients {
+			hasDefaultClientGroup = true
+		}
+	}
+	if len(spec.TLSGroups) > 0 && !hasDefaultClientGroup {
+		errs = append(errs, fmt.Sprintf(
+			"tlsGroups must include at least one group with InDefaultClients=true "+
+				"(e.g. %q, %q, %q, %q, %q) — SecP256r1MLKEM768 and SecP384r1MLKEM1024 "+
+				"are absent from the Node.js and Go current default group lists, so "+
+				"using them exclusively breaks all TLS connections",
+			nbv1.TLSGroupX25519, nbv1.TLSGroupSecp256r1,
+			nbv1.TLSGroupSecp384r1, nbv1.TLSGroupSecp521r1, nbv1.TLSGroupX25519MLKEM768))
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", strings.Join(errs, "; "))
+}
+
 // MapGroupPreferences converts a list of NooBaa TLSGroup values to the corresponding
 // tls.CurveID slice for use in tls.Config.CurvePreferences.
 func MapGroupPreferences(groups []nbv1.TLSGroup) []tls.CurveID {
 	var ids []tls.CurveID
 	var applied []string
 	for _, g := range groups {
-		if id, ok := TLSGroupToID[g]; ok {
-			ids = append(ids, id)
+		if entry, ok := TLSGroupMap[g]; ok {
+			ids = append(ids, entry.CurveID)
 			applied = append(applied, string(g))
 		} else {
 			log.Warnf("MapGroupPreferences: ignoring unsupported TLS group %q", g)

--- a/pkg/util/tls_connectivity_test.go
+++ b/pkg/util/tls_connectivity_test.go
@@ -1,0 +1,296 @@
+package util
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+)
+
+// TestSupportedConfigDoesNotBreakConnectivity verifies that every TLS configuration
+// the operator may write to NooBaa pods can still be negotiated by a client using
+// Go defaults — matching the InsecureHTTPTransport used by operator→core/endpoint
+// and core→endpoint connections.
+//
+// The server side is modelled by building a Go tls.Config from each supported CR
+// value via the same helpers used in ApplyTLSEnvVars and the admission server.
+// A real in-process TLS handshake is then performed with an operator-style client.
+func TestSupportedConfigDoesNotBreakConnectivity(t *testing.T) {
+	rsaCert := generateTestRSACert(t)
+	ecdsaCert := generateTestECDSACert(t)
+
+	minV12 := nbv1.VersionTLS12
+	minV13 := nbv1.VersionTLS13
+
+	cases := []struct {
+		name     string
+		spec     *nbv1.TLSSecuritySpec
+		useECDSA bool // ECDSA cert needed to exercise ECDHE-ECDSA cipher suites via TLS 1.2
+	}{
+		// --- TLS min version ---
+		{
+			name: "minVersion TLSv1.2",
+			spec: &nbv1.TLSSecuritySpec{TLSMinVersion: &minV12},
+		},
+		{
+			name: "minVersion TLSv1.3",
+			spec: &nbv1.TLSSecuritySpec{TLSMinVersion: &minV13},
+		},
+
+		// --- TLS 1.3 cipher suites ---
+		// Go's tls.Config.CipherSuites only affects TLS 1.2; TLS 1.3 suites are
+		// always negotiated when TLS 1.3 is available, so these three have no effect
+		// on connectivity with a modern client.
+		{
+			name: "cipher TLS_AES_128_GCM_SHA256",
+			spec: &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_AES_128_GCM_SHA256"}},
+		},
+		{
+			name: "cipher TLS_AES_256_GCM_SHA384",
+			spec: &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_AES_256_GCM_SHA384"}},
+		},
+		{
+			name: "cipher TLS_CHACHA20_POLY1305_SHA256",
+			spec: &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_CHACHA20_POLY1305_SHA256"}},
+		},
+
+		// --- ECDHE-RSA TLS 1.2 cipher suites ---
+		{
+			name: "cipher TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			spec: &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}},
+		},
+		{
+			name: "cipher TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			spec: &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}},
+		},
+		{
+			name: "cipher TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			spec: &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"}},
+		},
+
+		// --- ECDHE-ECDSA TLS 1.2 cipher suites ---
+		// We use an ECDSA cert so these are exercised at TLS 1.2 as well as TLS 1.3.
+		{
+			name:     "cipher TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			spec:     &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"}},
+			useECDSA: true,
+		},
+		{
+			name:     "cipher TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			spec:     &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"}},
+			useECDSA: true,
+		},
+		{
+			name:     "cipher TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+			spec:     &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"}},
+			useECDSA: true,
+		},
+
+		// --- TLS groups ---
+		{
+			name: "group X25519",
+			spec: &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupX25519}},
+		},
+		{
+			name: "group secp256r1",
+			spec: &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupSecp256r1}},
+		},
+		{
+			name: "group secp384r1",
+			spec: &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupSecp384r1}},
+		},
+		{
+			name: "group secp521r1",
+			spec: &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupSecp521r1}},
+		},
+		{
+			name: "group X25519MLKEM768",
+			spec: &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupX25519MLKEM768}},
+		},
+		// SecP256r1MLKEM768 and SecP384r1MLKEM1024 are in NoDefaultGroups — absent from
+		// Node.js 24 and Go < 1.26 default group lists. ValidateTLSGroups rejects them
+		// when used alone; the only safe (and valid) configuration is paired with a
+		// standard fallback group so clients can always negotiate a common group.
+		{
+			name: "group SecP256r1MLKEM768 + X25519 fallback",
+			spec: &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{
+				nbv1.TLSGroupSecP256r1MLKEM768, nbv1.TLSGroupX25519,
+			}},
+		},
+		{
+			name: "group SecP384r1MLKEM1024 + X25519 fallback",
+			spec: &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{
+				nbv1.TLSGroupSecP384r1MLKEM1024, nbv1.TLSGroupX25519,
+			}},
+		},
+
+		// --- All fields combined ---
+		{
+			name: "all fields: TLSv1.3 + RSA cipher + X25519 group",
+			spec: &nbv1.TLSSecuritySpec{
+				TLSMinVersion: &minV13,
+				TLSCiphers:    []string{"TLS_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+				TLSGroups:     []nbv1.TLSGroup{nbv1.TLSGroupX25519, nbv1.TLSGroupSecp256r1},
+			},
+		},
+		{
+			name: "all fields: TLSv1.3 + PQC group X25519MLKEM768",
+			spec: &nbv1.TLSSecuritySpec{
+				TLSMinVersion: &minV13,
+				TLSCiphers:    []string{"TLS_AES_256_GCM_SHA384"},
+				TLSGroups:     []nbv1.TLSGroup{nbv1.TLSGroupX25519MLKEM768, nbv1.TLSGroupX25519},
+			},
+		},
+
+		// --- Unknown / invalid values are dropped; remaining config must still work ---
+		{
+			name: "unknown cipher dropped; known cipher still applied",
+			spec: &nbv1.TLSSecuritySpec{
+				TLSCiphers: []string{"UNKNOWN_CIPHER", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+			},
+		},
+		{
+			name: "unknown group dropped; known group still applied",
+			spec: &nbv1.TLSSecuritySpec{
+				TLSGroups: []nbv1.TLSGroup{"UnknownGroup", nbv1.TLSGroupX25519},
+			},
+		},
+		{
+			name: "unknown min version dropped; server uses default",
+			spec: func() *nbv1.TLSSecuritySpec {
+				unknown := nbv1.TLSProtocolVersion("TLSv1.5")
+				return &nbv1.TLSSecuritySpec{TLSMinVersion: &unknown}
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cert := rsaCert
+			if tc.useECDSA {
+				cert = ecdsaCert
+			}
+			serverCfg := specToServerTLSConfig(tc.spec, cert)
+			assertTLSHandshakeSucceeds(t, serverCfg)
+		})
+	}
+}
+
+// specToServerTLSConfig builds a Go tls.Config for a server from a TLSSecuritySpec,
+// using the same mapping helpers as ApplyTLSEnvVars and the admission server.
+func specToServerTLSConfig(spec *nbv1.TLSSecuritySpec, cert tls.Certificate) *tls.Config {
+	cfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+	if spec == nil {
+		return cfg
+	}
+	if spec.TLSMinVersion != nil {
+		switch *spec.TLSMinVersion {
+		case nbv1.VersionTLS12:
+			cfg.MinVersion = tls.VersionTLS12
+		case nbv1.VersionTLS13:
+			cfg.MinVersion = tls.VersionTLS13
+		}
+	}
+	if suites := MapCipherSuites(spec.TLSCiphers); len(suites) > 0 {
+		cfg.CipherSuites = suites
+	}
+	if curves := MapGroupPreferences(spec.TLSGroups); len(curves) > 0 {
+		cfg.CurvePreferences = curves
+	}
+	return cfg
+}
+
+// assertTLSHandshakeSucceeds starts a TLS listener with serverCfg, dials it with
+// an operator-style client (InsecureSkipVerify, no other restrictions — matching
+// InsecureHTTPTransport), and fails the test if either side reports a handshake error.
+func assertTLSHandshakeSucceeds(t *testing.T, serverCfg *tls.Config) {
+	t.Helper()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatalf("failed to start TLS listener: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			serverErr <- fmt.Errorf("server accept: %w", acceptErr)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		serverErr <- conn.(*tls.Conn).Handshake()
+	}()
+
+	// Operator-style client: InsecureSkipVerify with no min-version / cipher / group
+	// restrictions — identical to the InsecureHTTPTransport used in util.go.
+	clientCfg := &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- intentional for test
+	conn, dialErr := tls.Dial("tcp", ln.Addr().String(), clientCfg)
+	if dialErr != nil {
+		t.Fatalf("client dial/handshake failed: %v", dialErr)
+	}
+	_ = conn.Close()
+
+	if se := <-serverErr; se != nil {
+		t.Fatalf("server handshake error: %v", se)
+	}
+}
+
+// generateTestRSACert returns a self-signed RSA-2048 certificate for use in tests.
+func generateTestRSACert(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return selfSignedTLSCert(t, key, &key.PublicKey)
+}
+
+// generateTestECDSACert returns a self-signed ECDSA P-256 certificate for use in tests.
+func generateTestECDSACert(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	return selfSignedTLSCert(t, key, &key.PublicKey)
+}
+
+func selfSignedTLSCert(t *testing.T, priv, pub interface{}) tls.Certificate {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "noobaa-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("x509.MarshalPKCS8PrivateKey: %v", err)
+	}
+	cert, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+	)
+	if err != nil {
+		t.Fatalf("tls.X509KeyPair: %v", err)
+	}
+	return cert
+}

--- a/pkg/util/tls_test.go
+++ b/pkg/util/tls_test.go
@@ -1,0 +1,206 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// tlsEnvWithValues returns an env slice that simulates a container that had TLS
+// config previously applied — i.e. the TLS vars already carry non-empty values.
+func tlsEnvWithValues() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "TLS_MIN_VERSION", Value: "TLSv1.2"},
+		{Name: "TLS_CIPHERS", Value: "ECDHE-RSA-AES128-GCM-SHA256"},
+		{Name: "TLS_GROUPS", Value: "X25519"},
+	}
+}
+
+func TestValidateTLSSpec(t *testing.T) {
+	minV12 := nbv1.VersionTLS12
+	minV13 := nbv1.VersionTLS13
+	minBad := nbv1.TLSProtocolVersion("TLSv9")
+
+	cases := []struct {
+		name    string
+		spec    *nbv1.TLSSecuritySpec
+		wantErr bool
+		errSubs []string // substrings expected in the error message
+	}{
+		{name: "nil spec", spec: nil, wantErr: false},
+		{name: "empty spec", spec: &nbv1.TLSSecuritySpec{}, wantErr: false},
+		// --- tlsMinVersion ---
+		{name: "valid minVersion TLSv1.2", spec: &nbv1.TLSSecuritySpec{TLSMinVersion: &minV12}, wantErr: false},
+		{name: "valid minVersion TLSv1.3", spec: &nbv1.TLSSecuritySpec{TLSMinVersion: &minV13}, wantErr: false},
+		{name: "unknown minVersion", spec: &nbv1.TLSSecuritySpec{TLSMinVersion: &minBad},
+			wantErr: true, errSubs: []string{"tlsMinVersion", "TLSv9"}},
+		// --- tlsCiphers ---
+		{name: "valid cipher", spec: &nbv1.TLSSecuritySpec{
+			TLSCiphers: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}}, wantErr: false},
+		{name: "unknown cipher", spec: &nbv1.TLSSecuritySpec{TLSCiphers: []string{"FAKE_CIPHER"}},
+			wantErr: true, errSubs: []string{"tlsCiphers", "FAKE_CIPHER"}},
+		{name: "mixed ciphers — unknown causes error", spec: &nbv1.TLSSecuritySpec{
+			TLSCiphers: []string{"TLS_AES_256_GCM_SHA384", "NOT_A_CIPHER"}},
+			wantErr: true, errSubs: []string{"NOT_A_CIPHER"}},
+		// --- tlsGroups ---
+		{name: "valid group", spec: &nbv1.TLSSecuritySpec{
+			TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupX25519}}, wantErr: false},
+		{name: "unknown group", spec: &nbv1.TLSSecuritySpec{
+			TLSGroups: []nbv1.TLSGroup{"UnknownGroup"}},
+			wantErr: true, errSubs: []string{"tlsGroups", "UnknownGroup"}},
+		{name: "PQC group alone — no InDefaultClients=true group", spec: &nbv1.TLSSecuritySpec{
+			TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupSecP256r1MLKEM768}},
+			wantErr: true, errSubs: []string{"InDefaultClients=true"}},
+		{name: "PQC group with standard fallback", spec: &nbv1.TLSSecuritySpec{
+			TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupSecP256r1MLKEM768, nbv1.TLSGroupX25519}},
+			wantErr: false},
+		// --- multiple errors reported together ---
+		{name: "unknown cipher + unknown group", spec: &nbv1.TLSSecuritySpec{
+			TLSCiphers: []string{"BAD_CIPHER"},
+			TLSGroups:  []nbv1.TLSGroup{"BadGroup"}},
+			wantErr: true, errSubs: []string{"BAD_CIPHER", "BadGroup"}},
+		{name: "unknown minVersion + unknown cipher", spec: &nbv1.TLSSecuritySpec{
+			TLSMinVersion: &minBad,
+			TLSCiphers:    []string{"BAD_CIPHER"}},
+			wantErr: true, errSubs: []string{"TLSv9", "BAD_CIPHER"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTLSSpec(tc.spec)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			for _, sub := range tc.errSubs {
+				if err == nil || !strings.Contains(err.Error(), sub) {
+					t.Errorf("expected error to contain %q, got: %v", sub, err)
+				}
+			}
+		})
+	}
+}
+
+
+func TestApplyTLSEnvVars(t *testing.T) {
+	minV12 := nbv1.VersionTLS12
+	minV13 := nbv1.VersionTLS13
+
+	cases := []struct {
+		name            string
+		disabled        string // value of DISABLE_TLS_SECURITY_CONFIG
+		spec            *nbv1.TLSSecuritySpec
+		expectedMin     string
+		expectedCiphers string
+		expectedGroups  string
+	}{
+		// --- DISABLE_TLS_SECURITY_CONFIG=true -----------------------------------------
+		// Previously-set values must be cleared even when a non-nil spec is provided,
+		// because the operator must be able to roll back TLS config by setting the flag.
+		{
+			name:     "disabled clears TLS vars regardless of non-nil spec",
+			disabled: "true",
+			spec: &nbv1.TLSSecuritySpec{
+				TLSMinVersion: &minV12,
+				TLSCiphers:    []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+				TLSGroups:     []nbv1.TLSGroup{nbv1.TLSGroupX25519},
+			},
+			expectedMin:     "",
+			expectedCiphers: "",
+			expectedGroups:  "",
+		},
+		{
+			name:            "disabled clears TLS vars when spec is nil",
+			disabled:        "true",
+			spec:            nil,
+			expectedMin:     "",
+			expectedCiphers: "",
+			expectedGroups:  "",
+		},
+		// --- DISABLE_TLS_SECURITY_CONFIG not set / false --------------------------------
+		{
+			name:        "enabled applies TLS min version TLSv1.2",
+			disabled:    "false",
+			spec:        &nbv1.TLSSecuritySpec{TLSMinVersion: &minV12},
+			expectedMin: "TLSv1.2",
+		},
+		{
+			name:        "enabled applies TLS min version TLSv1.3",
+			disabled:    "false",
+			spec:        &nbv1.TLSSecuritySpec{TLSMinVersion: &minV13},
+			expectedMin: "TLSv1.3",
+		},
+		{
+			name:            "enabled applies ciphers in OpenSSL format",
+			disabled:        "false",
+			spec:            &nbv1.TLSSecuritySpec{TLSCiphers: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}},
+			expectedCiphers: "ECDHE-RSA-AES128-GCM-SHA256",
+		},
+		{
+			name:     "enabled applies multiple ciphers colon-separated",
+			disabled: "false",
+			spec: &nbv1.TLSSecuritySpec{
+				TLSCiphers: []string{
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+				},
+			},
+			expectedCiphers: "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+		},
+		{
+			name:           "enabled applies groups colon-separated",
+			disabled:       "false",
+			spec:           &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{nbv1.TLSGroupX25519, nbv1.TLSGroupSecp256r1}},
+			expectedGroups: "X25519:secp256r1",
+		},
+		{
+			name:        "enabled with nil spec clears previously set TLS vars",
+			disabled:    "false",
+			spec:        nil,
+			expectedMin: "",
+		},
+		{
+			// ValidateTLSSpec (called in phase 1) would reject this before ApplyTLSEnvVars is reached.
+			// MapCiphersToOpenSSL skips unrecognized IANA names, so the result is empty.
+			name:            "unrecognized cipher is dropped by MapCiphersToOpenSSL",
+			disabled:        "false",
+			spec:            &nbv1.TLSSecuritySpec{TLSCiphers: []string{"UNKNOWN_CIPHER"}},
+			expectedCiphers: "",
+		},
+		{
+			// ValidateTLSSpec (called in phase 1) would reject this before ApplyTLSEnvVars is reached.
+			// ApplyTLSEnvVars passes group names through as-is without re-checking the map.
+			name:           "unknown TLS group is passed through as-is",
+			disabled:       "false",
+			spec:           &nbv1.TLSSecuritySpec{TLSGroups: []nbv1.TLSGroup{"UnknownGroup"}},
+			expectedGroups: "UnknownGroup",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(DisableTLSSecurityConfigEnv, tc.disabled)
+			env := tlsEnvWithValues()
+			ApplyTLSEnvVars(&env, tc.spec)
+
+			actual := map[string]string{}
+			for _, e := range env {
+				actual[e.Name] = e.Value
+			}
+
+			if actual["TLS_MIN_VERSION"] != tc.expectedMin {
+				t.Errorf("TLS_MIN_VERSION = %q, expected %q", actual["TLS_MIN_VERSION"], tc.expectedMin)
+			}
+			if actual["TLS_CIPHERS"] != tc.expectedCiphers {
+				t.Errorf("TLS_CIPHERS = %q, expected %q", actual["TLS_CIPHERS"], tc.expectedCiphers)
+			}
+			if actual["TLS_GROUPS"] != tc.expectedGroups {
+				t.Errorf("TLS_GROUPS = %q, expected %q", actual["TLS_GROUPS"], tc.expectedGroups)
+			}
+		})
+	}
+}

--- a/pkg/validations/noobaa_validation.go
+++ b/pkg/validations/noobaa_validation.go
@@ -23,7 +23,10 @@ func ValidateNoobaaUpdate(nb nbv1.NooBaa) error {
 	if err := validateNoobaaAutoscalerConfig(nb); err != nil {
 		return err
 	}
-	return validateNoobaaLoadbalancerSourceSubnets(nb)
+	if err := validateNoobaaLoadbalancerSourceSubnets(nb); err != nil {
+		return err
+	}
+	return validateTLSSecurity(nb)
 }
 
 // ValidateNoobaaCreation validates that the created Noobaa CR is valid
@@ -31,7 +34,20 @@ func ValidateNoobaaCreation(nb nbv1.NooBaa) error {
 	if err := validateNoobaaAutoscalerConfig(nb); err != nil {
 		return err
 	}
-	return validateNoobaaLoadbalancerSourceSubnets(nb)
+	if err := validateNoobaaLoadbalancerSourceSubnets(nb); err != nil {
+		return err
+	}
+	return validateTLSSecurity(nb)
+}
+
+func validateTLSSecurity(nb nbv1.NooBaa) error {
+	if nb.Spec.Security.APIServerSecurity == nil {
+		return nil
+	}
+	if err := util.ValidateTLSSpec(nb.Spec.Security.APIServerSecurity); err != nil {
+		return util.ValidationError{Msg: err.Error()}
+	}
+	return nil
 }
 
 // validateNoobaaLoadbalancerSourceSubnets validates that the Noobaa CR has


### PR DESCRIPTION
### Explain the changes
1. Passed the TLS env vars to noobaa-core pod as well
2. Added DISABLE_TLS_SECURITY_CONFIG env var for disabling this feature.
3. Added ApplyTLSEnvVars() function for applying env vars on both noobaa-core and endpoint and re-use the same code.
4. Added validation for TLS spec function that won't allow setting only groups that are not available as the defaults in node.js/go clients - unless every internal communication between noobaa components will break without changing the clients which is out of scope for this version.
operator -> MGMT/S3, CLI ->MGMT, MGMT -> S3, MGMT -> MGMT
6. Added unit tests for ApplyTLSEnvVars.

### Issues: Fixed #xxx / Gap #xxx
1. change options.go core image when the noobaa-core PR is merged.

### Testing Instructions:
1. Auto - `go test ./pkg/util/ -run TestApplyTLSEnvVars -v`
2. Manual - TBD see docs 
- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS security settings can be customized (min version, ciphers, groups) via environment variables; opt-out toggle added.

* **Improvements**
  * Centralized TLS env var handling and validation during reconcile to ensure consistent, validated configuration.

* **Tests**
  * Extensive unit and connectivity tests covering TLS combos, validation, and opt-out behavior.

* **Documentation**
  * Expanded TLS configuration guide and manual testing procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->