### PR TITLE
fix(system): clear POSTGRES_HOST in ExternalPgSecret mode

### DIFF
--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -512,8 +512,9 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 		case "POSTGRES_HOST":
 			if r.shouldReconcileStandaloneDB() {
 				c.Env[j].Value = r.NooBaaPostgresDB.Name + "-0." + r.NooBaaPostgresDB.Spec.ServiceName + "." + r.NooBaaPostgresDB.Namespace + ".svc"
-			} else if r.shouldReconcileCNPGCluster() {
-				// clear env. it will be passed by mounting the secret
+			} else {
+				// CNPG and external-pg both ship the host via mounted secret;
+				// clear the default so noobaa-core reads POSTGRES_HOST_PATH
 				c.Env[j].Value = ""
 				c.Env[j].ValueFrom = nil
 			}


### PR DESCRIPTION
### Describe the Problem

When a `NooBaa` CR uses `spec.externalPgSecret` to connect to an externally
managed PostgreSQL database, the `POSTGRES_HOST` env var on the resulting
`noobaa-core` StatefulSet and `noobaa-endpoint` Deployment keeps the
hard-coded default `"noobaa-db-pg-0.noobaa-db-pg"` baked into
`deploy/internal/statefulset-core.yaml` (line 121-122). As a result the
core process tries to connect to a non-existent host and the system never
comes up against the external DB.

The `setDesiredCoreEnv()` switch in `pkg/system/phase2_creating.go`
(lines 513-520) already overrides `POSTGRES_HOST` for the
`shouldReconcileStandaloneDB()` and `shouldReconcileCNPGCluster()` cases,
but has no branch for `r.NooBaa.Spec.ExternalPgSecret != nil`, leaving the
YAML default untouched.

A symptom of this bug is users having to manually patch the workloads
post-install (e.g. `kubectl set env sts/noobaa-core POSTGRES_HOST=<real-host>`),
which is racy because the operator re-applies the default at every reconcile.

### Explain the changes

1. Added an `else if r.NooBaa.Spec.ExternalPgSecret != nil` branch to the
   `POSTGRES_HOST` case in `setDesiredCoreEnv()`. The branch mirrors the
   existing CNPG behavior: `Value` and `ValueFrom` are cleared so the core
   process falls back to reading the host from `POSTGRES_HOST_PATH`
   (`/etc/postgres-secret/host`), which is already wired in the same
   function (lines 591-592) and mounted from the external secret in
   `phase2_creating.go` (lines 706-710) for the core and
   `phase4_configuring.go` (lines 563-569) for the endpoint.

### Issues: Fixed #1909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved host configuration conflicts between managed and external PostgreSQL setups by clearing overridden host entries when the system is not managing the standalone database, ensuring the application reads the database host from the mounted secret.
  * Clarified configuration behavior so both managed and external database deployments consistently provide the host via secrets, reducing misconfiguration risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->