### PR TITLE
GCP WIF (STS) | Default Backingstore with CCO

### DIFF
--- a/pkg/olm/olm.go
+++ b/pkg/olm/olm.go
@@ -278,6 +278,8 @@ func GenerateCSV(opConf *operator.Conf, csvParams *generateCSVParams) *operv1.Cl
 	csv.Annotations["features.operators.openshift.io/token-auth-aws"] = "true"
 	// annotation for Azure managed identity STS cluster
 	csv.Annotations["features.operators.openshift.io/token-auth-azure"] = "true"
+	// annotation for OpenShift GCP WIF (STS) cluster
+	csv.Annotations["features.operators.openshift.io/token-auth-gcp"] = "true"
 	csv.Annotations["capabilities"] = "Seamless Upgrades"
 	csv.Spec.Version.Version = semver.MustParse(version.Version)
 	csv.Spec.Description = bundle.File_deploy_olm_description_md

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -191,6 +191,8 @@ func RunUpgrade(cmd *cobra.Command, args []string) {
 		c.Deployment.Spec.Template.Spec.Containers[0].Env = operatorContainer.Env
 	}
 
+	appendGCPWIFEnvVars(&c.Deployment.Spec.Template.Spec.Containers[0], cmd)
+
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
 		operatorContainer := c.Deployment.Spec.Template.Spec.Containers[0]
@@ -305,6 +307,8 @@ func RunInstall(cmd *cobra.Command, args []string) {
 		})
 		c.Deployment.Spec.Template.Spec.Containers[0].Env = operatorContainer.Env
 	}
+
+	appendGCPWIFEnvVars(&c.Deployment.Spec.Template.Spec.Containers[0], cmd)
 
 	noDeploy, _ := cmd.Flags().GetBool("no-deploy")
 	if !noDeploy {
@@ -689,4 +693,26 @@ func AdmissionWebhookSetup(c *Conf) {
 
 func configureClusterRole(cr *rbacv1.ClusterRole) {
 	cr.Name = options.SubDomainNS()
+}
+
+// appendGCPWIFEnvVars appends GCP WIF (STS) environment variables to the operator container
+func appendGCPWIFEnvVars(operatorContainer *corev1.Container, cmd *cobra.Command) {
+	// flag to env var mapping
+	for _, flagEnv := range []struct {
+		envName string
+		flag    string
+	}{
+		{"PROJECT_NUMBER", "google-cloud-project-number"},
+		{"POOL_ID", "google-cloud-pool-id"},
+		{"PROVIDER_ID", "google-cloud-provider-id"},
+		{"SERVICE_ACCOUNT_EMAIL", "google-cloud-service-account-email"},
+	} {
+		value, _ := cmd.Flags().GetString(flagEnv.flag)
+		if value != "" {
+			operatorContainer.Env = append(operatorContainer.Env, corev1.EnvVar{
+				Name:  flagEnv.envName,
+				Value: value,
+			})
+		}
+	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -213,6 +213,22 @@ var SubscriptionId = ""
 // it can be overridden for testing.
 var ResourcegroupId = ""
 
+// GoogleCloudProjectNumber is used on a GCP WIF (STS) cluster.
+// it can be overridden for testing.
+var GoogleCloudProjectNumber = ""
+
+// GoogleCloudPoolId is used on a GCP WIF (STS) cluster.
+// it can be overridden for testing.
+var GoogleCloudPoolId = ""
+
+// GoogleCloudProviderId is used on a GCP WIF (STS) cluster.
+// it can be overridden for testing.
+var GoogleCloudProviderId = ""
+
+// GoogleCloudServiceAccountEmail is used on a GCP WIF (STS) cluster.
+// it can be overridden for testing.
+var GoogleCloudServiceAccountEmail = ""
+
 // SubDomainNS returns a unique subdomain for the namespace
 func SubDomainNS() string {
 	return Namespace + ".noobaa.io"
@@ -404,5 +420,21 @@ func init() {
 	FlagSet.StringVar(
 		&ResourcegroupId, "azure-resourcegroup",
 		ResourcegroupId, "The Azure STS resource group name",
+	)
+	FlagSet.StringVar(
+		&GoogleCloudProjectNumber, "google-cloud-project-number",
+		GoogleCloudProjectNumber, "The GCP WIF (STS) project number",
+	)
+	FlagSet.StringVar(
+		&GoogleCloudPoolId, "google-cloud-pool-id",
+		GoogleCloudPoolId, "The GCP WIF (STS) pool ID",
+	)
+	FlagSet.StringVar(
+		&GoogleCloudProviderId, "google-cloud-provider-id",
+		GoogleCloudProviderId, "The GCP WIF (STS) provider ID",
+	)
+	FlagSet.StringVar(
+		&GoogleCloudServiceAccountEmail, "google-cloud-service-account-email",
+		GoogleCloudServiceAccountEmail, "The GCP WIF (STS) service account email",
 	)
 }

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -46,6 +46,11 @@ const (
 	subscriptionIDEnvVar    string = "SUBSCRIPTIONID"
 	resourcegroupIDEnvVar   string = "RESOURCEGROUP"
 	azureRegionEnvVar       string = "AZUREREGION"
+	// GCP WIF (STS)
+	gcpProjectNumberEnvVar       string = "PROJECT_NUMBER"
+	gcpPoolIdEnvVar              string = "POOL_ID"
+	gcpProviderIdEnvVar          string = "PROVIDER_ID"
+	gcpServiceAccountEmailEnvVar string = "SERVICE_ACCOUNT_EMAIL"
 )
 
 // ReconcilePhaseCreating runs the reconcile phase
@@ -1163,6 +1168,28 @@ func (r *Reconciler) ReconcileAzureCredentials() error {
 
 // ReconcileGCPCredentials creates a CredentialsRequest resource if cloud credentials operator is available
 func (r *Reconciler) ReconcileGCPCredentials() error {
+	// check if we have the envs that indicates that this is an OpenShift GCP WIF (STS) cluster:
+	// PROJECT_NUMBER, POOL_ID, PROVIDER_ID (all 3 of them create the AUDIENCE), and SERVICE_ACCOUNT_EMAIL
+	// cluster admin set this env (either in the UI or via Subscription yaml) and set the mode to manual
+	// olm will then copy the env from the subscription to the operator deployment (which is where your operator can pick it up from)
+	projectNumber := os.Getenv(gcpProjectNumberEnvVar)
+	poolId := os.Getenv(gcpPoolIdEnvVar)
+	providerId := os.Getenv(gcpProviderIdEnvVar)
+	serviceAccountEmail := os.Getenv(gcpServiceAccountEmailEnvVar)
+
+	if projectNumber != "" || poolId != "" || providerId != "" || serviceAccountEmail != "" {
+		r.Logger.Infof("GCP WIF (STS) cluster: %s=%s %s=%s %s=%s %s=%s",
+			gcpProjectNumberEnvVar, projectNumber, gcpPoolIdEnvVar, poolId,
+			gcpProviderIdEnvVar, providerId, gcpServiceAccountEmailEnvVar, serviceAccountEmail,
+		)
+		if projectNumber != "" && poolId != "" && providerId != "" && serviceAccountEmail != "" {
+			r.IsGCPSTSCluster = true
+		} else {
+			r.Logger.Errorf("One or more required param missing for GCP WIF (STS)")
+			return fmt.Errorf("One or more required param missing for GCP WIF (STS)")
+		}
+	}
+
 	r.Logger.Info("Running on GCP. will create a CredentialsRequest resource")
 	err := r.Client.Get(r.Ctx, util.ObjectKey(r.GCPCloudCreds), r.GCPCloudCreds)
 	if err == nil || meta.IsNoMatchError(err) || runtime.IsNotRegisteredError(err) {
@@ -1171,6 +1198,24 @@ func (r *Reconciler) ReconcileGCPCredentials() error {
 	if errors.IsNotFound(err) {
 		// credential request does not exist. create one
 		r.Logger.Info("Creating CredentialsRequest resource")
+		if r.IsGCPSTSCluster {
+			codec := cloudcredsv1.Codec
+			gcpProviderSpec := &cloudcredsv1.GCPProviderSpec{}
+			err = codec.DecodeProviderSpec(r.GCPCloudCreds.Spec.ProviderSpec, gcpProviderSpec)
+			if err != nil {
+				r.Logger.Error("error decoding providerSpec from cloud credentials request")
+				return err
+			}
+			gcpProviderSpec.Audience = util.GoogleWIFAudience(projectNumber, poolId, providerId)
+			gcpProviderSpec.ServiceAccountEmail = serviceAccountEmail
+			updatedProviderSpec, err := codec.EncodeProviderSpec(gcpProviderSpec)
+			if err != nil {
+				r.Logger.Error("error encoding providerSpec for cloud credentials request")
+				return err
+			}
+			r.GCPCloudCreds.Spec.ProviderSpec = updatedProviderSpec
+			r.GCPCloudCreds.Spec.CloudTokenPath = r.webIdentityTokenPath
+		}
 		r.Own(r.GCPCloudCreds)
 		err = r.Client.Create(r.Ctx, r.GCPCloudCreds)
 		if err != nil {

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1306,29 +1306,40 @@ func (r *Reconciler) prepareGCPBackingStore() error {
 			return fmt.Errorf("got error on GCPBucketCreds creation. error: %v", err)
 		}
 	}
-	authJSON := &gcpAuthJSON{}
-	err := json.Unmarshal([]byte(cloudCredsSecret.StringData["service_account.json"]), authJSON)
-	if err != nil {
-		fmt.Println("Failed to parse secret", err)
-		return err
+	credsJSON := cloudCredsSecret.StringData["service_account.json"]
+	if credsJSON == "" {
+		return fmt.Errorf("cloud credentials secret %q is missing service_account.json", secretName)
 	}
-	projectID := authJSON.ProjectID
+	isExternalAccount, serviceAccountEmail, err := util.ParseGoogleCredentials(credsJSON)
+	if err != nil {
+		return fmt.Errorf("failed to parse GCP credentials from secret %q: %w", secretName, err)
+	}
 	if r.GCPBucketCreds.StringData == nil {
 		r.Logger.Infof("Secret %q does not contain a map of StringData yet. retry on next reconcile...", secretName)
 		return fmt.Errorf("cloud credentials secret %q is not ready yet (does not contain a map of StringData yet)", secretName)
 	}
-	r.GCPBucketCreds.StringData["GoogleServiceAccountPrivateKeyJson"] = cloudCredsSecret.StringData["service_account.json"]
-	ctx := context.Background()
-	gcpclient, err := storage.NewClient(ctx, option.WithCredentialsJSON([]byte(cloudCredsSecret.StringData["service_account.json"])))
-	if err != nil {
-		r.Logger.Info(err)
-		return err
-	}
+	r.GCPBucketCreds.StringData["GoogleServiceAccountPrivateKeyJson"] = credsJSON
 
-	var bucketName = strings.ToLower(randname.GenerateWithPrefix("noobaabucket", 5))
-	if err := r.createGCPBucketForBackingStore(gcpclient, projectID, bucketName); err != nil {
-		r.Logger.Info(err)
-		return err
+	var bucketName string
+	if isExternalAccount {
+		projectID, err := util.GcpProjectIDFromServiceAccountEmail(serviceAccountEmail)
+		if err != nil {
+			return err
+		}
+		bucketName, err = r.createGCPBucketWithCredentialsJSON(credsJSON, projectID)
+		if err != nil {
+			return err
+		}
+	} else {
+		authJSON := &gcpAuthJSON{}
+		err := json.Unmarshal([]byte(credsJSON), authJSON)
+		if err != nil {
+			return fmt.Errorf("failed to parse service_account credentials: %w", err)
+		}
+		bucketName, err = r.createGCPBucketWithCredentialsJSON(credsJSON, authJSON.ProjectID)
+		if err != nil {
+			return err
+		}
 	}
 
 	if errUpdate := r.Client.Update(r.Ctx, r.GCPBucketCreds); errUpdate != nil {
@@ -1447,6 +1458,20 @@ func (r *Reconciler) prepareIBMBackingStore() error {
 	return nil
 }
 
+func (r *Reconciler) createGCPBucketWithCredentialsJSON(credentialsJSON, projectID string) (string, error) {
+	bucketName := strings.ToLower(randname.GenerateWithPrefix("noobaabucket", 5))
+	ctx := context.Background()
+	gcpclient, err := storage.NewClient(ctx, option.WithCredentialsJSON([]byte(credentialsJSON)))
+	if err != nil {
+		r.Logger.Errorf("got error creating GCP storage client. error: %v", err)
+		return "", err
+	}
+	if err := r.createGCPBucketForBackingStore(gcpclient, projectID, bucketName); err != nil {
+		return "", err
+	}
+	return bucketName, nil
+}
+
 func (r *Reconciler) createGCPBucketForBackingStore(client *storage.Client, projectID, bucketName string) error {
 	// [START create_bucket]
 	ctx := context.Background()
@@ -1454,6 +1479,7 @@ func (r *Reconciler) createGCPBucketForBackingStore(client *storage.Client, proj
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	if err := client.Bucket(bucketName).Create(ctx, projectID, nil); err != nil {
+		r.Logger.Errorf("got error when trying to create bucket %s. error: %v", bucketName, err)
 		return err
 	}
 	// [END create_bucket]

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -105,6 +105,7 @@ type Reconciler struct {
 	IsAzureSTSCluster         bool
 	GCPBucketCreds            *corev1.Secret
 	GCPCloudCreds             *cloudcredsv1.CredentialsRequest
+	IsGCPSTSCluster           bool
 	IBMCosBucketCreds         *corev1.Secret
 	DefaultBackingStore       *nbv1.BackingStore
 	DefaultBucketClass        *nbv1.BucketClass
@@ -343,6 +344,9 @@ func NewReconciler(
 	r.AWSSTSRoleSessionName = "noobaa-sts-default-backing-store-session"
 	// Setting default AWS STS cluster as false
 	r.IsAWSSTSCluster = false
+
+	// Setting default GCP WIF (STS) cluster as false
+	r.IsGCPSTSCluster = false
 
 	// Set bucket logging volume mount name and path
 	r.BucketLoggingVolume = r.Request.Name + "-bucket-logging-volume"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1314,6 +1314,21 @@ func BuildGoogleWIFCredentialsJSON(projectNumber, poolID, providerID, serviceAcc
 	return string(credentialsBytes), nil
 }
 
+// GcpProjectIDFromServiceAccountEmail returns the GCP project ID from a service account email
+// (e.g. "noobaa-wif-sa@my-project.iam.gserviceaccount.com" -> "my-project").
+func GcpProjectIDFromServiceAccountEmail(email string) (string, error) {
+	const suffix = ".iam.gserviceaccount.com"
+	at := strings.LastIndex(email, "@")
+	if at < 0 {
+		return "", fmt.Errorf("invalid GCP service account email %q", email)
+	}
+	projectID := strings.TrimSuffix(email[at+1:], suffix)
+	if projectID == "" {
+		return "", fmt.Errorf("invalid GCP service account email %q", email)
+	}
+	return projectID, nil
+}
+
 // IsAzurePlatformNonGovernment returns true if this cluster is running on Azure and also not on azure government\DOD cloud
 func IsAzurePlatformNonGovernment() bool {
 	azurePlatformNonGovOnce.Do(func() {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -428,3 +428,53 @@ func TestBuildGoogleWIFCredentialsJSON(t *testing.T) {
 		}
 	})
 }
+
+func TestGcpProjectIDFromServiceAccountEmail(t *testing.T) {
+	tests := []struct {
+		name          string
+		email         string
+		expectedProjectID string
+		expectedErr       bool
+	}{
+		{
+			name:          "valid GCP service account email",
+			email:         "noobaa-wif-sa@my-project.iam.gserviceaccount.com",
+			expectedProjectID: "my-project",
+		},
+		{
+			name:    "missing at sign",
+			email:   "invalid-email",
+			expectedErr: true,
+		},
+		// GcpProjectIDFromServiceAccountEmail only strips .iam.gserviceaccount.com;
+		// other domains pass through the part after @ unchanged (no format validation).
+		{
+			name:          "non-GCP domain",
+			email:         "sa@other-domain.com",
+			expectedProjectID: "other-domain.com",
+		},
+		{
+			name:    "empty domain after at sign",
+			email:   "sa@",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GcpProjectIDFromServiceAccountEmail(tc.email)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("GcpProjectIDFromServiceAccountEmail expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GcpProjectIDFromServiceAccountEmail unexpected error: %v", err)
+			}
+			if got != tc.expectedProjectID {
+				t.Fatalf("GcpProjectIDFromServiceAccountEmail expected project ID %q, got %q", tc.expectedProjectID, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661), this PR sets the new endpoint type `GOOGLE_STS` (we had `GOOGLE`) and starts implementing code changes in parts of the flows related to the GCP WIF (STS) backing store.

### Explain the changes
1. Save the parameters (`PROJECT_NUMBER`, `POOL_ID`, `PROVIDER_ID`, `SERVICE_ACCOUNT_EMAIL`) that were passed as flags as envs in the operator for local testing (like we did for AWS STS and Azure STS). If we have all those envs, then we assume that `r.IsGCPSTSCluster = true`.
2. In `pkg/system/phase2_creating.go` added Code changes related to the cloud credential request (for the CCO) were made according to the CCO doc "How to STS" ([link](https://docs.google.com/document/d/1iFNpyycby_rOY1wUew-yl3uPWlE00krTgr9XHDZOTNo/edit?tab=t.0#bookmark=id.tziekkytt0ji)).
3. In `pkg/system/phase4_configuring.go` added code changes for bucket creation so it would be mutual for GCP and GCP WOF (STS).
4. In `olm.go` add the annotation of `features.operators.openshift.io/token-auth-gcp` (like we have for AWS STS and Azure STS).
5. Added utility function `GcpProjectIDFromServiceAccountEmail` and a unit test for it.

### Issues: 
List of GAPs:
1. Currently, in the secret we still have the field of `GoogleServiceAccountPrivateKeyJson` in the data; also,  for the case of GCP WIF (STS), we might change it later for readability.
2. I didn't add validation per required parameter in the CLI - would probably add in one of the following PRs (link to the issue #1933).

### Testing Instructions:
#### Unit Tests:
1. Utility function unit test: `go test -mod=vendor -count=1 -v ./pkg/util -run 'TestGcpProjectIDFromServiceAccountEmail'`

#### Manual Tests:
1. Deploy NooBaa on Minikube after adding GCP WIF configurations - see guide "Create GCP WIF (STS) Setup On Minikube With NooBaa" ([link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_gcp_wif_setup_on_minikube_with_noobaa.md)).

Note: must add code changes for local test as we do not have the cloud credential operator (CCO) on local run.
Once we have an cluster launched onGCP WIF (STS), we can test run the full flow (OCP -> ODF operator -> NooBaa operator -> GCP library).

2. Added code changes so we can test it locally with `noobaa install --dev --noobaa-image='noobaa-core:gcp-wif-enums-and-backingstore' --use-standalone-db -n test1 --show-secrets --google-cloud-project-number='<project-number>' --google-cloud-pool-id='<pool-id>' --google-cloud-provider-id='<provider-id>' --google-cloud-service-account-email='<email>'`
3. Check that you see the default backingstore type:
```bash
#------------------#
#- Backing Stores -#
#------------------#

NAME                           TYPE                   TARGET-BUCKET       PHASE   AGE
noobaa-default-backing-store   google-cloud-storage   noobaabucketcvi7u   Ready   1m7s
```
4. Check the secret json with: `oc get secret noobaa-gcp-bucket-creds -n test1 -o jsonpath='{.data.GoogleServiceAccountPrivateKeyJson}' | base64 -d | jq` (you can see the passed details and the external_account).

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShift GCP WIF (STS) support: CSV annotation, CLI flags to supply GCP WIF parameters, and operator injection of configured WIF env vars.

* **Improvements**
  * Stronger GCP credential validation and parsing; refactored GCS bucket creation and backing-store credential handling.
  * Reconciler now exposes an explicit GCP STS cluster flag.

* **Tests**
  * Added unit tests for service-account email parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->