### PR TITLE
[Backport into 5.18]DFBUGS-5052: Fix for Noobaa DB cleaner not honoring set value

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -143,6 +143,9 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4925,7 +4925,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "14226b25028637a7176dbdb4a6fa6e90a9e63cddd5f39cbe0c044f433b0a4764"
+const Sha256_deploy_internal_statefulset_core_yaml = "84bbde864a7dd95e4ceec7138c95b2d758bbce9beb716ca12e5c884ebd36b343"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5072,6 +5072,9 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Backport of [DFBUGS-6998](https://redhat.atlassian.net/browse/DFBUGS-6998) fix to the 5.18 release branch
- Cherry-picked commit 71a7301e from DFBUGS-5052-ConfigValue
- Fixes Noobaa DB cleaner not honoring the configured value


## Changes
- deploy/internal/statefulset-core.yaml: Added configuration support for DB cleaner value
- doc/noobaa-crd.md: Updated CRD documentation with the new field
- pkg/bundle/deploy.go: Regenerated bundle with updated statefulset YAML

## Test plan
- [ ] Verify DB cleaner honors the configured value on 5.18
- [ ] Ensure no regression in statefulset deployment

Fixes: DFBUGS-5052
