### PR TITLE
[Backport into 5.20]DFBUGS-5052: Fix for Noobaa DB cleaner not honoring set value

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -163,6 +163,9 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5103,7 +5103,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "34da89373b8398adb670d779a35f5c5a94365da99b5a2db65715fd62a7638d5c"
+const Sha256_deploy_internal_statefulset_core_yaml = "44e664b40a3ee292041ac2bceb26bc9a38f1116d4fe9c39d40eacdde74aa3f2f"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5270,6 +5270,9 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Backport of [DFBUGS-6997](https://redhat.atlassian.net/browse/DFBUGS-6997) fix to the 5.20 release branch
- Cherry-picked commit 71a7301e from DFBUGS-5052-ConfigValue
- Fixes Noobaa DB cleaner not honoring the configured value

## Changes
- deploy/internal/statefulset-core.yaml: Added configuration support for DB cleaner value
- doc/noobaa-crd.md: Updated CRD documentation with the new field
- pkg/bundle/deploy.go: Regenerated bundle with updated statefulset YAML

## Test plan
- [ ] Verify DB cleaner honors the configured value on 5.20
- [ ] Ensure no regression in statefulset deployment

Fixes: DFBUGS-5052
