### PR TITLE
Deep Archive NamespaceStore

### DIFF
--- a/deploy/crds/noobaa.io_namespacestores.yaml
+++ b/deploy/crds/noobaa.io_namespacestores.yaml
@@ -54,6 +54,11 @@ spec:
               accessMode:
                 description: AccessMode is an enum of supported access modes
                 type: string
+              archive:
+                description: |-
+                  Archive marks the namespace store for cold-storage archive use (e.g. IBM Deep Archive).
+                  Only valid with type s3-compatible.
+                type: boolean
               awsS3:
                 description: AWSS3Spec specifies a namespace store of type aws-s3
                 properties:

--- a/doc/namespace-store-crd.md
+++ b/doc/namespace-store-crd.md
@@ -100,6 +100,37 @@ spec:
   type: s3-compatible
 ```
 
+### S3 Compatible - Deep Archive
+Uses an S3-compatible API to write objects directly to a tape-based cold storage endpoint (e.g. IBM Deep Archive).
+This store type is intended for S3-compatible long-term archive where data is written once and read infrequently.
+
+`archive: true` - A flag that indicates the endpoint is a tape-based or cold-storage target (e.g. IBM Deep Archive).
+Archive stores can only be referenced via `archivePolicy` in a BucketClass; they cannot be used inside a `namespacePolicy`.
+
+```shell
+noobaa namespacestore create s3-compatible <NAMESPACESTORE NAME> --archive \
+  --endpoint <> --target-bucket <> --access-key <> --secret-key <> 
+```
+
+```yaml
+apiVersion: noobaa.io/v1alpha1
+kind: NamespaceStore
+metadata:
+  finalizers:
+  - noobaa.io/finalizer
+  name: <>
+  namespace: <>
+spec:
+  archive: true
+  s3Compatible:
+    endpoint: <>
+    secret:
+      name: <>
+      namespace: <>
+    targetBucket: <>
+  type: s3-compatible
+```
+
 ## IBM COS
 Uses the IBM COS API for IO operations on plain data in IBM COS buckets
 ```shell

--- a/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
+++ b/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
@@ -60,6 +60,11 @@ type NamespaceStoreSpec struct {
 	// Type is an enum of supported types
 	Type NSType `json:"type"`
 
+	// Archive marks the namespace store for cold-storage archive use (e.g. IBM Deep Archive).
+	// Only valid with type s3-compatible.
+	// +optional
+	Archive bool `json:"archive,omitempty"`
+
 	//AccessMode is an enum of supported access modes
 	// +optional
 	AccessMode AccessModeType `json:"accessMode,omitempty"`
@@ -87,6 +92,11 @@ type NamespaceStoreSpec struct {
 	// NSFS specifies a namespace store of type nsfs
 	// +optional
 	NSFS *NSFSSpec `json:"nsfs,omitempty"`
+}
+
+// IsArchiveNamespaceStore returns true when the store is configured for archive (cold storage) use.
+func IsArchiveNamespaceStore(ns *NamespaceStore) bool {
+	return ns != nil && ns.Spec.Archive
 }
 
 // NamespaceStoreStatus defines the observed state of NamespaceStore

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -963,7 +963,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_namespacestores_yaml = "3918d4e2b31648e242af9bb3ee522b792083d6b942279d305fbcf18a9cc72dfa"
+const Sha256_deploy_crds_noobaa_io_namespacestores_yaml = "771b9b6a9da4a926d8f22e3d129c339eea0edff563f4d7494a278179aae86fca"
 
 const File_deploy_crds_noobaa_io_namespacestores_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -1021,6 +1021,11 @@ spec:
               accessMode:
                 description: AccessMode is an enum of supported access modes
                 type: string
+              archive:
+                description: |-
+                  Archive marks the namespace store for cold-storage archive use (e.g. IBM Deep Archive).
+                  Only valid with type s3-compatible.
+                type: boolean
               awsS3:
                 description: AWSS3Spec specifies a namespace store of type aws-s3
                 properties:

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -182,6 +182,10 @@ func CmdCreateS3Compatible() *cobra.Command {
 		"access-mode", "read-write",
 		`The resource access privileges read-write|read-only`,
 	)
+	cmd.Flags().Bool(
+		"archive", false,
+		"Mark the namespace store for cold-storage archive use (IBM Deep Archive)",
+	)
 	return cmd
 }
 
@@ -595,6 +599,7 @@ func RunCreateGoogleCloudStorage(cmd *cobra.Command, args []string) {
 func RunCreateS3Compatible(cmd *cobra.Command, args []string) {
 	createCommon(cmd, args, nbv1.NSStoreTypeS3Compatible, func(namespaceStore *nbv1.NamespaceStore, secret *corev1.Secret) {
 		log := util.Logger()
+		archive, _ := cmd.Flags().GetBool("archive")
 		endpoint := util.GetFlagStringOrPrompt(cmd, "endpoint")
 		targetBucket := util.GetFlagStringOrPrompt(cmd, "target-bucket")
 		sigVer, _ := cmd.Flags().GetString("signature-version")
@@ -631,6 +636,7 @@ func RunCreateS3Compatible(cmd *cobra.Command, args []string) {
 				Namespace: secret.Namespace,
 			},
 		}
+		namespaceStore.Spec.Archive = archive
 	})
 }
 
@@ -915,6 +921,15 @@ func CheckPhase(namespaceStore *nbv1.NamespaceStore) {
 	}
 }
 
+// providerStorageClass returns the provider storage-class label for a NamespaceStore row.
+// Only s3-compatible stores carry the archive distinction; all other types return "-".
+func providerStorageClass(ns *nbv1.NamespaceStore) string {
+	if nbv1.IsArchiveNamespaceStore(ns) {
+		return "archive"
+	}
+	return "standard"
+}
+
 // RunList runs a CLI command
 func RunList(cmd *cobra.Command, args []string) {
 	list := &nbv1.NamespaceStoreList{
@@ -931,6 +946,7 @@ func RunList(cmd *cobra.Command, args []string) {
 		"NAME",
 		"TYPE",
 		"TARGET-BUCKET",
+		"PROVIDER-STORAGE-CLASS",
 		"PHASE",
 		"AGE",
 	)
@@ -942,6 +958,7 @@ func RunList(cmd *cobra.Command, args []string) {
 				bs.Name,
 				string(bs.Spec.Type),
 				tb,
+				providerStorageClass(bs),
 				string(bs.Status.Phase),
 				util.HumanizeDuration(time.Since(bs.CreationTimestamp.Time).Round(time.Second)),
 			)

--- a/pkg/validations/namespacestore_validations.go
+++ b/pkg/validations/namespacestore_validations.go
@@ -30,6 +30,9 @@ func ValidateNamespaceStore(nsStore *nbv1.NamespaceStore) error {
 	if err := ValidateNSEmptyTargetBucket(*nsStore); err != nil {
 		return err
 	}
+	if err := ValidateNSArchiveSpec(*nsStore); err != nil {
+		return err
+	}
 	switch nsStore.Spec.Type {
 
 	case nbv1.NSStoreTypeNSFS:
@@ -406,6 +409,24 @@ func ValidateTargetNSBucketChange(ns nbv1.NamespaceStore, oldNs nbv1.NamespaceSt
 	default:
 		return util.ValidationError{
 			Msg: "Failed to identify NamespaceStore type",
+		}
+	}
+	return nil
+}
+
+// ValidateNSArchiveSpec validates archive flag usage on a NamespaceStore.
+func ValidateNSArchiveSpec(nsStore nbv1.NamespaceStore) error {
+	if !nsStore.Spec.Archive {
+		return nil
+	}
+	if nsStore.Spec.Type != nbv1.NSStoreTypeS3Compatible {
+		return util.ValidationError{
+			Msg: "archive can only be set on s3-compatible type NamespaceStore",
+		}
+	}
+	if nsStore.Spec.S3Compatible == nil {
+		return util.ValidationError{
+			Msg: "S3Compatible spec must be provided when archive is enabled",
 		}
 	}
 	return nil


### PR DESCRIPTION
### Explain the changes
1. Added archive boolean to S3 compatible NamespaceStore CRD
2. Added namespacestore reconciler, admission and validations related changes.
3. Added CLI changes needed for supporting the new namespacestore archive field.
4. Added deep archive section to the namespacestore documentation.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - tests will be added in the following PR 
2. validate we don't set archive: true on non IBM deep archive s3 compatible namespacestores
3. re-consider adding the immutability validation for the `archive:boolean`

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for marking NamespaceStores as cold-storage archives (e.g., IBM Deep Archive) via a new archive option for S3-compatible stores.
  * Added a CLI flag to create archive-enabled NamespaceStores.

* **Bug Fixes / Validation**
  * Validation now enforces that archive can only be enabled for S3-compatible stores and that the archive setting cannot be changed after creation.

* **Documentation**
  * Added guidance and examples for S3-compatible deep-archive configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-operator/pull/1918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->