### PR TITLE
change core init command to new node script

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -59,6 +59,9 @@ spec:
             timeoutSeconds: 2
           image: NOOBAA_CORE_IMAGE
           terminationMessagePolicy: FallbackToLogsOnError
+          command:
+            - /usr/local/bin/node
+            - /root/node_modules/noobaa-core/src/cmd/core_init.js
           volumeMounts:
             - name: logs
               mountPath: /log

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5581,7 +5581,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "4ef493f94d8f81746f9d8904085de093b4ed37ee15d0767cc563f7aa89c86de8"
+const Sha256_deploy_internal_statefulset_core_yaml = "d801f303e997a9267f59d4fd80c3fe7586c8a62948db2324b6ac9afaca27064e"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5644,6 +5644,9 @@ spec:
             timeoutSeconds: 2
           image: NOOBAA_CORE_IMAGE
           terminationMessagePolicy: FallbackToLogsOnError
+          command:
+            - /usr/local/bin/node
+            - /root/node_modules/noobaa-core/src/cmd/core_init.js
           volumeMounts:
             - name: logs
               mountPath: /log


### PR DESCRIPTION
### Describe the Problem
see https://github.com/noobaa/noobaa-core/pull/9695
this PR adds a new init script to noobaa core pod. need to change the yaml to use the new node script

### Explain the changes
1. override core command to be the new node core init module

### Issues: Fixed Gap
1.in core docker file CMD remains the same. this command overrides it. butold path is now dead. need to remove it eventually 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
