### PR TITLE
GCP WIF (STS) | Backingstore CLI

### DIFF
--- a/doc/backing-store-crd.md
+++ b/doc/backing-store-crd.md
@@ -71,7 +71,7 @@ However, the difference between the two backingstore types lies in the authentic
 
 This type of backingstore is useful in cases where the user wishes to limit access to their AWS cloud for a specific amount of time, and for easier management of the cloud's security.
 
-Prior to using this backingstore, an OpenIDConnect provider needs to be set up, which is outside the scope of these docs.
+Before using this backingstore, an OpenIDConnect provider needs to be set up, which is outside the scope of these docs.
 
 ```shell
 noobaa backingstore create aws-sts-s3 <BACKINGSTORE NAME> --target-bucket <> --aws-sts-arn <>
@@ -143,7 +143,7 @@ spec:
   type: ibm-cos
 ```
 
-## Google Cloud Storage
+## Google Cloud Storage (GCP)
 Uses the Google Cloud Storage API for storing encrypted chunks of data in Google Cloud buckets
 ```shell
 noobaa backingstore create google-cloud-storage <BACKINGSTORE NAME> --private-key-json-file <PATH TO credentials.json> --target-bucket <>
@@ -172,6 +172,36 @@ Permissions: the service account should have the `storage.buckets.list` permissi
   - `Browser` role: provides the `storage.buckets.list` permission.
   - `Storage Admin` role: provides full control over buckets and objects.
 - The `Owner` role (for development; not recommended for production environments).
+
+## Google Cloud Storage Workload Identity Federation (GCP WIF, STS)
+Similarly to `Google Cloud Storage` this backing store uses the Google Cloud Storage API for storing encrypted chunks of data in GCP buckets.
+However, the difference between the two backingstore types lies in the authentication method:
+- `google-cloud-storage` uses long-lived `service_account` JSON keys.
+- `google-cloud-storage-sts` uses a short-lived token via GCP Workload Identity Federation: the JSON type is `external_account`, which is built from parameters (`PROJECT_NUMBER`, `POOL_ID`, `PROVIDER_ID`, `SERVICE_ACCOUNT_EMAIL`).
+
+This type of backingstore is useful in cases where the user wishes to limit access to their GCP cloud for a specific amount of time, and for easier management of the cloud's security.
+
+Before using this backingstore, there are configurations that need to be done on the GCP account and on the cluster (for example, an OpenIDConnect provider needs to be set up) which is outside the scope of these docs.
+
+```shell
+noobaa backingstore create google-cloud-storage-sts <BACKINGSTORE NAME> --target-bucket <> --project-number <> --pool-id <> --provider-id <> --service-account-email <>
+```
+```yaml
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  finalizers:
+  - noobaa.io/finalizer
+  name: <>
+  namespace: <>
+spec:
+  googleCloudStorage:
+    secret:
+      name: <>
+      namespace: <>
+    targetBucket: <>
+  type: google-cloud-storage
+```
 
 ## Azure Blob Storage
 Uses the Azure Blob API for storing encrypted chunks of data in an Azure container

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -64,6 +64,7 @@ func CmdCreate() *cobra.Command {
 		CmdCreateIBMCos(),
 		CmdCreateAzureBlob(),
 		CmdCreateGoogleCloudStorage(),
+		CmdCreateGoogleCloudStorageSTS(),
 		CmdCreatePVPool(),
 		CmdCreateAzureSTS(),
 	)
@@ -246,7 +247,7 @@ func CmdCreateAzureBlob() *cobra.Command {
 func CmdCreateGoogleCloudStorage() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "google-cloud-storage <backing-store-name>",
-		Short: "Create google-cloud-storage backing store",
+		Short: "Create google-cloud-storage backing store (using long-lived credentials)",
 		Run:   RunCreateGoogleCloudStorage,
 	}
 	cmd.Flags().String(
@@ -260,6 +261,40 @@ func CmdCreateGoogleCloudStorage() *cobra.Command {
 	cmd.Flags().String(
 		"secret-name", "",
 		`The name of a secret for authentication - should have GoogleServiceAccountPrivateKeyJson property`,
+	)
+	return cmd
+}
+
+// CmdCreateGoogleCloudStorageSTS returns a CLI command
+func CmdCreateGoogleCloudStorageSTS() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "google-cloud-storage-sts <backing-store-name>",
+		Short: "Create google-cloud-storage backing store using GCP WIF (STS, short-lived credentials)",
+		Run:   RunCreateGoogleCloudStorageSTS,
+	}
+	cmd.Flags().String(
+		"target-bucket", "",
+		"The target bucket name on Google cloud storage",
+	)
+	cmd.Flags().String(
+		"service-account-email", "",
+		"The GCP service account email to impersonate",
+	)
+	cmd.Flags().String(
+		"project-number", "",
+		"The GCP project number (numeric string, e.g. 123456789; not the project ID)",
+	)
+	cmd.Flags().String(
+		"pool-id", "",
+		"The GCP workload identity pool ID",
+	)
+	cmd.Flags().String(
+		"provider-id", "",
+		"The GCP workload identity provider ID",
+	)
+	cmd.Flags().String(
+		"secret-name", "",
+		`The name of a secret for authentication - should have GoogleServiceAccountPrivateKeyJson property (with type of external_account)`,
 	)
 	return cmd
 }
@@ -483,7 +518,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 	if len(args) != 1 || args[0] == "" {
 		log.Fatalf(`❌ Missing expected arguments: <backing-store-type> %s`, cmd.UsageString())
 	}
-	if args[0] != "aws-s3" && args[0] != "aws-sts-s3" && args[0] != "google-cloud-storage" &&
+	if args[0] != "aws-s3" && args[0] != "aws-sts-s3" && args[0] != "google-cloud-storage" && args[0] != "google-cloud-storage-sts" &&
 		args[0] != "azure-blob" && args[0] != "ibm-cos" && args[0] != "pv-pool" && args[0] != "s3-compatible" && args[0] != "azure-sts-blob" {
 		log.Fatalf(`❌ Unsupported <backing-store-type> -> %s %s`, args[0], cmd.UsageString())
 	}
@@ -725,6 +760,41 @@ func RunCreateGoogleCloudStorage(cmd *cobra.Command, args []string) {
 				log.Fatalf("Failed to parse json file %q: %v", privateKeyJSONFile, err)
 			}
 			secret.StringData["GoogleServiceAccountPrivateKeyJson"] = string(bytes)
+		} else {
+			util.VerifyCredsInSecret(secretName, options.Namespace, mandatoryProperties)
+			secret.Name = secretName
+			secret.Namespace = options.Namespace
+		}
+
+		backStore.Spec.GoogleCloudStorage = &nbv1.GoogleCloudStorageSpec{
+			TargetBucket: targetBucket,
+			Secret: corev1.SecretReference{
+				Name:      secret.Name,
+				Namespace: secret.Namespace,
+			},
+		}
+	})
+}
+
+// RunCreateGoogleCloudStorageSTS runs a CLI command
+func RunCreateGoogleCloudStorageSTS(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+	createCommon(cmd, args, nbv1.StoreTypeGoogleCloudStorage, func(backStore *nbv1.BackingStore, secret *corev1.Secret) {
+		targetBucket := util.GetFlagStringOrPrompt(cmd, "target-bucket")
+		secretName, _ := cmd.Flags().GetString("secret-name")
+		mandatoryProperties := []string{"GoogleServiceAccountPrivateKeyJson"}
+
+		if secretName == "" {
+			projectNumber := util.GetFlagStringOrPrompt(cmd, "project-number")
+			poolID := util.GetFlagStringOrPrompt(cmd, "pool-id")
+			providerID := util.GetFlagStringOrPrompt(cmd, "provider-id")
+			serviceAccountEmail := util.GetFlagStringOrPrompt(cmd, "service-account-email")
+			credentialsJSON, err := util.BuildGoogleWIFCredentialsJSON(projectNumber,
+				poolID, providerID, serviceAccountEmail)
+			if err != nil {
+				log.Fatalf("Failed to build GCP WIF credentials: %v", err)
+			}
+			secret.StringData["GoogleServiceAccountPrivateKeyJson"] = credentialsJSON
 		} else {
 			util.VerifyCredsInSecret(secretName, options.Namespace, mandatoryProperties)
 			secret.Name = secretName

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -110,6 +110,32 @@ var _ = Describe("CLI tests", func() {
 			Expect(out).To(ContainSubstring("secret-name"))
 		})
 	})
+
+	Context("Noobaa CLI commands related to GCP", func() {
+		It("backingstore create google-cloud-storage --help shows GCP options", func() {
+			out, err := RunCLI("backingstore", "create", "google-cloud-storage", "--help")
+			Expect(err).To(BeNil())
+			Expect(out).To(ContainSubstring("target-bucket"))
+			Expect(out).To(ContainSubstring("private-key-json-file"))
+			Expect(out).To(ContainSubstring("secret-name"))
+			Expect(out).NotTo(ContainSubstring("service-account-email"))
+			Expect(out).NotTo(ContainSubstring("project-number"))
+			Expect(out).NotTo(ContainSubstring("pool-id"))
+			Expect(out).NotTo(ContainSubstring("provider-id"))
+		})
+
+		It("backingstore create google-cloud-storage-sts --help shows GCP WIF (STS) options", func() {
+			out, err := RunCLI("backingstore", "create", "google-cloud-storage-sts", "--help")
+			Expect(err).To(BeNil())
+			Expect(out).To(ContainSubstring("target-bucket"))
+			Expect(out).To(ContainSubstring("service-account-email"))
+			Expect(out).To(ContainSubstring("project-number"))
+			Expect(out).To(ContainSubstring("pool-id"))
+			Expect(out).To(ContainSubstring("provider-id"))
+			Expect(out).To(ContainSubstring("secret-name"))
+			Expect(out).NotTo(ContainSubstring("private-key-json-file"))
+		})
+	})
 })
 
 func RunCLI(args ...string) (string, error) {

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -350,7 +350,7 @@ func NewReconciler(
 
 	r.DefaultCoreApp = r.CoreApp.Spec.Template.Spec.DeepCopy()
 	r.DefaultDeploymentEndpoint = r.DeploymentEndpoint.Spec.Template.Spec.DeepCopy()
-	r.webIdentityTokenPath = "/var/run/secrets/openshift/serviceaccount/token"
+	r.webIdentityTokenPath = util.WebIdentityTokenPath
 
 	return r
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -95,6 +95,9 @@ const (
 	// InjectedBundleCertCAFile points to OCP root CA to be added to the default root CA list
 	InjectedBundleCertCAFile = "/etc/ocp-injected-ca-bundle/ca-bundle.crt"
 
+	// WebIdentityTokenPath is the projected service account token path used for AWS/Azure/GCP STS.
+	WebIdentityTokenPath = "/var/run/secrets/openshift/serviceaccount/token"
+
 	// Google impersonation URL constants
 	GoogleImpersonationURLPrefix = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
 	GoogleImpersonationURLSuffix = ":generateAccessToken"
@@ -116,6 +119,21 @@ type googleCredentialsJSON struct {
 	Type                           string `json:"type"`
 	PrivateKeyID                   string `json:"private_key_id,omitempty"`
 	ServiceAccountImpersonationURL string `json:"service_account_impersonation_url,omitempty"`
+}
+
+// googleCredentialsJSONFullSTS represents the complete structure of GCP Workload Identity Federation credentials
+type googleCredentialsJSONFullSTS struct {
+	Type                           string                    `json:"type"`
+	Audience                       string                    `json:"audience"`
+	SubjectTokenType               string                    `json:"subject_token_type"`
+	TokenURL                       string                    `json:"token_url"`
+	ServiceAccountImpersonationURL string                    `json:"service_account_impersonation_url"`
+	CredentialSource               googleWIFCredentialSource `json:"credential_source"`
+}
+
+type googleWIFCredentialSource struct {
+	File   string            `json:"file"`
+	Format map[string]string `json:"format"`
 }
 
 // AccessKeyRegexp validates access keys, which are 20 characters long and may include alphanumeric characters
@@ -1251,6 +1269,49 @@ func googleIdentityFromImpersonationURL(impersonationURL string) (string, error)
 		return "", fmt.Errorf("invalid service_account_impersonation_url: malformed service account email %q in %q", email, impersonationURL)
 	}
 	return email, nil
+}
+
+// GoogleWIFAudience returns the WIF audience URL for the given pool and provider for GCP WIF (STS)..
+func GoogleWIFAudience(projectNumber, poolID, providerID string) string {
+	return fmt.Sprintf("//iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s",
+		projectNumber, poolID, providerID)
+}
+
+// BuildGoogleWIFCredentialsJSON builds external_account credentials JSON for GCP WIF (STS).
+func BuildGoogleWIFCredentialsJSON(projectNumber, poolID, providerID, serviceAccountEmail string) (string, error) {
+	projectNumber = strings.TrimSpace(projectNumber)
+	poolID = strings.TrimSpace(poolID)
+	providerID = strings.TrimSpace(providerID)
+	serviceAccountEmail = strings.TrimSpace(serviceAccountEmail)
+
+	if projectNumber == "" || poolID == "" || providerID == "" || serviceAccountEmail == "" {
+		return "", fmt.Errorf("project number, pool id, provider id, and service account email are required")
+	}
+	if !strings.Contains(serviceAccountEmail, "@") {
+		return "", fmt.Errorf("invalid service_account_impersonation_url: malformed service account email %q", serviceAccountEmail)
+	}
+
+	googleExternalAccountCredentialType := "external_account"
+	audience := GoogleWIFAudience(projectNumber, poolID, providerID)
+
+	credentials := googleCredentialsJSONFullSTS{
+		Type:                           googleExternalAccountCredentialType,
+		Audience:                       audience,
+		SubjectTokenType:               "urn:ietf:params:oauth:token-type:jwt",
+		TokenURL:                       "https://sts.googleapis.com/v1/token",
+		ServiceAccountImpersonationURL: GoogleImpersonationURLPrefix + serviceAccountEmail + GoogleImpersonationURLSuffix,
+		CredentialSource: googleWIFCredentialSource{
+			File:   WebIdentityTokenPath,
+			Format: map[string]string{"type": "text"},
+		},
+	}
+
+	credentialsBytes, err := json.Marshal(credentials)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal credentials: %w", err)
+	}
+
+	return string(credentialsBytes), nil
 }
 
 // IsAzurePlatformNonGovernment returns true if this cluster is running on Azure and also not on azure government\DOD cloud

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
@@ -348,4 +349,82 @@ func TestGoogleIdentityFromImpersonationURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGoogleWIFAudience(t *testing.T) {
+	got := GoogleWIFAudience("123456789", "my-pool", "my-provider")
+	want := "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider"
+	if got != want {
+		t.Fatalf("expected audience %q, got %q", want, got)
+	}
+}
+
+func TestBuildGoogleWIFCredentialsJSON(t *testing.T) {
+	const (
+		projectNumber       = "123456789"
+		poolID              = "my-pool"
+		providerID          = "my-provider"
+		serviceAccountEmail = "noobaa-wif-sa@my-project.iam.gserviceaccount.com"
+	)
+
+	t.Run("valid parameters", func(t *testing.T) {
+		credentialsJSON, err := BuildGoogleWIFCredentialsJSON(
+			projectNumber, poolID, providerID, serviceAccountEmail,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		isExternalAccount, identity, err := ParseGoogleCredentials(credentialsJSON)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+		if !isExternalAccount {
+			t.Fatal("expected external_account credentials")
+		}
+		if identity != serviceAccountEmail {
+			t.Fatalf("expected identity %q, got %q", serviceAccountEmail, identity)
+		}
+		if !strings.Contains(credentialsJSON, GoogleWIFAudience(projectNumber, poolID, providerID)) {
+			t.Fatalf("expected audience in credentials json: %s", credentialsJSON)
+		}
+		if !strings.Contains(credentialsJSON, WebIdentityTokenPath) {
+			t.Fatalf("expected token path in credentials json: %s", credentialsJSON)
+		}
+	})
+
+	t.Run("ignores surrounding whitespace on parameters", func(t *testing.T) {
+		credentialsJSON, err := BuildGoogleWIFCredentialsJSON(
+			" "+projectNumber+" ",
+			" "+poolID+" ",
+			" "+providerID+" ",
+			" "+serviceAccountEmail+" ",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedAudience := GoogleWIFAudience(projectNumber, poolID, providerID)
+		if !strings.Contains(credentialsJSON, expectedAudience) {
+			t.Fatalf("expected audience %q in json, got: %s", expectedAudience, credentialsJSON)
+		}
+		if strings.Contains(credentialsJSON, " "+projectNumber+" ") {
+			t.Fatalf("json must not contain untrimmed project number with spaces")
+		}
+
+		_, identity, err := ParseGoogleCredentials(credentialsJSON)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+		if identity != serviceAccountEmail {
+			t.Fatalf("expected trimmed identity %q, got %q", serviceAccountEmail, identity)
+		}
+	})
+
+	t.Run("missing required parameters", func(t *testing.T) {
+		_, err := BuildGoogleWIFCredentialsJSON("", "", "", "")
+		if err == nil {
+			t.Fatal("expected error when required params are missing")
+		}
+	})
 }


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661), this PR sets the new endpoint type `GOOGLE_STS` (we had `GOOGLE`) and starts implementing code changes in parts of the flows related to the GCP WIF (STS) backing store.

### Explain the changes
1. Added a new subcommand `noobaa backingstore google-cloud-storage-sts <backing-store-name>` that either get the required parameters for creating the JSON in the secret or gets the secret with the JSON inside.
2. Added in utils the token path const and set it where it was already used. Also, added helper function for creating the JSON that would be set as a value in the GCP WIF (STS) value.
3. Added AI-generated tests for the helper functions.
4. Added documentation about the GCP WIF (STS) type.
5. Added tests on the help to test the existing flags for GCP and GCP WIF (STS) in the `noobaa backingstore` command.

### Issues:
List of GAPs:
1. GCP WIF (STS) namespace store is not handled as part of this PR.
2. Currently, in the secret we still have the field of `GoogleServiceAccountPrivateKeyJson` in the data; also,  for the case of GCP WIF (STS), we might change it later for readability.
3. I didn't add validation per required parameter in the CLI - would probably add in one of the following PRs (link to the issue #1933).

### Testing Instructions:
#### Unit Tests:
Please run:
1. CLI help test: 
- First, build the image and the CLI (can be done by `make all DOCKER_DEFAULT_PLATFORM=linux/arm64 GOARCH=arm64`).
- Export the operator image tag that was build: `export OPERATOR_IMAGE=noobaa/noobaa-operator:5.23.0` 
- Run the test: `go test -mod=vendor -v ./pkg/cli -ginkgo.focus "google-cloud-storage"`
2. Helper functions unit tests: `go test -mod=vendor -count=1 -v ./pkg/util -run 'TestGoogleWIFAudience|TestBuildGoogleWIFCredentialsJSON'`

#### Manual Tests:
1. Deploy NooBaa on Minikube after adding GCP WIF configurations - see guide "Create GCP WIF (STS) Setup On Minikube With NooBaa" ([link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_gcp_wif_setup_on_minikube_with_noobaa.md)).
2. Create a secret with the details of the credential.json for GCP WIF (STS).
3. Create a backing using the CLI (expect the backingstore to be `Ready`):
- (should ask for required parameters): `nooba backingstore create google-cloud-storage-sts <backingstore-name> -n <namespace>`
- (should not ask for required parameters): `nooba backingstore create google-cloud-storage-sts <backingstore-name> --secret-name  <secret-name> -n <namespace>` (the instructions for creating the secret [here](https://github.com/noobaa/noobaa-operator/pull/1923#issuecomment-4590173559)).

- [X] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Cloud Storage Workload Identity Federation (WIF/STS) backing store support and new CLI options to configure WIF parameters; backing store creation accepts STS credentials.
  * Reconciler now uses the projected web identity token path by default for STS flows.

* **Documentation**
  * Clarified GCS credential types and WIF/STS usage with CLI and BackingStore examples.

* **Tests**
  * Added tests for WIF audience/credentials generation and updated CLI help tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->