### PR TITLE
[Backport into 5.22] STS | Azure provider spec missing Region

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -45,6 +45,7 @@ const (
 	tenantIDEnvVar          string = "TENANTID"
 	subscriptionIDEnvVar    string = "SUBSCRIPTIONID"
 	resourcegroupIDEnvVar   string = "RESOURCEGROUP"
+	azureRegionEnvVar       string = "AZUREREGION"
 )
 
 // ReconcilePhaseCreating runs the reconcile phase
@@ -1087,6 +1088,11 @@ func (r *Reconciler) ReconcileAzureCredentials() error {
 	resourcegroupID := os.Getenv(resourcegroupIDEnvVar)
 	tenantID := os.Getenv(tenantIDEnvVar)
 	subscriptionID := os.Getenv(subscriptionIDEnvVar)
+	azureRegion := os.Getenv(azureRegionEnvVar)
+	// The OCP console does not prompt for a region, and the Azure CCO documentation hardcoded region
+	if azureRegion == "" {
+		azureRegion = "centralus"
+	}
 	r.Logger.Infof("Getting Azure : %s = %s", clientIDEnvVar, clientID)
 
 	r.Logger.Infof("Reconcile Azure STS with clientID: %s ", clientID)
@@ -1130,6 +1136,7 @@ func (r *Reconciler) ReconcileAzureCredentials() error {
 			azureProviderSpec.AzureClientID = clientID
 			azureProviderSpec.AzureTenantID = tenantID
 			azureProviderSpec.AzureSubscriptionID = subscriptionID
+			azureProviderSpec.AzureRegion = azureRegion
 		}
 		updatedProviderSpec, err := codec.EncodeProviderSpec(azureProviderSpec)
 		if err != nil {


### PR DESCRIPTION
### Explain the changes
[Backport into 5.22] STS | Azure provider spec missing Region

(cherry picked from commit 104a2b9d9d0c69a1caf9f63cf71a7b07e09d0401)
