### PR TITLE
Fixed Stale External Connection on Endpoint Change

### DIFF
--- a/pkg/admission/validate_namespacestore.go
+++ b/pkg/admission/validate_namespacestore.go
@@ -81,6 +81,11 @@ func (nsv *ResourceValidator) ValidateUpdateNS() {
 		return
 	}
 
+	if err := validations.ValidateNSEndpointChange(*ns, *oldNS); err != nil && util.IsValidationError(err) {
+		nsv.SetValidationResult(false, err.Error())
+		return
+	}
+
 	if err := validations.ValidateNamespaceStore(ns); err != nil && util.IsValidationError(err) {
 		nsv.SetValidationResult(false, err.Error())
 		return

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -62,9 +62,9 @@ type Reconciler struct {
 	Secret         *corev1.Secret
 	ServiceAccount *corev1.ServiceAccount
 
-	SystemInfo             *nb.SystemInfo
-	ExternalConnectionInfo *nb.ExternalConnectionInfo
-	NamespaceResourceinfo  *nb.NamespaceResourceInfo
+	SystemInfo              *nb.SystemInfo
+	ExternalConnectionInfo  *nb.ExternalConnectionInfo
+	NamespaceResourceinfo   *nb.NamespaceResourceInfo
 
 	AddExternalConnectionParams    *nb.AddExternalConnectionParams
 	CreateNamespaceResourceParams  *nb.CreateNamespaceResourceParams
@@ -384,17 +384,22 @@ func (r *Reconciler) ReconcileDeletion(systemFound bool) error {
 			}
 		}
 
-		if r.ExternalConnectionInfo != nil {
-			// TODO we cannot assume we are the only one using this connection...
-			err := r.NBClient.DeleteExternalConnectionAPI(nb.DeleteExternalConnectionParams{Name: r.ExternalConnectionInfo.Name})
+		if r.NBClient != nil && r.NamespaceStore.Spec.Type != nbv1.NSStoreTypeNSFS {
+			hasOwned, err := r.hasOwnedExternalConnection()
 			if err != nil {
-				if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
-					if rpcErr.RPCCode != "IN_USE" {
+				return err
+			}
+			if hasOwned {
+				err := r.NBClient.DeleteExternalConnectionAPI(nb.DeleteExternalConnectionParams{Name: r.NamespaceStore.Name})
+				if err != nil {
+					if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
+						if rpcErr.RPCCode != "IN_USE" {
+							return err
+						}
+						r.Logger.Warnf("DeleteExternalConnection cannot complete because it is IN_USE %q", r.NamespaceStore.Name)
+					} else {
 						return err
 					}
-					r.Logger.Warnf("DeleteExternalConnection cannot complete because it is IN_USE %q", r.ExternalConnectionInfo.Name)
-				} else {
-					return err
 				}
 			}
 		}
@@ -402,6 +407,22 @@ func (r *Reconciler) ReconcileDeletion(systemFound bool) error {
 
 	r.Logger.Infof("NamepsaceStore %q remove finalizer", r.NamespaceStore.Name)
 	return r.FinalizeDeletion()
+}
+
+// hasOwnedExternalConnection checks list_accounts for an external connection named like this NamespaceStore
+func (r *Reconciler) hasOwnedExternalConnection() (bool, error) {
+	accountsList, err := r.NBClient.ListAccountsAPI(nb.ListAccountsParams{})
+	if err != nil {
+		return false, err
+	}
+	for _, account := range accountsList.Accounts {
+		for i := range account.ExternalConnections.Connections {
+			if account.ExternalConnections.Connections[i].Name == r.NamespaceStore.Name {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // FinalizeDeletion removed the finalizer and updates in order to let the namespace-store get reclaimed by kubernetes
@@ -438,6 +459,10 @@ func (r *Reconciler) ReadSystemInfo() error {
 			r.NamespaceResourceinfo = nsr
 			break
 		}
+	}
+
+	if r.NamespaceStore.DeletionTimestamp != nil {
+		return nil
 	}
 
 	nsr := r.NamespaceResourceinfo
@@ -493,8 +518,12 @@ func (r *Reconciler) ReadSystemInfo() error {
 		account := &r.SystemInfo.Accounts[i]
 		for j := range account.ExternalConnections.Connections {
 			c := &account.ExternalConnections.Connections[j]
+			endpointsEqual, epErr := validations.EndpointsEquivalent(c.Endpoint, conn.Endpoint)
+			if epErr != nil {
+				return epErr
+			}
 			if c.EndpointType == conn.EndpointType &&
-				c.Endpoint == conn.Endpoint &&
+				endpointsEqual &&
 				c.Identity == string(conn.Identity) {
 				r.ExternalConnectionInfo = c
 				conn.Name = c.Name
@@ -752,7 +781,7 @@ func (r *Reconciler) fixAlternateKeysNames() {
 // ReconcileExternalConnection handles the external connection using noobaa api
 func (r *Reconciler) ReconcileExternalConnection() error {
 
-	if r.ExternalConnectionInfo != nil {
+	if r.ExternalConnectionInfo != nil && r.UpdateExternalConnectionParams == nil {
 		return nil
 	}
 

--- a/pkg/namespacestore/validation_test.go
+++ b/pkg/namespacestore/validation_test.go
@@ -184,6 +184,52 @@ func TestNamespaceStoreGoogleCloudStorage(t *testing.T) {
 	AssertError(t, err, "Empty target bucket should be denied")
 }
 
+func TestValidateNSEndpointChange(t *testing.T) {
+	// S3Compatible: endpoint change should be denied
+	oldNS := getDefaultS3CompatibleNsStore()
+	newNS := getDefaultS3CompatibleNsStore()
+	newNS.Spec.S3Compatible.Endpoint = "https://different-endpoint.example.com"
+	err := validations.ValidateNSEndpointChange(newNS, oldNS)
+	AssertError(t, err, "S3Compatible endpoint change should be denied")
+
+	// S3Compatible: only secret changed, endpoint same — should be allowed
+	oldNS = getDefaultS3CompatibleNsStore()
+	newNS = getDefaultS3CompatibleNsStore()
+	newNS.Spec.S3Compatible.Secret.Name = "new-secret"
+	err = validations.ValidateNSEndpointChange(newNS, oldNS)
+	AssertNotError(t, err, "S3Compatible secret-only change should be allowed")
+
+	// S3Compatible: canonical vs non-canonical endpoint with secret rotation — should be allowed
+	oldNS = getDefaultS3CompatibleNsStore()
+	oldNS.Spec.S3Compatible.Endpoint = "minio.s3-a.svc:9000"
+	newNS = getDefaultS3CompatibleNsStore()
+	newNS.Spec.S3Compatible.Endpoint = "https://minio.s3-a.svc:9000"
+	newNS.Spec.S3Compatible.Secret.Name = "new-secret"
+	err = validations.ValidateNSEndpointChange(newNS, oldNS)
+	AssertNotError(t, err, "S3Compatible secret rotation with equivalent endpoints should be allowed")
+
+	// S3Compatible: nil spec on either side — should not panic and should be allowed
+	oldNS = getDefaultS3CompatibleNsStore()
+	oldNS.Spec.S3Compatible = nil
+	newNS = getDefaultS3CompatibleNsStore()
+	err = validations.ValidateNSEndpointChange(newNS, oldNS)
+	AssertNotError(t, err, "nil old S3Compatible spec should not cause error or panic")
+
+	// IBMCos: endpoint change should be denied
+	oldIBM := getDefaultIBMCosNsStore()
+	newIBM := getDefaultIBMCosNsStore()
+	newIBM.Spec.IBMCos.Endpoint = "https://different-ibm-endpoint.example.com"
+	err = validations.ValidateNSEndpointChange(newIBM, oldIBM)
+	AssertError(t, err, "IBMCos endpoint change should be denied")
+
+	// IBMCos: only secret changed, endpoint same — should be allowed
+	oldIBM = getDefaultIBMCosNsStore()
+	newIBM = getDefaultIBMCosNsStore()
+	newIBM.Spec.IBMCos.Secret.Name = "new-secret"
+	err = validations.ValidateNSEndpointChange(newIBM, oldIBM)
+	AssertNotError(t, err, "IBMCos secret-only change should be allowed")
+}
+
 func AssertNotError(t *testing.T, err error, format string, a ...interface{}) {
 	if err != nil {
 		msg := fmt.Sprintf(format, a...)

--- a/pkg/validations/namespacestore_validations.go
+++ b/pkg/validations/namespacestore_validations.go
@@ -281,6 +281,18 @@ func ValidateEndPoint(endPointPointer *string) error {
 	return nil
 }
 
+// EndpointsEquivalent validates whether two endpoint strings are equivalent after normalization
+func EndpointsEquivalent(endpointA, endpointB string) (bool, error) {
+	a, b := endpointA, endpointB
+	if err := ValidateEndPoint(&a); err != nil {
+		return false, err
+	}
+	if err := ValidateEndPoint(&b); err != nil {
+		return false, err
+	}
+	return a == b, nil
+}
+
 // ValidateNSEmptySecretName validates a secret name is provided for cloud namespacestore
 func ValidateNSEmptySecretName(ns nbv1.NamespaceStore) error {
 	switch ns.Spec.Type {
@@ -427,6 +439,37 @@ func ValidateNSArchiveSpec(nsStore nbv1.NamespaceStore) error {
 	if nsStore.Spec.S3Compatible == nil {
 		return util.ValidationError{
 			Msg: "S3Compatible spec must be provided when archive is enabled",
+		}
+	}
+	return nil
+}
+
+// ValidateNSEndpointChange validates the user is not trying to update the namespacestore endpoint
+func ValidateNSEndpointChange(ns nbv1.NamespaceStore, oldNs nbv1.NamespaceStore) error {
+	switch ns.Spec.Type {
+	case nbv1.NSStoreTypeS3Compatible:
+		if oldNs.Spec.S3Compatible != nil && ns.Spec.S3Compatible != nil {
+			equal, err := EndpointsEquivalent(oldNs.Spec.S3Compatible.Endpoint, ns.Spec.S3Compatible.Endpoint)
+			if err != nil {
+				return err
+			}
+			if !equal {
+				return util.ValidationError{
+					Msg: "Changing a NamespaceStore endpoint is unsupported; delete and re-create the NamespaceStore",
+				}
+			}
+		}
+	case nbv1.NSStoreTypeIBMCos:
+		if oldNs.Spec.IBMCos != nil && ns.Spec.IBMCos != nil {
+			equal, err := EndpointsEquivalent(oldNs.Spec.IBMCos.Endpoint, ns.Spec.IBMCos.Endpoint)
+			if err != nil {
+				return err
+			}
+			if !equal {
+				return util.ValidationError{
+					Msg: "Changing a NamespaceStore endpoint is unsupported; delete and re-create the NamespaceStore",
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
### Describe the Problem
Updating a NamespaceStore's endpoint leaves the internal NooBaa connection stale — the operator reports "Credentials are not valid", the connection is not cleaned up on deletion (orphaned), and re-creating the store fails with "Connection name already exists".

### Explain the changes
1. Admission webhook (`validate_namespacestore.go`): Reject endpoint mutations on UPDATE  with: *"Changing a NamespaceStore endpoint is unsupported; delete and re-create the NamespaceStore"*. 
2. Owned connection cleanup on delete(`reconciler.go`): Use `list_accounts` to check whether this store owns an external connection (name == CR name). If yes, call `delete_external_connection`. If no (shared connection reuse), skip — shared connections are not deleted.
3. Delete path (`reconciler.go`): `ReadSystemInfo` returns early during deletion after loading the namespace resource — no endpoint/connection setup on delete.
4. Secret rotation(`reconciler.go`): Allow `update_external_connection` when credentials change but the connection already exists.


<img width="2574" height="380" alt="image" src="https://github.com/user-attachments/assets/e157c8c3-6ea4-4d5f-8b5a-cb05182c0429" />

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6006

### Testing Instructions:
1. Create a NamespaceStore pointing to endpoint A, verify it reaches Ready
3. Try to update the endpoint to B  — verify it is rejected with `"Changing a NamespaceStore endpoint is unsupported"`
4. Delete the NamespaceStore — verify the internal connection is removed 
5. Re-create the NamespaceStore pointing to endpoint B — verify it reaches Ready with no `"Connection name already exists"` error
6. Rotate credentials (same endpoint, new secret) — verify UpdateExternalConnectionAPI is called and store stays Ready
7. Delete a store that reuses a shared connection — verify the shared connection is not removed.


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updates that change storage endpoints for S3-compatible and IBM COS namespace stores are now rejected; to change an endpoint, delete and recreate the namespace store.

* **Behavior**
  * External connection handling improved: identity/credential updates can be applied without recreate when safe; endpoint mismatches still require delete + recreate. Admission validation now rejects invalid endpoint-change updates earlier.

* **Tests**
  * Added tests covering endpoint-change validation and nil-spec scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->