### PR TITLE
silence log noise for Fusion HCI StorageClass not-found

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -1119,24 +1120,42 @@ func SetErrorCondition(conditions *[]conditionsv1.Condition, reason string, mess
 	})
 }
 
+var (
+	awsPlatformOnce         sync.Once
+	awsPlatform             bool
+	azurePlatformNonGovOnce sync.Once
+	azurePlatformNonGov     bool
+	gcpPlatformOnce         sync.Once
+	gcpPlatform             bool
+	ibmPlatformOnce         sync.Once
+	ibmPlatform             bool
+	fusionHCIWithScaleOnce  sync.Once
+	fusionHCIWithScale      bool
+)
+
 // IsAWSPlatform returns true if this cluster is running on AWS
 func IsAWSPlatform() bool {
-	nodesList := &corev1.NodeList{}
-	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
-		Panic(fmt.Errorf("failed to list kubernetes nodes"))
-	}
-	isAWS := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "aws")
-	return isAWS
+	awsPlatformOnce.Do(func() {
+		nodesList := &corev1.NodeList{}
+		if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
+			Panic(fmt.Errorf("failed to list kubernetes nodes"))
+		}
+		awsPlatform = strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "aws")
+	})
+	return awsPlatform
 }
 
 // IsFusionHCIWithScale checks if the noobaa is deployed on HCI platform and
 // using Spectrum Scale storage.
 func IsFusionHCIWithScale() bool {
-	sc := &storagev1.StorageClass{
-		TypeMeta:   metav1.TypeMeta{Kind: "StorageClass"},
-		ObjectMeta: metav1.ObjectMeta{Name: "ibm-spectrum-scale-csi-storageclass-version2"},
-	}
-	return KubeCheck(sc)
+	fusionHCIWithScaleOnce.Do(func() {
+		sc := &storagev1.StorageClass{
+			TypeMeta:   metav1.TypeMeta{Kind: "StorageClass"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ibm-spectrum-scale-csi-storageclass-version2"},
+		}
+		fusionHCIWithScale = KubeCheckQuiet(sc)
+	})
+	return fusionHCIWithScale
 }
 
 // IsSTSClusterBS returns true if it is running on an STS cluster
@@ -1173,50 +1192,58 @@ func IsAzureSTSClusterNS(ns *nbv1.NamespaceStore) bool {
 
 // IsAzurePlatformNonGovernment returns true if this cluster is running on Azure and also not on azure government\DOD cloud
 func IsAzurePlatformNonGovernment() bool {
-	nodesList := &corev1.NodeList{}
-	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
-		Panic(fmt.Errorf("failed to list kubernetes nodes"))
-	}
-	const regionLabel string = "topology.kubernetes.io/region"
-	node := nodesList.Items[0]
-	isAzure := strings.HasPrefix(node.Spec.ProviderID, "azure")
-	if isAzure {
-		nodeLabels := node.GetLabels()
-		region, ok := nodeLabels[regionLabel]
-		if !ok {
-			log.Warnf("did not find the expected label %q on node %q to determine azure region", regionLabel, node.Name)
-		} else if strings.HasPrefix(region, "usgov") || strings.HasPrefix(region, "usdod") {
-			log.Infof("identified the region [%q] as an Azure gov/DOD region", region)
-			return false
+	azurePlatformNonGovOnce.Do(func() {
+		nodesList := &corev1.NodeList{}
+		if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
+			Panic(fmt.Errorf("failed to list kubernetes nodes"))
 		}
-	}
-	return isAzure
+		const regionLabel string = "topology.kubernetes.io/region"
+		node := nodesList.Items[0]
+		isAzure := strings.HasPrefix(node.Spec.ProviderID, "azure")
+		if isAzure {
+			nodeLabels := node.GetLabels()
+			region, ok := nodeLabels[regionLabel]
+			if !ok {
+				log.Warnf("did not find the expected label %q on node %q to determine azure region", regionLabel, node.Name)
+			} else if strings.HasPrefix(region, "usgov") || strings.HasPrefix(region, "usdod") {
+				log.Infof("identified the region [%q] as an Azure gov/DOD region", region)
+				isAzure = false
+			}
+		}
+		azurePlatformNonGov = isAzure
+	})
+	return azurePlatformNonGov
 }
 
 // IsGCPPlatform returns true if this cluster is running on GCP
 func IsGCPPlatform() bool {
-	nodesList := &corev1.NodeList{}
-	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
-		Panic(fmt.Errorf("failed to list kubernetes nodes"))
-	}
-	isGCP := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "gce")
-	return isGCP
+	gcpPlatformOnce.Do(func() {
+		nodesList := &corev1.NodeList{}
+		if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
+			Panic(fmt.Errorf("failed to list kubernetes nodes"))
+		}
+		gcpPlatform = strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "gce")
+	})
+	return gcpPlatform
 }
 
 // IsIBMPlatform returns true if this cluster is running on IBM Cloud
 func IsIBMPlatform() bool {
-	nodesList := &corev1.NodeList{}
-	if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
-		Panic(fmt.Errorf("failed to list kubernetes nodes"))
-	}
-	isIBM := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "ibm")
-	if isIBM {
-		// In case of Satellite cluster is deployed in user provided infrastructure
-		if strings.Contains(nodesList.Items[0].Spec.ProviderID, "/sat-") {
-			isIBM = false
+	ibmPlatformOnce.Do(func() {
+		nodesList := &corev1.NodeList{}
+		if ok := KubeList(nodesList); !ok || len(nodesList.Items) == 0 {
+			Panic(fmt.Errorf("failed to list kubernetes nodes"))
 		}
-	}
-	return isIBM
+		isIBM := strings.HasPrefix(nodesList.Items[0].Spec.ProviderID, "ibm")
+		if isIBM {
+			// In case of Satellite cluster is deployed in user provided infrastructure
+			if strings.Contains(nodesList.Items[0].Spec.ProviderID, "/sat-") {
+				isIBM = false
+			}
+		}
+		ibmPlatform = isIBM
+	})
+	return ibmPlatform
 }
 
 // GetIBMRegion returns the cluster's region in IBM Cloud


### PR DESCRIPTION
### Describe the Problem
Bug: https://redhat.atlassian.net/browse/DFBUGS-2868
The noobaa-operator pod logs repeatedly show a misleading error on internal and provider ODF clusters:
`❌ Not Found: StorageClass \"ibm-spectrum-scale-csi-storageclass-version2\"`

This occurs when KubeCheck() was being called from IsFusionHCIWithScale(). It is a check which returns a boolean, hence it is a misleading not-found message.

### Explain the changes
1. Use KubeCheckQuiet() instead of KubeCheck() in IsFusionHCIWithScale() to avoid false not-found log noise.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed repeated false StorageClass not-found logs in noobaa-operator on non-Fusion HCI clusters.

### Testing Instructions:
1. Check noobaa-operator logs on an internal/provider ODF cluster and confirm the IBM Spectrum Scale StorageClass not-found message is gone.
2. Verify default backing store and bucket class still reconcile successfully.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced verbose logging during storage class availability checks to improve operational clarity and reduce noise.
  * Maintains the same validation outcome while suppressing non-essential status messages.

* **Refactor**
  * Improved runtime efficiency of platform detection by caching results to avoid repeated checks and speed up subsequent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-operator/pull/1915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->