### PR TITLE
Harden CNPG PostgreSQL config for replica HA stability

### DIFF
--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +28,10 @@ const (
 
 	noobaaDBUser = "noobaa"
 	noobaaDBName = "nbcore"
+
+	defaultCalcMemoryKB     = int64(16 * 1024 * 1024) // 16GB in KB — used when DBResources not specified
+	defaultCalcCPU          = int64(4)                // used when DBResources not specified
+	defaultFailoverDelaySec = int32(30)
 )
 
 // ReconcileCNPGCluster reconciles the CNPG cluster
@@ -300,6 +303,8 @@ func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
 		Enabled: true,
 	}
 
+	r.CNPGCluster.Spec.FailoverDelay = defaultFailoverDelaySec
+
 	r.setPostgresConfig()
 
 	// Configure backup settings if specified
@@ -562,53 +567,50 @@ func (r *Reconciler) setPostgresConfig() {
 		desiredParameters = map[string]string{}
 	}
 
-	var overrideParameters map[string]string
+	// default parameters
+	overrideParameters := map[string]string{
+		"huge_pages":                   "off",
+		"checkpoint_completion_target": "0.9",
+		"default_statistics_target":    "100",
+		"random_page_cost":             "1.1",
+		"effective_io_concurrency":     "300",
+		"min_wal_size":                 "2GB",
+		"max_wal_size":                 "8GB",
+		"jit":                          "off",
+		"wal_compression":              "lz4",
+		"wal_level":                    "replica",
+		"wal_sender_timeout":           "60s",
+		"wal_receiver_timeout":         "60s",
+		"pg_stat_statements.track":     "all",
+	}
+
 	_, endpointMaxCount := r.getEndpointMinMaxCount()
+
+	totalMemoryKB := defaultCalcMemoryKB
+	cpuNum := defaultCalcCPU
 	dbResources := r.NooBaa.Spec.DBSpec.DBResources
-	if dbResources != nil && !dbResources.Requests.Memory().IsZero() {
-		totalMemoryKB := dbResources.Requests.Memory().Value() / 1024
-
-		var cpuNum int64
-		if !dbResources.Requests.Cpu().IsZero() {
+	if dbResources != nil {
+		if !dbResources.Limits.Memory().IsZero() {
+			totalMemoryKB = dbResources.Limits.Memory().Value() / 1024
+		} else if !dbResources.Requests.Memory().IsZero() {
+			totalMemoryKB = dbResources.Requests.Memory().Value() / 1024
+		}
+		if !dbResources.Limits.Cpu().IsZero() {
+			cpuNum = dbResources.Limits.Cpu().MilliValue() / 1000
+		} else if !dbResources.Requests.Cpu().IsZero() {
 			cpuNum = dbResources.Requests.Cpu().MilliValue() / 1000
-			if cpuNum < 1 {
-				cpuNum = 1
-			}
 		}
-
-		// calculate max_connections from DBConf if specified, otherwise derive from endpoint count
-		maxConnections := calculateMaxConnections(int(endpointMaxCount))
-		if r.NooBaa.Spec.DBSpec.DBConf != nil {
-			if val, ok := r.NooBaa.Spec.DBSpec.DBConf["max_connections"]; ok {
-				if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
-					maxConnections = parsed
-				}
-			}
-		}
-
-		overrideParameters = calculatePGConfig(totalMemoryKB, cpuNum, maxConnections)
-		r.cnpgLog("calculated PGTune config: memory=%dKB, cpu=%d, max_connections=%d", totalMemoryKB, cpuNum, maxConnections)
-	} else {
-		// fallback to static defaults when DB resources are not specified
-		overrideParameters = map[string]string{
-			"huge_pages":                   "off",
-			"max_connections":              fmt.Sprintf("%d", calculateMaxConnections(int(endpointMaxCount))),
-			"shared_buffers":               "1GB",
-			"effective_cache_size":         "3GB",
-			"maintenance_work_mem":         "256MB",
-			"checkpoint_completion_target": "0.9",
-			"wal_buffers":                  "16MB",
-			"default_statistics_target":    "100",
-			"random_page_cost":             "1.1",
-			"effective_io_concurrency":     "300",
-			"work_mem":                     "1747kB",
-			"min_wal_size":                 "2GB",
-			"max_wal_size":                 "8GB",
-			"pg_stat_statements.track":     "all",
+		if cpuNum < 1 {
+			cpuNum = 1
 		}
 	}
 
-	// apply any user-specified DBConf overrides on top of the calculated/default values
+	for k, v := range calculatePGConfig(totalMemoryKB, cpuNum, int(endpointMaxCount), r.CNPGCluster.Spec.StorageConfiguration.Size) {
+		overrideParameters[k] = v
+	}
+	r.cnpgLog("PGTune config: memory=%dKB, cpu=%d, endpoints=%d", totalMemoryKB, cpuNum, endpointMaxCount)
+
+	// apply any user-specified DBConf overrides on top of the calculated values
 	if r.NooBaa.Spec.DBSpec.DBConf != nil {
 		for k, v := range r.NooBaa.Spec.DBSpec.DBConf {
 			overrideParameters[k] = v
@@ -625,25 +627,20 @@ func (r *Reconciler) setPostgresConfig() {
 	r.CNPGCluster.Spec.PostgresConfiguration.Parameters = desiredParameters
 }
 
-// calculatePGConfig computes PostgreSQL configuration parameters using PGTune logic.
-// Calculations are based on the source code: https://github.com/le0pard/pgtune/blob/master/src/features/configuration/configurationSlice.js
-// Web UI: https://pgtune.leopard.in.ua/
+// calculatePGConfig computes dynamically-calculated PostgreSQL configuration parameters.
+// Calculations are based on PGTune logic: https://github.com/le0pard/pgtune/blob/master/src/features/configuration/configurationSlice.js
 // Fixed assumptions: DB Version: 16, OS: Linux, DB Type: OLTP, Storage: SAN.
 // totalMemoryKB is the total DB memory in kilobytes, cpuNum is the number of CPU
-// cores (0 means unknown), and maxConnections is the desired max_connections value.
-func calculatePGConfig(totalMemoryKB int64, cpuNum int64, maxConnections int) map[string]string {
+// cores (0 means unknown), numEndpoints is the number of endpoint pods used to
+// derive max_connections, and dataVolumeSize is the PVC size string used to derive wal_keep_size.
+func calculatePGConfig(totalMemoryKB int64, cpuNum int64, numEndpoints int, dataVolumeSize string) map[string]string {
 	params := map[string]string{}
+
+	maxConnections := calculateMaxConnections(numEndpoints)
 
 	// shared_buffers = 25% of total memory
 	sharedBuffersKB := totalMemoryKB / 4
 	params["shared_buffers"] = formatBytesKB(sharedBuffersKB)
-
-	// huge_pages: "try" when shared_buffers >= 2GB (Linux only)
-	if sharedBuffersKB >= 2*1024*1024 {
-		params["huge_pages"] = "try"
-	} else {
-		params["huge_pages"] = "off"
-	}
 
 	// effective_cache_size = 75% of total memory
 	params["effective_cache_size"] = formatBytesKB((totalMemoryKB * 3) / 4)
@@ -654,8 +651,6 @@ func calculatePGConfig(totalMemoryKB int64, cpuNum int64, maxConnections int) ma
 		maintenanceWorkMemKB = 8 * 1024 * 1024
 	}
 	params["maintenance_work_mem"] = formatBytesKB(maintenanceWorkMemKB)
-
-	params["checkpoint_completion_target"] = "0.9"
 
 	// wal_buffers = 3% of shared_buffers, clamped to [32kB, 16MB], rounded up near 14MB
 	walBuffersKB := (3 * sharedBuffersKB) / 100
@@ -670,12 +665,7 @@ func calculatePGConfig(totalMemoryKB int64, cpuNum int64, maxConnections int) ma
 	}
 	params["wal_buffers"] = formatBytesKB(walBuffersKB)
 
-	params["default_statistics_target"] = "100"
-	params["random_page_cost"] = "1.1"
-	params["effective_io_concurrency"] = "300"
 	params["max_connections"] = fmt.Sprintf("%d", maxConnections)
-	params["min_wal_size"] = "2GB"
-	params["max_wal_size"] = "8GB"
 
 	// parallel query settings (only beneficial with >= 4 cores)
 	parallelForWorkMem := int64(8) // PG default max_worker_processes
@@ -706,10 +696,8 @@ func calculatePGConfig(totalMemoryKB int64, cpuNum int64, maxConnections int) ma
 	}
 	params["work_mem"] = formatBytesKB(workMemKB)
 
-	params["jit"] = "off"
-	params["wal_compression"] = "lz4"
-	// cnpg operator automatically adds the extension to the DB
-	params["pg_stat_statements.track"] = "all"
+	// wal_keep_size = 12% of data volume, capped at 16GB
+	params["wal_keep_size"] = calculateWalKeepSize(dataVolumeSize)
 
 	return params
 }
@@ -728,6 +716,29 @@ func formatBytesKB(kb int64) string {
 		return fmt.Sprintf("%dMB", kb/mbInKB)
 	}
 	return fmt.Sprintf("%dkB", kb)
+}
+
+// calculateWalKeepSize computes wal_keep_size as 12% of the data PVC size,
+// capped at 16GB. Falls back to "6GB" if the volume size cannot be parsed.
+func calculateWalKeepSize(dataVolumeSize string) string {
+	const (
+		walKeepFractionPercent = 12
+		maxWalKeepSizeMB       = int64(16 * 1024) // 16GB in MB
+		minWalKeepSizeMB       = int64(1024)      // 1GB minimum
+	)
+	qty, err := resource.ParseQuantity(dataVolumeSize)
+	if err != nil {
+		return "6GB"
+	}
+	volMB := qty.Value() / (1024 * 1024)
+	walKeepMB := volMB * int64(walKeepFractionPercent) / 100
+	if walKeepMB > maxWalKeepSizeMB {
+		walKeepMB = maxWalKeepSizeMB
+	}
+	if walKeepMB < minWalKeepSizeMB {
+		walKeepMB = minWalKeepSizeMB
+	}
+	return formatBytesKB(walKeepMB * 1024)
 }
 
 // calculateMaxConnections computes the PostgreSQL max_connections based on the
@@ -880,5 +891,6 @@ func (r *Reconciler) wasClusterSpecChanged(existingClusterSpec *cnpgv1.ClusterSp
 		!reflect.DeepEqual(existingClusterSpec.Monitoring, r.CNPGCluster.Spec.Monitoring) ||
 		!reflect.DeepEqual(existingClusterSpec.PostgresConfiguration.Parameters, r.CNPGCluster.Spec.PostgresConfiguration.Parameters) ||
 		!reflect.DeepEqual(existingClusterSpec.Backup, r.CNPGCluster.Spec.Backup) ||
-		existingClusterSpec.PriorityClassName != r.CNPGCluster.Spec.PriorityClassName
+		existingClusterSpec.PriorityClassName != r.CNPGCluster.Spec.PriorityClassName ||
+		existingClusterSpec.FailoverDelay != r.CNPGCluster.Spec.FailoverDelay
 }

--- a/pkg/system/db_reconciler_test.go
+++ b/pkg/system/db_reconciler_test.go
@@ -32,30 +32,21 @@ func TestFormatBytesKB(t *testing.T) {
 	}
 }
 
-func TestCalculatePGConfig_4GB_2CPU_300Conn(t *testing.T) {
-	// 4GB = 4 * 1024 * 1024 KB
+func TestCalculatePGConfig_4GB_2CPU_3Endpoints(t *testing.T) {
 	totalMemoryKB := int64(4 * 1024 * 1024)
 	cpuNum := int64(2)
-	maxConnections := 300
+	numEndpoints := 3
 
-	params := calculatePGConfig(totalMemoryKB, cpuNum, maxConnections)
+	params := calculatePGConfig(totalMemoryKB, cpuNum, numEndpoints, "50Gi")
 
+	// 3 endpoints -> max_connections = 3*20 + 3*80 + 3 = 303
 	expected := map[string]string{
-		"shared_buffers":               "1GB",
-		"effective_cache_size":         "3GB",
-		"maintenance_work_mem":         "256MB",
-		"huge_pages":                   "off",
-		"checkpoint_completion_target": "0.9",
-		"wal_buffers":                  "16MB",
-		"default_statistics_target":    "100",
-		"random_page_cost":             "1.1",
-		"effective_io_concurrency":     "300",
-		"max_connections":              "300",
-		"min_wal_size":                 "2GB",
-		"max_wal_size":                 "8GB",
-		"jit":                          "off",
-		"wal_compression":              "lz4",
-		"pg_stat_statements.track":     "all",
+		"shared_buffers":       "1GB",
+		"effective_cache_size": "3GB",
+		"maintenance_work_mem": "256MB",
+		"wal_buffers":          "16MB",
+		"max_connections":      "303",
+		"wal_keep_size":        "6GB",
 	}
 
 	for key, want := range expected {
@@ -81,29 +72,23 @@ func TestCalculatePGConfig_4GB_2CPU_300Conn(t *testing.T) {
 		}
 	}
 
-	// work_mem: (4GB - 1GB) / ((300 + 8) * 3) = 3GB / 924 = 3407kB
-	if params["work_mem"] != "4096kB" {
-		// (4194304 - 1048576) / ((300 + 8) * 3) = 3145728 / 924 = 3404
-		// 3404kB < 4096kB (4MB minimum), so work_mem should be 4MB
-		if params["work_mem"] != "4MB" {
-			t.Errorf("work_mem = %q, want %q", params["work_mem"], "4MB")
-		}
-	}
+	// work_mem: (4GB - 1GB) / ((303 + 8) * 3) = 3145728 / 933 = 3371kB < 4MB minimum
+	assertParam(t, params, "work_mem", "4MB")
 }
 
-func TestCalculatePGConfig_16GB_8CPU_300Conn(t *testing.T) {
+func TestCalculatePGConfig_16GB_8CPU_3Endpoints(t *testing.T) {
 	totalMemoryKB := int64(16 * 1024 * 1024)
 	cpuNum := int64(8)
-	maxConnections := 300
+	numEndpoints := 3
 
-	params := calculatePGConfig(totalMemoryKB, cpuNum, maxConnections)
+	params := calculatePGConfig(totalMemoryKB, cpuNum, numEndpoints, "50Gi")
 
+	// 3 endpoints -> max_connections = 303
 	assertParam(t, params, "shared_buffers", "4GB")
 	assertParam(t, params, "effective_cache_size", "12GB")
 	assertParam(t, params, "maintenance_work_mem", "1GB")
-	assertParam(t, params, "huge_pages", "try")
 	assertParam(t, params, "wal_buffers", "16MB")
-	assertParam(t, params, "max_connections", "300")
+	assertParam(t, params, "max_connections", "303")
 
 	// parallel settings with 8 CPUs
 	assertParam(t, params, "max_worker_processes", "8")
@@ -111,92 +96,75 @@ func TestCalculatePGConfig_16GB_8CPU_300Conn(t *testing.T) {
 	assertParam(t, params, "max_parallel_workers_per_gather", "4")
 	assertParam(t, params, "max_parallel_maintenance_workers", "4")
 
-	// work_mem: (16GB - 4GB) / ((300 + 8) * 3) = 12GB / 924
-	// = 12582912 / 924 = 13618kB = ~13MB
+	// work_mem: (16GB - 4GB) / ((303 + 8) * 3) = 12582912 / 933 = 13487kB
 	workMem := params["work_mem"]
 	if workMem == "" {
 		t.Error("work_mem not set")
 	}
 }
 
-func TestCalculatePGConfig_8GB_4CPU_600Conn(t *testing.T) {
+func TestCalculatePGConfig_8GB_4CPU_7Endpoints(t *testing.T) {
 	totalMemoryKB := int64(8 * 1024 * 1024)
 	cpuNum := int64(4)
-	maxConnections := 600
+	numEndpoints := 7
 
-	params := calculatePGConfig(totalMemoryKB, cpuNum, maxConnections)
+	params := calculatePGConfig(totalMemoryKB, cpuNum, numEndpoints, "50Gi")
 
+	// 7 endpoints -> max_connections = 3*20 + 7*80 + 3 = 623
 	assertParam(t, params, "shared_buffers", "2GB")
 	assertParam(t, params, "effective_cache_size", "6GB")
 	assertParam(t, params, "maintenance_work_mem", "512MB")
-	assertParam(t, params, "huge_pages", "try")
-	assertParam(t, params, "max_connections", "600")
+	assertParam(t, params, "max_connections", "623")
 
 	// parallel: cpuNum=4 so parallel settings should be set
 	assertParam(t, params, "max_worker_processes", "4")
 	assertParam(t, params, "max_parallel_workers", "4")
-	// ceil(4/2) = 2
 	assertParam(t, params, "max_parallel_workers_per_gather", "2")
 	assertParam(t, params, "max_parallel_maintenance_workers", "2")
 
-	// work_mem: (8GB - 2GB) / ((600 + 4) * 3) = 6GB / 1812
-	// = 6291456 / 1812 = 3472kB < 4096kB minimum
+	// work_mem: (8GB - 2GB) / ((623 + 4) * 3) = 6291456 / 1881 = 3344kB < 4MB minimum
 	assertParam(t, params, "work_mem", "4MB")
-}
-
-func TestCalculatePGConfig_HugePages_Threshold(t *testing.T) {
-	// 7GB memory -> shared_buffers = 1.75GB -> huge_pages = off
-	params7GB := calculatePGConfig(7*1024*1024, 2, 300)
-	assertParam(t, params7GB, "huge_pages", "off")
-
-	// 8GB memory -> shared_buffers = 2GB (exactly at threshold) -> huge_pages = try
-	params8GB := calculatePGConfig(8*1024*1024, 2, 300)
-	assertParam(t, params8GB, "huge_pages", "try")
-
-	// 16GB memory -> shared_buffers = 4GB -> huge_pages = try
-	params16GB := calculatePGConfig(16*1024*1024, 2, 300)
-	assertParam(t, params16GB, "huge_pages", "try")
 }
 
 func TestCalculatePGConfig_MaintenanceWorkMem_Cap(t *testing.T) {
 	// 256GB memory -> maintenance_work_mem = 256GB / 16 = 16GB, capped at 8GB
-	params := calculatePGConfig(256*1024*1024, 16, 300)
+	params := calculatePGConfig(256*1024*1024, 16, 3, "50Gi")
 	assertParam(t, params, "maintenance_work_mem", "8GB")
 }
 
 func TestCalculatePGConfig_WalBuffers(t *testing.T) {
 	// 256MB memory -> shared_buffers = 64MB -> wal_buffers = 3% * 64MB = 1966kB
-	params256MB := calculatePGConfig(256*1024, 1, 300)
+	params256MB := calculatePGConfig(256*1024, 1, 3, "50Gi")
 	got := params256MB["wal_buffers"]
 	if got != "1966kB" && got != "1MB" {
-		// 3 * 65536 / 100 = 1966kB (not evenly divisible by 1024 so stays as kB)
 		t.Logf("wal_buffers for 256MB = %q (this is expected to vary)", got)
 	}
 
-	// 1GB memory -> shared_buffers = 256MB -> wal_buffers = 3% * 256MB = 7864kB -> 7864kB
-	params1GB := calculatePGConfig(1024*1024, 1, 300)
+	// 1GB memory -> shared_buffers = 256MB -> wal_buffers = 3% * 256MB = 7864kB
+	params1GB := calculatePGConfig(1024*1024, 1, 3, "50Gi")
 	walBuf1GB := params1GB["wal_buffers"]
 	if walBuf1GB == "" {
 		t.Error("wal_buffers not set for 1GB")
 	}
 
 	// 4GB+ memory -> shared_buffers = 1GB+ -> wal_buffers = 3% >= ~30MB -> capped at 16MB
-	params4GB := calculatePGConfig(4*1024*1024, 1, 300)
+	params4GB := calculatePGConfig(4*1024*1024, 1, 3, "50Gi")
 	assertParam(t, params4GB, "wal_buffers", "16MB")
 }
 
 func TestCalculatePGConfig_WorkMem_MinimumFloor(t *testing.T) {
-	// Tiny memory with many connections -> work_mem should be at least 4MB
+	// Tiny memory with many endpoints -> work_mem should be at least 4MB
+	// 10 endpoints -> max_connections = 3*20 + 10*80 + 3 = 863
 	totalMemoryKB := int64(512 * 1024) // 512MB
-	params := calculatePGConfig(totalMemoryKB, 1, 1000)
+	params := calculatePGConfig(totalMemoryKB, 1, 10, "50Gi")
 
-	// work_mem = (512MB - 128MB) / ((1000 + 8) * 3) = 384MB / 3024 = 130kB -> floor to 4MB
+	// work_mem = (512MB - 128MB) / ((863 + 8) * 3) = 393216 / 2613 = 150kB -> floor to 4MB
 	assertParam(t, params, "work_mem", "4MB")
 }
 
 func TestCalculatePGConfig_ParallelWorkers_Capping(t *testing.T) {
 	// 32 CPUs -> workers_per_gather = ceil(32/2) = 16 -> capped at 4
-	params := calculatePGConfig(32*1024*1024, 32, 300)
+	params := calculatePGConfig(32*1024*1024, 32, 3, "50Gi")
 
 	assertParam(t, params, "max_worker_processes", "32")
 	assertParam(t, params, "max_parallel_workers", "32")
@@ -205,7 +173,7 @@ func TestCalculatePGConfig_ParallelWorkers_Capping(t *testing.T) {
 }
 
 func TestCalculatePGConfig_NoCPU(t *testing.T) {
-	params := calculatePGConfig(4*1024*1024, 0, 300)
+	params := calculatePGConfig(4*1024*1024, 0, 3, "50Gi")
 
 	// no parallel settings when cpuNum < 4
 	for _, key := range []string{
@@ -220,16 +188,51 @@ func TestCalculatePGConfig_NoCPU(t *testing.T) {
 	}
 }
 
+func TestCalculatePGConfig_WalKeepSize(t *testing.T) {
+	params50 := calculatePGConfig(4*1024*1024, 2, 3, "50Gi")
+	assertParam(t, params50, "wal_keep_size", "6GB")
+
+	params200 := calculatePGConfig(4*1024*1024, 2, 3, "200Gi")
+	assertParam(t, params200, "wal_keep_size", "16GB")
+
+	paramsInvalid := calculatePGConfig(4*1024*1024, 2, 3, "invalid")
+	assertParam(t, paramsInvalid, "wal_keep_size", "6GB")
+}
+
+func TestCalculateWalKeepSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		volSize  string
+		expected string
+	}{
+		{"50Gi default", "50Gi", "6GB"},
+		{"100Gi", "100Gi", "12GB"},
+		{"200Gi hits 16GB cap", "200Gi", "16GB"},
+		{"500Gi hits 16GB cap", "500Gi", "16GB"},
+		{"10Gi small", "10Gi", "1228MB"},
+		{"invalid falls back", "invalid", "6GB"},
+		{"empty falls back", "", "6GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateWalKeepSize(tt.volSize)
+			if got != tt.expected {
+				t.Errorf("calculateWalKeepSize(%q) = %q, want %q", tt.volSize, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestCalculateMaxConnections(t *testing.T) {
 	tests := []struct {
 		name         string
 		numEndpoints int
 		expected     int
 	}{
-		{"1 endpoint", 1, 3*20 + 1*80 + 3},   // 143
-		{"2 endpoints", 2, 3*20 + 2*80 + 3},   // 223
-		{"3 endpoints", 3, 3*20 + 3*80 + 3},   // 303
-		{"5 endpoints", 5, 3*20 + 5*80 + 3},   // 463
+		{"1 endpoint", 1, 3*20 + 1*80 + 3},     // 143
+		{"2 endpoints", 2, 3*20 + 2*80 + 3},    // 223
+		{"3 endpoints", 3, 3*20 + 3*80 + 3},    // 303
+		{"5 endpoints", 5, 3*20 + 5*80 + 3},    // 463
 		{"10 endpoints", 10, 3*20 + 10*80 + 3}, // 863
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Describe the Problem

CNPG's default PostgreSQL configuration is not suitable for NooBaa's workload. Specifically:
- `wal_keep_size` defaults to 512MB (CNPG default), which is insufficient for replica bootstrap windows at NooBaa's WAL generation rate (~150-200 MB/min), causing permanent stuck replicas.
- `wal_level` defaults to `logical`, adding ~10-30% WAL volume overhead with no benefit (NooBaa does not use logical replication).
- `wal_sender_timeout` and `wal_receiver_timeout` default to 5s (CNPG override of PG's 60s default), causing premature WAL streaming disconnects on transient hiccups.
- `failoverDelay` defaults to 0, triggering unnecessary failovers on brief blips.
- `setPostgresConfig` had two divergent code paths (calculated vs. static fallback) that were hard to maintain.

### Explain the Changes
1. Simplify `setPostgresConfig` — remove the static fallback map; always call `calculatePGConfig` using defaults of 16GB memory and 4 CPUs when `DBResources` are not specified (for calculation only, not set on the CR).
2. Move static/constant PG parameters to the top of `setPostgresConfig` as a single map literal; `calculatePGConfig` now only handles dynamically-computed values.
3. Set `wal_level: replica` — eliminates ~10-30% WAL overhead from unused logical decoding.
4. Set `wal_sender_timeout: 60s` and `wal_receiver_timeout: 60s` — match PostgreSQL upstream defaults; prevents premature streaming disconnects.
5. Add `calculateWalKeepSize` — computes `wal_keep_size` as 12% of the data PVC size, capped at 16GB (min 1GB), protecting replica bootstrap from WAL recycling.
6. Set `failoverDelay: 30` on the CNPG Cluster spec — gives transient issues 30s to resolve before triggering a failover.
7. Always set `huge_pages: off` — removes conditional logic that set `"try"` for large shared_buffers.
8. Move `calculateMaxConnections` call inside `calculatePGConfig` — function now takes `numEndpoints` directly.
9. Track `FailoverDelay` in `wasClusterSpecChanged` so changes propagate to existing clusters.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6943

### Testing Instructions:
1. Run unit tests: `go test ./pkg/system/ -run "TestCalculatePGConfig|TestCalculateWalKeepSize|TestCalculateMaxConnections|TestFormatBytesKB" -v`
2. Deploy operator on a cluster with a CNPG-managed NooBaa DB and verify the Cluster CR parameters are updated on reconcile.
3. Verify `DBConf` user overrides still take precedence (set `dbConf.wal_level: logical` in NooBaa CR and confirm it wins).

- [ ] Doc added/updated
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PostgreSQL auto-tuning: computes settings from container limits (with request fallbacks), uses endpoint count for max connections, applies static overrides (e.g., huge_pages off, checkpoint target), and enforces defaults and DB-config overrides; clusters now honor failover-delay changes.

* **Tests**
  * Expanded unit tests for endpoint-based tuning and WAL keep-size parsing, capping, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->