### PR TITLE
GCP WIF (STS) | NSS Reconcile Changes

### DIFF
--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -2,7 +2,6 @@ package namespacestore
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -683,21 +682,23 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		}
 
 	case nbv1.NSStoreTypeGoogleCloudStorage:
-		conn.EndpointType = nb.EndpointTypeGoogle
 		conn.Endpoint = "https://www.googleapis.com"
-		privateKeyJSON := r.Secret.StringData["GoogleServiceAccountPrivateKeyJson"]
-		privateKey := &struct {
-			ID string `json:"private_key_id"`
-		}{}
-		err := json.Unmarshal([]byte(privateKeyJSON), privateKey)
+		googleCredentialsJSON := r.Secret.StringData["GoogleServiceAccountPrivateKeyJson"]
+
+		isGoogleExternalAccountJSON, identity, err := util.ParseGoogleCredentials(googleCredentialsJSON)
 		if err != nil {
 			return nil, util.NewPersistentError("InvalidGoogleSecret", fmt.Sprintf(
-				"Invalid secret for google type %q expected JSON in data.GoogleServiceAccountPrivateKeyJson",
-				r.Secret.Name,
+				"Invalid secret for google type %q expected JSON in data.GoogleServiceAccountPrivateKeyJson: %v",
+				r.Secret.Name, err,
 			))
 		}
-		conn.Identity = nb.MaskedString(privateKey.ID)
-		conn.Secret = nb.MaskedString(privateKeyJSON)
+		if isGoogleExternalAccountJSON {
+			conn.EndpointType = nb.EndpointTypeGoogleSTS
+		} else {
+			conn.EndpointType = nb.EndpointTypeGoogle
+		}
+		conn.Identity = nb.MaskedString(identity)
+		conn.Secret = nb.MaskedString(googleCredentialsJSON)
 
 	default:
 		return nil, util.NewPersistentError("InvalidType",

--- a/pkg/namespacestore/validation_test.go
+++ b/pkg/namespacestore/validation_test.go
@@ -152,7 +152,36 @@ func TestNamespaceStoreIBMCos(t *testing.T) {
 	defaultNs.Spec.IBMCos.Endpoint = "hostname:port"
 	err = validations.ValidateNamespaceStore(&defaultNs)
 	AssertError(t, err, "Invalid endPoint %s validation is failed", defaultNs.Spec.IBMCos.Endpoint)
+}
 
+func TestNamespaceStoreGoogleCloudStorage(t *testing.T) {
+
+	//Valid namespacestore
+	defaultNs := getDefaultGoogleCloudStorageNsStore()
+	err := validations.ValidateNamespaceStore(&defaultNs)
+	AssertNotError(t, err, "Valid Google Cloud Storage namespacestore validation failed")
+
+	// GoogleCloudStorage spec is nil
+	defaultNs = nbv1.NamespaceStore{
+		Spec: nbv1.NamespaceStoreSpec{
+			Type: nbv1.NSStoreTypeGoogleCloudStorage,
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gcp"},
+	}
+	err = validations.ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "GoogleCloudStorage spec nil should be denied")
+
+	// Empty secret name
+	defaultNs = getDefaultGoogleCloudStorageNsStore()
+	defaultNs.Spec.GoogleCloudStorage.Secret.Name = ""
+	err = validations.ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Empty secret name for Google Cloud Storage namespacestore should be denied")
+
+	// Empty target bucket
+	defaultNs = getDefaultGoogleCloudStorageNsStore()
+	defaultNs.Spec.GoogleCloudStorage.TargetBucket = ""
+	err = validations.ValidateNamespaceStore(&defaultNs)
+	AssertError(t, err, "Empty target bucket should be denied")
 }
 
 func AssertNotError(t *testing.T, err error, format string, a ...interface{}) {
@@ -243,5 +272,21 @@ func getDefaultAzureBlobNsStore() nbv1.NamespaceStore {
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{Name: "test-azure"},
+	}
+}
+
+func getDefaultGoogleCloudStorageNsStore() nbv1.NamespaceStore {
+	return nbv1.NamespaceStore{
+		Spec: nbv1.NamespaceStoreSpec{
+			Type: nbv1.NSStoreTypeGoogleCloudStorage,
+			GoogleCloudStorage: &nbv1.GoogleCloudStorageSpec{
+				TargetBucket: "gcp-target-bucket",
+				Secret: corev1.SecretReference{
+					Name:      "gcp-secret",
+					Namespace: "namespace",
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gcp"},
 	}
 }


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661), this PR sets the new endpoint type `GOOGLE_STS` (we had `GOOGLE`) and implements code changes in parts of the flows related to the GCP WIF (STS) namespace store.

### Explain the changes
1. Change the reconcile code for the type `NSStoreTypeGoogleCloudStorage` so it can add GCP WIF (STS). it is based on the changes in backingstore reconcile (`noobaa-operator/pkg/backingstore/reconciler.go`).
2. Added AI generated validation test for the type `NSStoreTypeGoogleCloudStorage` which was missing (regardless of GCP WIF (STS) changes, therefore, added in a separate commit).

### Issues:
List of GAPs
1. Since NSS GCP is not GA'd, we don't have the CLI changes for GCP WIF (STS) - as we don't have those for GCP.

### Testing Instructions:
#### Unit Tests:
1. `go test -v ./pkg/namespacestore -run TestNamespaceStore`

#### Manual Test:
This PR is tested with the code changes in noobaa/noobaa-core#9697  (for the full steps, see [comment](https://github.com/noobaa/noobaa-core/pull/9697#issuecomment-4680190094)).
Create 2 namespaces for GCP WIF (STS), and GCP checks that it is in `Ready` phase:
Partial output (I removed the target bucket name):

```bash
nb namespacestore list -n test1
NAME               TYPE                   TARGET-BUCKET    PROVIDER-STORAGE-CLASS   PHASE   AGE
shira-gcs-ns       google-cloud-storage   ***     standard                 Ready   14s
shira-gcs-wif-ns   google-cloud-storage   ***   standard                 Ready   36m53s
```

In the logs of noobaa-core pod you can see:
```bash
Jun-11 6:34:39.432 [BGWorkers/32]    [L0] core.server.bg_services.namespace_monitor:: update_last_monitoring: monitoring namespace shira-gcs-wif-ns type GOOGLE_STS, 6a2a4e1bb28c0f002261f66a finished successfully..
Jun-11 6:34:39.528 [BGWorkers/32]    [L0] core.server.bg_services.namespace_monitor:: update_last_monitoring: monitoring namespace shira-gcs-ns type GOOGLE, 6a2a56b2b28c0f002261f677 finished successfully..
```


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Cloud Storage credential handling with more robust parsing and clearer error reporting, including correct handling of identity/secret and STS vs non-STS connection flows.

* **Tests**
  * Added Google Cloud Storage namespace store validation coverage to ensure default configurations pass and invalid specs (missing store, secret name, or bucket) correctly surface validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->