### PR TITLE
Bumping version from 5.22.0 to 5.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ The following options can be passed to any command:
     --manual-default-backingstore=false: allow to delete the default backingstore
     --mini=false: Signal the operator that it is running in a low resource environment
     -n, --namespace='default': Target namespace
-    --noobaa-image='noobaa/noobaa-core:5.22.0': NooBaa image
-    --operator-image='noobaa/noobaa-operator:5.22.0': Operator image
+    --noobaa-image='noobaa/noobaa-core:5.23.0': NooBaa image
+    --operator-image='noobaa/noobaa-operator:5.23.0': Operator image
     --pg-ssl-cert='': ssl cert for postgres (client-side cert - need to be signed by external pg accepted CA)
     --pg-ssl-key='': ssl key for postgres (client-side cert - need to be signed by external pg accepted CA)
     --pg-ssl-required=false: Force noobaa to work with ssl (external postgres - server-side) [if server cert is self-signed, needs to add --ssl-unauthorized]
@@ -177,9 +177,9 @@ $ noobaa version
 ```
 
 ```
-INFO[0000] CLI version: 5.22.0
-INFO[0000] noobaa-image: noobaa/noobaa-core:5.22.0
-INFO[0000] operator-image: noobaa/noobaa-operator:5.22.0
+INFO[0000] CLI version: 5.23.0
+INFO[0000] noobaa-image: noobaa/noobaa-core:5.23.0
+INFO[0000] operator-image: noobaa/noobaa-operator:5.23.0
 ```
 
 ## Troubleshooting

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1,6 +1,6 @@
 package bundle
 
-const Version = "5.22.0"
+const Version = "5.23.0"
 
 const Sha256_deploy_cluster_role_yaml = "6417dcd3e52c38e04ba6b70b7e22985f0f7ddf1edec96287fcc0cb5f42b30c04"
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version is the noobaa-operator version (semver)
-	Version = "5.22.0"
+	Version = "5.23.0"
 )


### PR DESCRIPTION
### Explain the changes
Bumping version from 5.22.0 to 5.23.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 5.23.0 across all components
  * Updated CLI documentation to reflect the new version and current image references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-operator/pull/1919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->