### PR TITLE
Deep Archive | avoid Analyze, reject noobaaaccount default resource and olm changes

### DIFF
--- a/pkg/admission/validate_noobaaaccount.go
+++ b/pkg/admission/validate_noobaaaccount.go
@@ -68,6 +68,11 @@ func (nav *ResourceValidator) ValidateCreateNA() {
 		nav.SetValidationResult(false, err.Error())
 		return
 	}
+
+	if err := validations.ValidateAccountDefaultResource(*na); err != nil {
+		nav.SetValidationResult(false, err.Error())
+		return
+	}
 }
 
 // ValidateUpdateNA runs all the validations tests for UPDATE operations
@@ -89,5 +94,5 @@ func (nav *ResourceValidator) ValidateUpdateNA() {
 			nav.SetValidationResult(false, err.Error())
 			return
 		}
-	}	
+	}
 }

--- a/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
+++ b/pkg/apis/noobaa/v1alpha1/namespacestore_types.go
@@ -94,11 +94,6 @@ type NamespaceStoreSpec struct {
 	NSFS *NSFSSpec `json:"nsfs,omitempty"`
 }
 
-// IsArchiveNamespaceStore returns true when the store is configured for archive (cold storage) use.
-func IsArchiveNamespaceStore(ns *NamespaceStore) bool {
-	return ns != nil && ns.Spec.Archive
-}
-
 // NamespaceStoreStatus defines the observed state of NamespaceStore
 // +k8s:openapi-gen=true
 type NamespaceStoreStatus struct {

--- a/pkg/diagnostics/analyze.go
+++ b/pkg/diagnostics/analyze.go
@@ -150,7 +150,10 @@ func checkIfBackingStoreTypeIsSupported(backingStore *nbv1.BackingStore) bool {
 }
 
 func checkIfNamespaceStoreTypeIsSupported(namespaceStore *nbv1.NamespaceStore) bool {
-	if util.IsSTSClusterNS(namespaceStore) || util.IsAzureSTSClusterNS(namespaceStore) || namespaceStore.Spec.Type == nbv1.NSStoreTypeNSFS {
+	if util.IsSTSClusterNS(namespaceStore) ||
+		util.IsAzureSTSClusterNS(namespaceStore) ||
+		namespaceStore.Spec.Type == nbv1.NSStoreTypeNSFS ||
+		util.IsArchiveNamespaceStore(namespaceStore) {
 		return false
 	}
 	return true

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -924,7 +924,7 @@ func CheckPhase(namespaceStore *nbv1.NamespaceStore) {
 // providerStorageClass returns the provider storage-class label for a NamespaceStore row.
 // Only s3-compatible stores carry the archive distinction; all other types return "-".
 func providerStorageClass(ns *nbv1.NamespaceStore) string {
-	if nbv1.IsArchiveNamespaceStore(ns) {
+	if util.IsArchiveNamespaceStore(ns) {
 		return "archive"
 	}
 	return "standard"

--- a/pkg/noobaaaccount/noobaaaccount.go
+++ b/pkg/noobaaaccount/noobaaaccount.go
@@ -11,6 +11,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -207,15 +208,8 @@ func RunCreate(cmd *cobra.Command, args []string) {
 		defaultResource = sys.Name + "-default-backing-store"
 	}
 
-	isResourceBackingStore := checkResourceBackingStore(defaultResource)
-	isResourceNamespaceStore := checkResourceNamespaceStore(defaultResource)
-
-	if isResourceBackingStore && isResourceNamespaceStore {
-		log.Fatalf(`❌  got BackingStore and NamespaceStore %q in namespace %q`,
-			defaultResource, options.Namespace)
-	} else if !isResourceBackingStore && !isResourceNamespaceStore {
-		log.Fatalf(`❌ Could not get BackingStore or NamespaceStore %q in namespace %q`,
-			defaultResource, options.Namespace)
+	if err := validations.ValidateAccountDefaultResource(*noobaaAccount); err != nil {
+		log.Fatalf(`❌ %s`, err.Error())
 	}
 
 	noobaaAccount.Spec.DefaultResource = defaultResource
@@ -816,32 +810,4 @@ func ValidateAccessKeys(accessKeys nb.S3AccessKeys) {
 	if !util.SecretKeyRegexp.MatchString(string(accessKeys.SecretKey)) {
 		log.Fatalf(`❌ Account secret length must be 40, and must contain only alpha-numeric chars, "+", "/"`)
 	}
-}
-
-// checkResourceBackingStore checks if a resourceName exists and if BackingStore
-func checkResourceBackingStore(resourceName string) bool {
-	// check that a backing store exists
-	resourceBackingStore := &nbv1.BackingStore{
-		TypeMeta: metav1.TypeMeta{Kind: "BackingStore"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName,
-			Namespace: options.Namespace,
-		},
-	}
-
-	return util.KubeCheckQuiet(resourceBackingStore)
-}
-
-// checkResourceNamespaceStore checks if a resourceName exists and if NamespaceStore
-func checkResourceNamespaceStore(resourceName string) bool {
-	// check that a namespace store exists
-	resourceNamespaceStore := &nbv1.NamespaceStore{
-		TypeMeta: metav1.TypeMeta{Kind: "NamespaceStore"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName,
-			Namespace: options.Namespace,
-		},
-	}
-
-	return util.KubeCheckQuiet(resourceNamespaceStore)
 }

--- a/pkg/noobaaaccount/reconciler.go
+++ b/pkg/noobaaaccount/reconciler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/sirupsen/logrus"
@@ -210,17 +211,9 @@ func (r *Reconciler) ReconcilePhaseVerifying() error {
 		return util.NewPersistentError("MissingDefaultResource",
 			fmt.Sprintf("Account %q is allowed to create buckets, but no resource is provided", r.NooBaaAccount.Name))
 	}
-
 	if r.NooBaaAccount.Spec.DefaultResource != "" {
-		isResourceBackingStore := checkResourceBackingStore(r.NooBaaAccount.Spec.DefaultResource)
-		isResourceNamespaceStore := checkResourceNamespaceStore(r.NooBaaAccount.Spec.DefaultResource)
-		if !isResourceBackingStore && !isResourceNamespaceStore {
-			return util.NewPersistentError("MissingDefaultResource",
-				fmt.Sprintf("Account %q is allowed to create buckets, but resource %q was not found",
-					r.NooBaaAccount.Name, r.NooBaaAccount.Spec.DefaultResource))
-		} else if isResourceBackingStore && isResourceNamespaceStore {
-			return util.NewPersistentError("MissingDefaultResource",
-				fmt.Sprintf("BackingStore and NamespaceStore should not have the same name: %q, ", r.NooBaaAccount.Spec.DefaultResource))
+		if err := validations.ValidateAccountDefaultResource(*r.NooBaaAccount); err != nil {
+			return util.NewPersistentError("InvalidDefaultResource", err.Error())
 		}
 	}
 

--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -415,6 +415,7 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 		uiFieldGroupIBMCos             = uiFieldGroup + "ibmCos"
 		uiFieldGroupPlacementPolicy    = uiFieldGroup + "placementPolicy"
 		uiFieldGroupNamespacePolicy    = uiFieldGroup + "namespacePolicy"
+		uiFieldGroupArchivePolicy      = uiFieldGroup + "archivePolicy"
 	)
 
 	crdSpecDescriptors := map[string][]operv1.SpecDescriptor{
@@ -655,6 +656,12 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 				DisplayName:  "Target Bucket",
 			},
 			{
+				Description:  "Archive specifies if the namespace store should be used for archiving. If true, the namespace store will be used for archiving and not for regular data storage.",
+				Path:         "archive",
+				XDescriptors: []string{uiBooleanSwitch},
+				DisplayName:  "Archive",
+			},
+			{
 				Description:  "Endpoint is the IBM COS endpoint: http(s)://host:port.",
 				Path:         "IBMCos.endpoint",
 				XDescriptors: []string{uiFieldGroupIBMCos, uiText},
@@ -722,6 +729,12 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 				Path:         "namespacePolicy.Cache.hubResource",
 				XDescriptors: []string{uiFieldGroupNamespacePolicy, uiText},
 				DisplayName:  "Hub Resource",
+			},
+			{
+				Description:  "DeepArchiveResource specifies the namespace store configured by the archivePolicy.",
+				Path:         "archivePolicy.deepArchiveResource",
+				XDescriptors: []string{uiFieldGroupArchivePolicy, uiText},
+				DisplayName:  "Deep Archive Resource",
 			},
 		},
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1345,6 +1345,11 @@ func GetAWSRegion() (string, error) {
 	return awsRegion, nil
 }
 
+// IsArchiveNamespaceStore returns true when the store is configured for archive (cold storage) use.
+func IsArchiveNamespaceStore(ns *nbv1.NamespaceStore) bool {
+	return ns != nil && ns.Spec.Archive
+}
+
 // IsValidS3BucketName checks the name according to
 // https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html
 func IsValidS3BucketName(name string) bool {

--- a/pkg/validations/bucketclass_validation.go
+++ b/pkg/validations/bucketclass_validation.go
@@ -203,7 +203,7 @@ func ValidateNamespacePolicy(namespacePolicy *nbv1.NamespacePolicy, namespace st
 			return util.NewPersistentError("MissingNamespaceStore",
 				fmt.Sprintf("NooBaa NamespaceStore %q not found or deleted", name))
 		}
-		if nbv1.IsArchiveNamespaceStore(nsStore) {
+		if util.IsArchiveNamespaceStore(nsStore) {
 			return util.NewPersistentError("InvalidNamespaceStore",
 				fmt.Sprintf("NamespaceStore %q is an archive store and cannot be referenced in a namespacePolicy; use archivePolicy instead",
 					name))

--- a/pkg/validations/noobaaaccount_validation.go
+++ b/pkg/validations/noobaaaccount_validation.go
@@ -1,9 +1,36 @@
 package validations
 
 import (
+	"fmt"
+
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// ValidateAccountDefaultResource is the public entry point for validating that a NooBaaAccount's
+// DefaultResource is not an archive NamespaceStore.
+func ValidateAccountDefaultResource(na nbv1.NooBaaAccount) error {
+	if na.Spec.DefaultResource == "" {
+		return nil
+	}
+	isBackingStore, _ := checkResourceBackingStore(na.Spec.DefaultResource)
+	isNamespaceStore, namespaceStoreObj := checkResourceNamespaceStore(na.Spec.DefaultResource)
+
+	if !isBackingStore && !isNamespaceStore {
+		return util.NewPersistentError("MissingDefaultResource",
+			fmt.Sprintf("Account %q default resource %q was not found", na.Name, na.Spec.DefaultResource))
+	} else if isBackingStore && isNamespaceStore {
+		return util.NewPersistentError("MissingDefaultResource",
+			fmt.Sprintf("BackingStore and NamespaceStore should not have the same name: %q", na.Spec.DefaultResource))
+	}
+	if util.IsArchiveNamespaceStore(namespaceStoreObj) {
+		return util.NewPersistentError("InvalidDefaultResource",
+			fmt.Sprintf("NamespaceStore %q is an archive store and cannot be used as a default resource", namespaceStoreObj.Name))
+	}
+	return nil
+}
 
 // ValidateRemoveNSFSConfig validates that the NSFS config was not removed
 func ValidateRemoveNSFSConfig(na nbv1.NooBaaAccount, oldNa nbv1.NooBaaAccount) error {
@@ -38,4 +65,34 @@ func ValidateNSFSConfig(na nbv1.NooBaaAccount) error {
 	}
 
 	return nil
+}
+
+// checkResourceBackingStore checks if a resourceName exists and if BackingStore
+// returns true if the resource exists and is a BackingStore, and also returns the BackingStore object if it exists
+func checkResourceBackingStore(resourceName string) (bool, *nbv1.BackingStore) {
+	// check that a backing store exists
+	resourceBackingStore := &nbv1.BackingStore{
+		TypeMeta: metav1.TypeMeta{Kind: "BackingStore"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceName,
+			Namespace: options.Namespace,
+		},
+	}
+	res := util.KubeCheckQuiet(resourceBackingStore)
+	return res, resourceBackingStore
+}
+
+// checkResourceNamespaceStore checks if a resourceName exists and if NamespaceStore
+// returns true if the resource exists and is a NamespaceStore, and also returns the NamespaceStore object if it exists
+func checkResourceNamespaceStore(resourceName string) (bool, *nbv1.NamespaceStore) {
+	// check that a namespace store exists
+	resourceNamespaceStore := &nbv1.NamespaceStore{
+		TypeMeta: metav1.TypeMeta{Kind: "NamespaceStore"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceName,
+			Namespace: options.Namespace,
+		},
+	}
+	res := util.KubeCheckQuiet(resourceNamespaceStore)
+	return res, resourceNamespaceStore
 }


### PR DESCRIPTION
### Describe the Problem

### Explain the changes
1. Avoid analyzing archive namespacestore
2. Reject on noobaa account to have archive namespacestore as their default resource - CLI, admission server and reconciler (also refactoring)
3. olm changes

### Issues: Fixed #xxx / Gap #xxx
Manual testing - 
1. Analyze
```
> nb namespacestore create s3-compatible nss1 --access-key=<access_key> --secret-key=<secret_key> --endpoint=https://<endpoint_pod_ip>:6443 --target-bucket=first.bucket --archive

> nb diagnostics analyze namespacestore nss1
INFO[0000] ✅ Exists: NamespaceStore "nss1"
INFO[0000] NamespaceStore nss1 type is not supported in analyze
```
2. Account creation should be rejected for having an archive default resource 
```
> nb namespacestore create s3-compatible nss1 --access-key=<access_key> --secret-key=<secret_key> --endpoint=https://<endpoint_pod_ip>:6443 --target-bucket=first.bucket --archive


a. CLI
> nb account create account1 --default_resource=nss1

 nb account create account1 --default_resource=nss1
INFO[0000] ✅ Exists: NooBaa "noobaa"
INFO[0000] ❌ Status Error: NooBaaAccount "account1": admission webhook "admissionwebhook.noobaa.io" denied the request: NamespaceStore "nss1" is an archive store and cannot be used as a default resource
FATA[0000] ❌ Could not create noobaaAccount "account1" in Namespace "default" (conflict)


> vi account2.yaml
apiVersion: noobaa.io/v1alpha1
kind: NooBaaAccount
metadata:
  name: account2
  namespace: default
spec:
  allow_bucket_creation: true
  default_resource: nss1

b. Admission Server -

> oc apply -f account2.yaml 
Error from server: error when creating "account2.yaml": admission webhook "admissionwebhook.noobaa.io" denied the request: NamespaceStore "nss1" is an archive store and cannot be used as a default resource

c. Reconciler (no admission server) -

> oc apply -f account2.yaml
noobaaaccount.noobaa.io/account2 created
> k get noobaaaccounts
NAME       PHASE      AGE
account2   Rejected   6s
> k describe noobaaaccount account2
Name:         account2
....
Spec:
  allow_bucket_creation:  true
  default_resource:       nss1
Status:
  Conditions:
    Last Heartbeat Time:   2026-05-31T18:08:28Z
    Last Transition Time:  2026-05-31T18:08:28Z
    Message:               NamespaceStore "nss1" is used as an archive store and cannot be used as a default resource
    Reason:                InvalidDefaultResource
    Status:                Unknown
    Type:                  Available
    Last Heartbeat Time:   2026-05-31T18:08:28Z
    Last Transition Time:  2026-05-31T18:08:28Z
    Message:               NamespaceStore "nss1" is used as an archive store and cannot be used as a default resource
    Reason:                InvalidDefaultResource
    Status:                False
    Type:                  Progressing
    Last Heartbeat Time:   2026-05-31T18:08:28Z
    Last Transition Time:  2026-05-31T18:08:28Z
    Message:               NamespaceStore "nss1" is used as an archive store and cannot be used as a default resource
    Reason:                InvalidDefaultResource
    Status:                True
    Type:                  Degraded
    Last Heartbeat Time:   2026-05-31T18:08:28Z
    Last Transition Time:  2026-05-31T18:08:28Z
    Message:               NamespaceStore "nss1" is used as an archive store and cannot be used as a default resource
    Reason:                InvalidDefaultResource
    Status:                Unknown
    Type:                  Upgradeable
  Phase:                   Rejected
Events:
  Type     Reason                  Age                From             Message
  ----     ------                  ----               ----             -------
  Warning  InvalidDefaultResource  14s (x2 over 14s)  noobaa-operator  NamespaceStore "nss1" is used as an archive store and cannot be used as a default resource

```
### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default resource validation now rejects archive (cold storage) namespace stores, detects missing or ambiguous defaults, and prevents invalid defaults from being accepted.

* **New Features**
  * Added archivePolicy UI group with archive-related fields for NamespaceStore and BucketClass configuration.

* **Refactor**
  * Default resource validation centralized for consistent behavior across create and reconcile flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->