### PR TITLE
STS | Azure provider spec missing Region

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -45,6 +45,7 @@ const (
 	tenantIDEnvVar          string = "TENANTID"
 	subscriptionIDEnvVar    string = "SUBSCRIPTIONID"
 	resourcegroupIDEnvVar   string = "RESOURCEGROUP"
+	azureRegionEnvVar       string = "AZUREREGION"
 )
 
 // ReconcilePhaseCreating runs the reconcile phase
@@ -1087,6 +1088,11 @@ func (r *Reconciler) ReconcileAzureCredentials() error {
 	resourcegroupID := os.Getenv(resourcegroupIDEnvVar)
 	tenantID := os.Getenv(tenantIDEnvVar)
 	subscriptionID := os.Getenv(subscriptionIDEnvVar)
+	azureRegion := os.Getenv(azureRegionEnvVar)
+	// The OCP console does not prompt for a region, and the Azure CCO documentation hardcoded region
+	if azureRegion == "" {
+		azureRegion = "centralus"
+	}
 	r.Logger.Infof("Getting Azure : %s = %s", clientIDEnvVar, clientID)
 
 	r.Logger.Infof("Reconcile Azure STS with clientID: %s ", clientID)
@@ -1130,6 +1136,7 @@ func (r *Reconciler) ReconcileAzureCredentials() error {
 			azureProviderSpec.AzureClientID = clientID
 			azureProviderSpec.AzureTenantID = tenantID
 			azureProviderSpec.AzureSubscriptionID = subscriptionID
+			azureProviderSpec.AzureRegion = azureRegion
 		}
 		updatedProviderSpec, err := codec.EncodeProviderSpec(azureProviderSpec)
 		if err != nil {


### PR DESCRIPTION
### Explain the changes
1. Added Azure provider spec missing Region
2. The OCP console does not prompt for a region, and the Azure CCO documentation hardcoded region
			

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6456

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure credential requests now default to the Central US region when no region is specified. The selected region is applied to STS credential provisioning so cluster credential requests consistently target Central US by default, reducing misconfiguration and improving reliability when the region environment variable is not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->