### PR TITLE
Create OBC with Archive Policy

### DIFF
--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -96,7 +96,8 @@ type BucketInfo struct {
 		ResiliencyStatus string `json:"resiliency_status"`
 		QuotaStatus      string `json:"quota_status"`
 	} `json:"policy_modes,omitempty"`
-	Namespace *NamespaceBucketInfo `json:"namespace,omitempty"`
+	Namespace     *NamespaceBucketInfo `json:"namespace,omitempty"`
+	ArchivePolicy *ArchivePolicyConfig `json:"archive_policy,omitempty"`
 	// TODO BucketInfo struct is partial ...
 }
 
@@ -338,14 +339,15 @@ type CreateSystemReply struct {
 	OperatorToken string `json:"operator_token"`
 }
 
-// CreateBucketParams is the params of bucket_api.create_bucket()
+// CreateBucketParams is the params of bucket_api.create_bucket() and bucket_api.update_bucket().
 type CreateBucketParams struct {
-	Name         string               `json:"name"`
-	Tiering      string               `json:"tiering,omitempty"`
-	ForceMd5Etag *bool                `json:"force_md5_etag,omitempty"`
-	BucketClaim  *BucketClaimInfo     `json:"bucket_claim,omitempty"`
-	Namespace    *NamespaceBucketInfo `json:"namespace,omitempty"`
-	Quota        *QuotaConfig         `json:"quota,omitempty"`
+	Name          string               `json:"name"`
+	Tiering       string               `json:"tiering,omitempty"`
+	ForceMd5Etag  *bool                `json:"force_md5_etag,omitempty"`
+	BucketClaim   *BucketClaimInfo     `json:"bucket_claim,omitempty"`
+	Namespace     *NamespaceBucketInfo `json:"namespace,omitempty"`
+	Quota         *QuotaConfig         `json:"quota,omitempty"`
+	ArchivePolicy *ArchivePolicyConfig `json:"archive_policy,omitempty"`
 }
 
 // QuotaConfig quota configuration
@@ -391,6 +393,12 @@ type NamespaceBucketInfo struct {
 type NamespaceResourceFullConfig struct {
 	Resource string `json:"resource"`
 	Path     string `json:"path,omitempty"`
+}
+
+// ArchivePolicyConfig represents the archive_policy API field.
+// DeepArchiveResource identifies the namespace resource (and optional path) used as the deep archive target.
+type ArchivePolicyConfig struct {
+	DeepArchiveResource *NamespaceResourceFullConfig `json:"deep_archive_resource,omitempty"`
 }
 
 // CacheSpec specifies the cache specifications for the bucket class

--- a/pkg/obc/provisioner.go
+++ b/pkg/obc/provisioner.go
@@ -560,6 +560,13 @@ func (r *BucketRequest) CreateAndUpdateBucket(
 			return fmt.Errorf("CreateTieringStructure for PlacementPolicy failed to create policy %q with error: %v", tierName, err)
 		}
 		createBucketParams.Tiering = tierName
+		if r.BucketClass.Spec.ArchivePolicy != nil {
+			createBucketParams.ArchivePolicy = &nb.ArchivePolicyConfig{
+				DeepArchiveResource: &nb.NamespaceResourceFullConfig{
+					Resource: r.BucketClass.Spec.ArchivePolicy.DeepArchiveResource,
+				},
+			}
+		}
 	}
 
 	// create NS bucket


### PR DESCRIPTION
### Describe the Problem

### Explain the changes
1. Update obc provisioner for setting archivePolicy on creation of a bucket.
2. Add ArchivePolicy to createBucketParams and bucketInfo in types.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - update image

### Testing Instructions:
1. Manual tests - 
```
> k get secret noobaa-admin -o json | jq '.data | map_values(@base64d)'
> nb namespacestore create s3-compatible nss1 --access-key=<admins-access-key> --secret-key=<admin-secret-key> --endpoint=https://<endpoint-pod-address>:6443 --target-bucket=first.bucket --archive
> nb bucketclass create placement-bucketclass bc1 --backingstores=noobaa-default-backing-store --deep-archive-resource=nss1
> nb obc create obc1 --exact --bucketclass=bc1

check in DB - 
> oc rsh noobaa-db-pg-cluster-1
> psql nbcore
> select * from buckets;
 6a205ba6b6b12e0022dcd578 | {"_id": "6a205ba6b6b12e0022dcd578", "tag": "", "name": "obc1", "..... , "archive_policy": {"deep_archive_resource": {"resource": "6a205b98b6b12e0022dcd574"} .....} 
```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring archive policies on buckets, including optional deep-archive targets for archival storage.
  * Archive policies can now be provided when creating or updating buckets, and are applied automatically for buckets provisioned via placement policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->