### PR TITLE
Doc | Backingstore Doc Update Permission

### DIFF
--- a/doc/backing-store-crd.md
+++ b/doc/backing-store-crd.md
@@ -32,6 +32,11 @@ Also note that, if possible and applicable, omitting the `access-key` and `secre
 If the user opts to use the CLI's `--secret-name` option, or to apply a YAML, please see [Store Secret Creation](store-connection-secrets.md).
 In case of YAML application, the value under `secret.namespace` needs to point to the secret's namespace.
 
+# Cloud Storage Permissions
+To successfully initialize a BackingStore, the provided cloud credentials must have sufficient permissions to manage the target bucket and list all buckets within the account. This listing is required for NooBaa’s external connection validation.
+
+If permissions are insufficient, the BackingStore will remain in the `Creating` phase with a `TemporaryError`. After several retry attempts, it will ultimately transition to the `Rejected` phase.
+
 ## AWS S3
 Uses the S3 API for storing encrypted chunks of data in AWS buckets
 ```shell
@@ -53,6 +58,10 @@ spec:
     targetBucket: <>
   type: aws-s3
 ```
+
+Permissions: the user need to have permissions in AWS account for AWS S3 service:
+1. Account level: `s3:ListAllMyBuckets`
+2. Bucket level: grant access on both `arn:aws:s3:::<target-bucket>` and `arn:aws:s3:::<target-bucket>/*` (bucket and object ARNs are both required).
 
 ## AWS-S3 Security Token Service (STS)
 Similarly to `AWS-S3` this backingstore uses the S3 API for storing encrypted chunks of data in AWS buckets.
@@ -155,6 +164,14 @@ spec:
     targetBucket: <>
   type: google-cloud-storage
 ```
+
+The `credentials.json` is an example path to the Google Cloud service account JSON key. Service account keys are used to authenticate a service account to Google Cloud APIs. When you create a key, you download the private key, which you can then use to authenticate your application.  
+
+Permissions: the service account should have the `storage.buckets.list` permission. You can grant it by assigning project-level roles, for example:
+- Combination of the Browser and Storage Admin roles.
+  - `Browser` role: provides the `storage.buckets.list` permission.
+  - `Storage Admin` role: provides full control over buckets and objects.
+- The `Owner` role (for development; not recommended for production environments).
 
 ## Azure Blob Storage
 Uses the Azure Blob API for storing encrypted chunks of data in an Azure container

--- a/doc/store-connection-secrets.md
+++ b/doc/store-connection-secrets.md
@@ -35,6 +35,14 @@ data:
   GoogleServiceAccountPrivateKeyJson: <>
 ```
 
+To create the secret using `kubectl` command from `credentials.json` path:
+
+```bash
+kubectl create secret generic <SECRET NAME> \
+  --from-file=GoogleServiceAccountPrivateKeyJson=<PATH TO credentials.json> \
+  -n <NAMESPACE>
+```
+
 ## Azure
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
### Explain the changes
1. Update the needed permissions on the account with AWS S3 and the project in Google Cloud Storage.
2. Added a command to create the needed Secret when using GCP.

### Issues: 
1. none

### Testing Instructions:
1. none

- [X] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Cloud Storage Permissions guidance: required cloud credential capabilities, validation behavior when permissions are insufficient (Creating → TemporaryError → Rejected), and explicit AWS S3 permission examples including account- and bucket-level permissions.
  * Expanded Google Cloud Storage guidance: clarified service account key usage, required storage.buckets.list permission and example project roles, and added a kubectl example for creating the credential secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->