### PR TITLE
General | Update Core Image Tag "master-20260602"

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20260408"
+	ContainerImageTag = "master-20260602"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
### Describe the Problem
We once in a while updating the core image tag.

### Explain the changes
1. Update it to yesterday - I checked the [noobaa/nooba-core Docker repository](https://hub.docker.com/r/noobaa/noobaa-core/tags) and could see the image ([link](https://hub.docker.com/layers/noobaa/noobaa-core/master-20260602/images/sha256-7f6393e712dbad0e4a2cce7c064f50525ad2e3da4246eefb99d506d07e8a899f)).

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none (should be done by the CI)

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image version used by the CLI when no image override is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->