### PR TITLE
GCP WIF (STS) | Adding  a New Type of Backingstore

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -2,7 +2,6 @@ package backingstore
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -832,21 +831,23 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		}
 
 	case nbv1.StoreTypeGoogleCloudStorage:
-		conn.EndpointType = nb.EndpointTypeGoogle
 		conn.Endpoint = "https://www.googleapis.com"
-		privateKeyJSON := r.Secret.StringData["GoogleServiceAccountPrivateKeyJson"]
-		privateKey := &struct {
-			ID string `json:"private_key_id"`
-		}{}
-		err := json.Unmarshal([]byte(privateKeyJSON), privateKey)
+		googleCredentialsJSON := r.Secret.StringData["GoogleServiceAccountPrivateKeyJson"]
+
+		isGoogleExternalAccountJSON, identity, err := util.ParseGoogleCredentials(googleCredentialsJSON)
 		if err != nil {
 			return nil, util.NewPersistentError("InvalidGoogleSecret", fmt.Sprintf(
-				"Invalid secret for google type %q expected JSON in data.GoogleServiceAccountPrivateKeyJson",
-				r.Secret.Name,
+				"Invalid secret for google type %q expected JSON in data.GoogleServiceAccountPrivateKeyJson: %v",
+				r.Secret.Name, err,
 			))
 		}
-		conn.Identity = nb.MaskedString(privateKey.ID)
-		conn.Secret = nb.MaskedString(privateKeyJSON)
+		if isGoogleExternalAccountJSON {
+			conn.EndpointType = nb.EndpointTypeGoogleSTS
+		} else {
+			conn.EndpointType = nb.EndpointTypeGoogle
+		}
+		conn.Identity = nb.MaskedString(identity)
+		conn.Secret = nb.MaskedString(googleCredentialsJSON)
 
 	case nbv1.StoreTypePVPool:
 		return nil, util.NewPersistentError("InvalidType",

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -658,6 +658,8 @@ const (
 	EndpointTypeAzureSTS EndpointType = "AZURESTS"
 	// EndpointTypeGoogle enum
 	EndpointTypeGoogle EndpointType = "GOOGLE"
+	// EndpointTypeGoogleSTS enum
+	EndpointTypeGoogleSTS EndpointType = "GOOGLE_STS"
 	// EndpointTypeS3Compat enum
 	EndpointTypeS3Compat EndpointType = "S3_COMPATIBLE"
 	// EndpointTypeIBMCos enum

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -94,6 +94,10 @@ const (
 
 	// InjectedBundleCertCAFile points to OCP root CA to be added to the default root CA list
 	InjectedBundleCertCAFile = "/etc/ocp-injected-ca-bundle/ca-bundle.crt"
+
+	// Google impersonation URL constants
+	GoogleImpersonationURLPrefix = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
+	GoogleImpersonationURLSuffix = ":generateAccessToken"
 )
 
 // OAuth2Endpoints holds OAuth2 endpoints information.
@@ -105,6 +109,13 @@ type OAuth2Endpoints struct {
 // ValidationError is a custom error if the validation failed
 type ValidationError struct {
 	Msg string
+}
+
+// googleCredentialsJSON is a minimal view of Google credential JSON (service_account or external_account).
+type googleCredentialsJSON struct {
+	Type                           string `json:"type"`
+	PrivateKeyID                   string `json:"private_key_id,omitempty"`
+	ServiceAccountImpersonationURL string `json:"service_account_impersonation_url,omitempty"`
 }
 
 // AccessKeyRegexp validates access keys, which are 20 characters long and may include alphanumeric characters
@@ -1188,6 +1199,58 @@ func IsAzureSTSClusterNS(ns *nbv1.NamespaceStore) bool {
 		return ns.Spec.AzureBlob.ClientId != nil
 	}
 	return false
+}
+
+// ParseGoogleCredentials parses credential JSON and returns whether it is GCP WIF (STS) and the identity
+func ParseGoogleCredentials(credentialsJSON string) (bool, string, error) {
+	creds := &googleCredentialsJSON{}
+	if err := json.Unmarshal([]byte(credentialsJSON), creds); err != nil {
+		return false, "", fmt.Errorf("invalid google credentials json: %w", err)
+	}
+	identity, err := googleIdentityFromCredentials(creds)
+	if err != nil {
+		return false, "", err
+	}
+	return creds.Type == "external_account", identity, nil
+}
+
+// googleIdentityFromCredentials returns the identity.
+// - For GCP (service_account type in JSON) - it uses private_key_id
+// - For GCP STS (external_account type in JSON) it uses the email from service_account_impersonation_url.
+// Unknown or missing type fails immediately.
+func googleIdentityFromCredentials(creds *googleCredentialsJSON) (string, error) {
+	switch creds.Type {
+	case "external_account":
+		return googleIdentityFromImpersonationURL(creds.ServiceAccountImpersonationURL)
+	case "service_account":
+		if creds.PrivateKeyID == "" {
+			return "", fmt.Errorf("invalid google service account json: missing private_key_id")
+		}
+		return creds.PrivateKeyID, nil
+	case "":
+		return "", fmt.Errorf("invalid google credentials json: missing type")
+	default:
+		return "", fmt.Errorf("invalid google credentials json: unsupported type %q", creds.Type)
+	}
+}
+
+// googleIdentityFromImpersonationURL returns the email from the impersonation URL
+func googleIdentityFromImpersonationURL(impersonationURL string) (string, error) {
+	if !strings.HasPrefix(impersonationURL, GoogleImpersonationURLPrefix) ||
+		!strings.HasSuffix(impersonationURL, GoogleImpersonationURLSuffix) {
+		return "", fmt.Errorf("invalid service_account_impersonation_url: %q", impersonationURL)
+	}
+	email := strings.TrimSuffix(
+		strings.TrimPrefix(impersonationURL, GoogleImpersonationURLPrefix),
+		GoogleImpersonationURLSuffix,
+	)
+	if email == "" {
+		return "", fmt.Errorf("invalid service_account_impersonation_url: empty service account email in %q", impersonationURL)
+	}
+	if !strings.Contains(email, "@") {
+		return "", fmt.Errorf("invalid service_account_impersonation_url: malformed service account email %q in %q", email, impersonationURL)
+	}
+	return email, nil
 }
 
 // IsAzurePlatformNonGovernment returns true if this cluster is running on Azure and also not on azure government\DOD cloud

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,9 +1,15 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+)
+
+const (
+	googleWIFServiceAccountEmail = "noobaa-wif-sa@my-project.iam.gserviceaccount.com"
+	googleServiceAccountKeyID    = "key-id-123"
 )
 
 // TestMapAlternateKeysValue a tiny test for util.MapAlternateKeysValue()
@@ -76,9 +82,9 @@ func TestIsAzureSTSClusterBS(t *testing.T) {
 	tenantID := "test-tenant-id"
 
 	tests := []struct {
-		name        string
+		name         string
 		backingStore *nbv1.BackingStore
-		expected    bool
+		expected     bool
 	}{
 		{
 			name: "azure-blob with ClientId returns true",
@@ -136,8 +142,8 @@ func TestIsAzureSTSClusterBS(t *testing.T) {
 						TargetBlobContainer: "container",
 						ClientId:            &clientID,
 						TenantId:            &tenantID,
-						SubscriptionId:     ptrString("sub-id"),
-						ResourcegroupId:    ptrString("rg-id"),
+						SubscriptionId:      ptrString("sub-id"),
+						ResourcegroupId:     ptrString("rg-id"),
 					},
 				},
 			},
@@ -157,4 +163,189 @@ func TestIsAzureSTSClusterBS(t *testing.T) {
 
 func ptrString(s string) *string {
 	return &s
+}
+
+// googleImpersonationURL returns the impersonation URL for the given email
+func googleImpersonationURL(email string) string {
+	return GoogleImpersonationURLPrefix + email + GoogleImpersonationURLSuffix
+}
+
+// TestParseGoogleCredentials tests ParseGoogleCredentials function
+func TestParseGoogleCredentials(t *testing.T) {
+	validExternalAccountJSON := fmt.Sprintf(
+		`{"type":"external_account","service_account_impersonation_url":%q}`,
+		googleImpersonationURL(googleWIFServiceAccountEmail),
+	)
+
+	tests := []struct {
+		name                    string
+		json                    string
+		expectedExternalAccount bool
+		expectedIdentity        string
+		expectedErr             bool
+	}{
+		{
+			name:                    "external_account",
+			json:                    validExternalAccountJSON,
+			expectedExternalAccount: true,
+			expectedIdentity:        googleWIFServiceAccountEmail,
+		},
+		{
+			name:                    "service_account",
+			json:                    fmt.Sprintf(`{"type":"service_account","private_key_id":%q}`, googleServiceAccountKeyID),
+			expectedExternalAccount: false,
+			expectedIdentity:        googleServiceAccountKeyID,
+		},
+		{
+			name:        "invalid JSON",
+			json:        `{`,
+			expectedErr: true,
+		},
+		{
+			name:        "propagates identity error",
+			json:        `{"type":"service_account"}`,
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isExternalAccount, identity, err := ParseGoogleCredentials(tc.json)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if isExternalAccount != tc.expectedExternalAccount {
+				t.Fatalf("expected isExternalAccount=%v, got %v", tc.expectedExternalAccount, isExternalAccount)
+			}
+			if identity != tc.expectedIdentity {
+				t.Fatalf("expected identity %q, got %q", tc.expectedIdentity, identity)
+			}
+		})
+	}
+}
+
+// TestGoogleIdentityFromCredentials tests googleIdentityFromCredentials function
+func TestGoogleIdentityFromCredentials(t *testing.T) {
+	tests := []struct {
+		name             string
+		creds            *googleCredentialsJSON
+		expectedIdentity string
+		expectedErr      bool
+	}{
+		{
+			name: "external_account",
+			creds: &googleCredentialsJSON{
+				Type:                           "external_account",
+				ServiceAccountImpersonationURL: googleImpersonationURL(googleWIFServiceAccountEmail),
+			},
+			expectedIdentity: googleWIFServiceAccountEmail,
+		},
+		{
+			name: "service_account",
+			creds: &googleCredentialsJSON{
+				Type:         "service_account",
+				PrivateKeyID: googleServiceAccountKeyID,
+			},
+			expectedIdentity: googleServiceAccountKeyID,
+		},
+		{
+			name: "service_account missing private_key_id",
+			creds: &googleCredentialsJSON{
+				Type: "service_account",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "missing type",
+			creds: &googleCredentialsJSON{
+				PrivateKeyID: googleServiceAccountKeyID,
+			},
+			expectedErr: true,
+		},
+		{
+			name: "unsupported type",
+			creds: &googleCredentialsJSON{
+				Type: "authorized_user",
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			identity, err := googleIdentityFromCredentials(tc.creds)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if identity != tc.expectedIdentity {
+				t.Fatalf("expected identity %q, got %q", tc.expectedIdentity, identity)
+			}
+		})
+	}
+}
+
+// TestGoogleIdentityFromImpersonationURL tests googleIdentityFromImpersonationURL function
+func TestGoogleIdentityFromImpersonationURL(t *testing.T) {
+	tests := []struct {
+		name             string
+		impersonationURL string
+		expectedIdentity string
+		expectedErr      bool
+	}{
+		{
+			name:             "valid url",
+			impersonationURL: googleImpersonationURL(googleWIFServiceAccountEmail),
+			expectedIdentity: googleWIFServiceAccountEmail,
+		},
+		{
+			name:             "invalid prefix or suffix",
+			impersonationURL: "https://example.com",
+			expectedErr:      true,
+		},
+		{
+			name:             "empty url",
+			impersonationURL: "",
+			expectedErr:      true,
+		},
+		{
+			name:             "empty email",
+			impersonationURL: GoogleImpersonationURLPrefix + GoogleImpersonationURLSuffix,
+			expectedErr:      true,
+		},
+		{
+			name:             "malformed email",
+			impersonationURL: googleImpersonationURL("not-an-email"),
+			expectedErr:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			identity, err := googleIdentityFromImpersonationURL(tc.impersonationURL)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if identity != tc.expectedIdentity {
+				t.Fatalf("expected identity %q, got %q", tc.expectedIdentity, identity)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661), this PR sets the new endpoint type `GOOGLE_STS` (we had `GOOGLE`) and starts implementing code changes in parts of the flows related to the GCP WIF (STS) backing store. This PR relies on the changes in PR noobaa/noobaa-core#9644.

### Explain the changes
1. In Backingstore, reconcile the use of the new endpoint type `EndpointTypeGoogleSTS`.
Note: In the `IsStringGraphicOrSpacesCharsOnly` I excluded GCP and GCP STS as it seems to be only for AWS-style properties.
2. Added util functions for the new type, and also added AI-generated tests for the new functions.

### Issues: 
List of GAPS:
1. In this PR we do not handle the CLI changes and default backingstore changes.
2. GCP WIF (STS) namespace store is not handled as part of this PR.
3. Currently, in the secret we still have the field of `GoogleServiceAccountPrivateKeyJson` in the data; also, for the case of GCP WIF (STS), we might change it later for readability.

### Testing Instructions:
#### Unit Tests
1. Please run: `go test -mod=vendor -v ./pkg/util -run 'TestParseGoogleCredentials|TestGoogleIdentityFromJSON|TestGoogleIdentityFromImpersonationURL'`

#### Manual Test:
More details can be found in [comment](https://github.com/noobaa/noobaa-operator/pull/1923#issuecomment-4590173559)
1. Deploy NooBaa on Minikube after adding GCP WIF configurations - see guide "Create GCP WIF (STS) Setup On Minikube With NooBaa" ([link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_gcp_wif_setup_on_minikube_with_noobaa.md)).
2. Create a secret with the details of the credential.json for GCP WIF (STS).
3. Create a backing store to use the secret of the kind GCP WIF (STS), expect it to be in `Ready`.
4. Write to the bucket and read from it - for this need to create a bucketclass on top of the backingstore and an OBC and then use the credentials to put object and get object from the bucket.

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Cloud Storage backing stores now detect and support Google STS (Workload Identity Federation) alongside service-account auth, deriving and storing a consistent masked identity and using the appropriate endpoint type.

* **Tests**
  * Added comprehensive unit tests for parsing and validating service-account and external-account Google credential JSONs, including impersonation URL handling and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->