### PR TITLE
Update Core Image Tag "master-20260603"

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20260602"
+	ContainerImageTag = "master-20260603"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
### Describe the Problem
Updating noobaa-core tag due to create_bucket() api updates.

### Explain the changes
1. Update it to yesterday - I checked the [noobaa/nooba-core Docker repository](https://hub.docker.com/r/noobaa/noobaa-core/tags) and could see the image ([link](https://hub.docker.com/layers/noobaa/noobaa-core/master-20260603/images/sha256-8b8abd7bb2bdab1ff6659c0ec8aba97527783c6b9c6edf79dfb3caf7baf886ad)).

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default container image tag to "master-20260603", changing the default image used by the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->