### PR TITLE
[Backport into 5.19]DFBUGS-5052: Fix for Noobaa DB cleaner not honoring set value

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -147,6 +147,9 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5053,7 +5053,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "ac5e3c4caf9983c154a706f808f02cfd2bea064729d90bba3d5ad42547b8d100"
+const Sha256_deploy_internal_statefulset_core_yaml = "fb211a77508c64ec21d2db81023c4075988c40292ccf17bf25499282480adcbb"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5204,6 +5204,9 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Backport of [DFBUGS-6996](https://redhat.atlassian.net/browse/DFBUGS-6996) fix to the 5.19 release branch
- Cherry-picked commit 71a7301e from DFBUGS-5052-ConfigValue
- Fixes Noobaa DB cleaner not honoring the configured value

## Changes
- deploy/internal/statefulset-core.yaml: Added configuration support for DB cleaner value
- doc/noobaa-crd.md: Updated CRD documentation with the new field
- pkg/bundle/deploy.go: Regenerated bundle with updated statefulset YAML

## Test plan
- [ ] Verify DB cleaner honors the configured value on 5.19
- [ ] Ensure no regression in statefulset deployment

Fixes: DFBUGS-5052
