### PR TITLE
Add runtime-configurable OPERATOR_LOG_LEVEL and reduce log noise

### DIFF
--- a/doc/operator-log-level.md
+++ b/doc/operator-log-level.md
@@ -1,0 +1,97 @@
+# Operator Log Level Configuration
+
+## Design
+
+Add a separate `OPERATOR_LOG_LEVEL` key in the `noobaa-config` ConfigMap to control
+operator log verbosity independently from core/endpoint pods. Changing this key does
+**not** trigger a pod rollout for core or endpoint pods.
+
+Additionally, noisy Update/Generic event predicate logs are demoted from Info to Debug
+level, so they only appear when `OPERATOR_LOG_LEVEL` is set to `debug`.
+
+### Supported Values
+
+| Value | logrus Level | Behavior |
+|-------|-------------|----------|
+| `warn` | WarnLevel | Minimal logging: only warnings and errors |
+| `info` | InfoLevel | **Default.** Create/Delete events, phase transitions, reconcile start/done |
+| `debug` | DebugLevel | Verbose: includes Update/Generic event predicates, all debug traces |
+
+### Config Source
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noobaa-config
+data:
+  NOOBAA_LOG_LEVEL: "default_level"   # controls core + endpoint pods
+  OPERATOR_LOG_LEVEL: "info"           # controls operator process only
+```
+
+`OPERATOR_LOG_LEVEL` is excluded from the ConfigMap hash used in pod-template
+annotations. The operator computes a hash of the ConfigMap data and stores it in
+the `noobaa.io/configmap-hash` annotation on core/endpoint pod templates. When
+this hash changes, Kubernetes detects a spec change and triggers a rolling
+restart. By filtering out `OPERATOR_LOG_LEVEL` before computing the hash,
+changing the operator's log verbosity does not cause core/endpoint pod rollouts.
+
+### CLI Flag
+
+A separate `--operator-log-level` flag controls the initial operator log level at startup,
+independent from `--debug-level` (which controls core/endpoint via `NOOBAA_LOG_LEVEL`).
+
+```bash
+noobaa-operator operator --operator-log-level=warn
+```
+
+Once the first reconcile completes and the ConfigMap is read, `OPERATOR_LOG_LEVEL` takes over.
+
+### How to Change at Runtime
+
+```bash
+# Quiet the operator (warnings and errors only)
+kubectl patch configmap noobaa-config -n <namespace> \
+  -p '{"data":{"OPERATOR_LOG_LEVEL":"warn"}}'
+
+# Verbose debugging
+kubectl patch configmap noobaa-config -n <namespace> \
+  -p '{"data":{"OPERATOR_LOG_LEVEL":"debug"}}'
+
+# Back to default
+kubectl patch configmap noobaa-config -n <namespace> \
+  -p '{"data":{"OPERATOR_LOG_LEVEL":"info"}}'
+```
+
+The operator picks up the change on the next reconcile cycle (no restart needed).
+Core and endpoint pods are **not** affected.
+
+### Example Output
+
+**Before the change** (`OPERATOR_LOG_LEVEL` = `info`, Update events logged at Info):
+
+```
+time="2025-10-10T13:20:54Z" level=info msg="Update event detected for noobaa (openshift-storage), queuing Reconcile"
+time="2025-10-10T13:20:54Z" level=info msg="Update event detected for noobaa-default-backing-store (openshift-storage), queuing Reconcile"
+```
+
+**After the change** (`OPERATOR_LOG_LEVEL` = `info`, Update events demoted to Debug — hidden):
+
+```
+time="2025-10-10T13:20:54Z" level=info msg="Create event detected for noobaa (openshift-storage), queuing Reconcile"
+time="2025-10-10T13:20:54Z" level=info msg="Delete event detected for noobaa-default-backing-store (openshift-storage), queuing Reconcile"
+```
+
+Only Create and Delete events appear at Info level. The frequent Update/Generic
+events are now Debug-only and no longer visible unless `OPERATOR_LOG_LEVEL` is
+set to `debug`.
+
+**With `OPERATOR_LOG_LEVEL` = `debug`** (all events visible):
+
+```
+time="2025-10-10T13:20:54Z" level=info  msg="Create event detected for noobaa (openshift-storage), queuing Reconcile"
+time="2025-10-10T13:20:54Z" level=debug msg="Update event detected for noobaa (openshift-storage), queuing Reconcile"
+time="2025-10-10T13:20:54Z" level=debug msg="Update event detected for noobaa-default-backing-store (openshift-storage), queuing Reconcile"
+time="2025-10-10T13:20:57Z" level=info  msg="Delete event detected for noobaa-default-backing-store (openshift-storage), queuing Reconcile"
+time="2025-10-10T13:20:57Z" level=debug msg="Generic event detected for noobaa (openshift-storage), queuing Reconcile"
+```

--- a/pkg/operator/manager.go
+++ b/pkg/operator/manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/version"
-	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 
@@ -39,11 +38,7 @@ var (
 
 // RunOperator is the main function of the operator but it is called from a cobra.Command
 func RunOperator(cmd *cobra.Command, args []string) {
-	if options.DebugLevel == "warn" {
-		util.InitLogger(logrus.WarnLevel)
-	} else {
-		util.InitLogger(logrus.DebugLevel)
-	}
+	util.InitLogger(util.OperatorLogLevel(options.OperatorLogLevel))
 	version.RunVersion(cmd, args)
 	// Probe address from CLI flag (defaults to :8081)
 	probeAddr := os.Getenv("HEALTH_PROBE_BIND_ADDRESS")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -117,6 +117,9 @@ var PostgresSSLCert = ""
 // DebugLevel can be used to override the default debug level
 var DebugLevel = "default_level"
 
+// OperatorLogLevel controls the operator process log verbosity (warn/info/debug)
+var OperatorLogLevel = "info"
+
 // PVPoolDefaultStorageClass is used for PVC's allocation for the noobaa server data
 // it can be overridden for testing or different PV providers.
 var PVPoolDefaultStorageClass = ""
@@ -301,6 +304,10 @@ func init() {
 	FlagSet.StringVar(
 		&DebugLevel, "debug-level",
 		DebugLevel, "The type of debug sets that the system prints (all, nsfs, warn, default_level)",
+	)
+	FlagSet.StringVar(
+		&OperatorLogLevel, "operator-log-level",
+		OperatorLogLevel, "The operator process log verbosity (warn, info, debug)",
 	)
 	FlagSet.StringVar(
 		&PVPoolDefaultStorageClass, "pv-pool-default-storage-class",

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -133,11 +133,10 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 		return err
 	}
 
-	if r.CoreAppConfig.Data["NOOBAA_LOG_LEVEL"] == "warn" {
-		r.Logger.Infof("Setting operator log level to Warn")
-		util.InitLogger(logrus.WarnLevel)
-	} else {
-		util.InitLogger(logrus.DebugLevel)
+	newLevel := util.OperatorLogLevel(r.CoreAppConfig.Data["OPERATOR_LOG_LEVEL"])
+	if logrus.GetLevel() != newLevel {
+		r.Logger.Warnf("Setting operator log level to %s", newLevel)
+		util.InitLogger(newLevel)
 	}
 
 	// A failure to discover OAuth endpoints should not fail the entire reconcile phase.
@@ -1624,6 +1623,7 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 		"NOOBAA_METRICS_AUTH_ENABLED":  "true",
 		"NOOBAA_VERSION_AUTH_ENABLED":  "true",
 		"ENDPOINT_SYSTEM_STORE_SOURCE": "core", // by default, load the system store in the endpoint from the core instead of the DB
+		"OPERATOR_LOG_LEVEL":           "info",
 	}
 	for key, value := range DefaultConfigMapData {
 		if _, ok := r.CoreAppConfig.Data[key]; !ok {
@@ -1634,7 +1634,16 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 	if r.CoreAppConfig.Annotations == nil {
 		r.CoreAppConfig.Annotations = make(map[string]string)
 	}
-	r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"] = util.GetCmDataHash(r.CoreAppConfig.Data)
+	// Exclude operator-only keys from the hash so that changing them
+	// does not trigger a rolling restart of core/endpoint pods.
+	operatorOnlyKeys := map[string]bool{"OPERATOR_LOG_LEVEL": true}
+	coreData := make(map[string]string, len(r.CoreAppConfig.Data))
+	for k, v := range r.CoreAppConfig.Data {
+		if !operatorOnlyKeys[k] {
+			coreData[k] = v
+		}
+	}
+	r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"] = util.GetCmDataHash(coreData)
 
 	return nil
 }

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -1422,13 +1422,14 @@ func CheckPostgresURL(postgresDbURL string) error {
 
 // LoadConfigMapFromFlags loads a config-map with values from the cli flags, if provided.
 func LoadConfigMapFromFlags() {
-	if options.DebugLevel != "default_level" {
+	if options.DebugLevel != "default_level" || options.OperatorLogLevel != "info" {
 		cm := util.KubeObject(bundle.File_deploy_internal_configmap_empty_yaml).(*corev1.ConfigMap)
 		cm.Namespace = options.Namespace
 		cm.Name = "noobaa-config"
 
 		DefaultConfigMapData := map[string]string{
-			"NOOBAA_LOG_LEVEL": options.DebugLevel,
+			"NOOBAA_LOG_LEVEL":   options.DebugLevel,
+			"OPERATOR_LOG_LEVEL": options.OperatorLogLevel,
 		}
 
 		cm.Data = DefaultConfigMapData

--- a/pkg/util/predicates.go
+++ b/pkg/util/predicates.go
@@ -151,7 +151,7 @@ func (p LogEventsPredicate) Delete(e event.DeleteEvent) bool {
 // Update implements the update event trap for LogEventsPredicate
 func (p LogEventsPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld != nil {
-		logrus.Infof("Update event detected for %s (%s), queuing Reconcile",
+		logrus.Debugf("Update event detected for %s (%s), queuing Reconcile",
 			e.ObjectOld.GetName(), e.ObjectOld.GetNamespace())
 	}
 	return true
@@ -160,7 +160,7 @@ func (p LogEventsPredicate) Update(e event.UpdateEvent) bool {
 // Generic implements the generic event trap for LogEventsPredicate
 func (p LogEventsPredicate) Generic(e event.GenericEvent) bool {
 	if e.Object != nil {
-		logrus.Infof("Generic event detected for %s (%s), queuing Reconcile",
+		logrus.Debugf("Generic event detected for %s (%s), queuing Reconcile",
 			e.Object.GetName(), e.Object.GetNamespace())
 	}
 	return true

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -902,6 +902,20 @@ func InitLogger(lvl logrus.Level) {
 	})
 }
 
+// OperatorLogLevel maps a string log level name to a logrus.Level.
+// Accepted values: "warn", "info", "debug".
+// Any unrecognized value defaults to InfoLevel.
+func OperatorLogLevel(level string) logrus.Level {
+	switch level {
+	case "warn":
+		return logrus.WarnLevel
+	case "debug":
+		return logrus.DebugLevel
+	default:
+		return logrus.InfoLevel
+	}
+}
+
 // Logger returns a default logger
 func Logger() *logrus.Entry {
 	return log


### PR DESCRIPTION
## Summary

- Demote Update/Generic event predicate logs from Info to Debug level, eliminating the main source of log noise at default verbosity
- Add separate `OPERATOR_LOG_LEVEL` key in `noobaa-config` ConfigMap — controls operator log level without triggering core/endpoint pod rollouts
- Supported levels: `warn`, `info` (default), `debug`
- Changes applied at runtime via reconcile, no operator restart needed

Fixes: https://redhat.atlassian.net/browse/DFBUGS-4372

## Usage

```bash
kubectl patch configmap noobaa-config -n <namespace> -p '{"data":{"OPERATOR_LOG_LEVEL":"warn"}}'
```

## Test plan

- [x] Verified `OPERATOR_LOG_LEVEL: warn` suppresses all Info/Debug messages
- [x] Verified changing `OPERATOR_LOG_LEVEL` does not cause core/endpoint pod rollouts
- [x] Verified `NOOBAA_LOG_LEVEL` still works independently for core/endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator log level is independently configurable via a new startup flag and OPERATOR_LOG_LEVEL in the config; changes take effect after the next reconcile without restarting pods
  * Operator config changes do not trigger core/endpoint pod rollouts (operator key excluded from rollout hash)

* **Behavior Changes**
  * Update/Generic event logs are quieter by default (demoted to debug) unless operator log level is set to debug

* **Documentation**
  * Added docs describing OPERATOR_LOG_LEVEL, supported values (warn, info, debug) and runtime examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-operator/pull/1900)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->