### PR TITLE
[Backport into 5.21]DFBUGS-5052: Fix for Noobaa DB cleaner not honoring set value

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -164,6 +164,9 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5314,7 +5314,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "3dba40ad6babb033832e999680f333849bf3f194a24aa1163587529315ebe8da"
+const Sha256_deploy_internal_statefulset_core_yaml = "b3ffaeb8aec8fddf963763159a24002c95b5d2d37f6e4fcb762c36fdd35809d4"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5482,6 +5482,9 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Backport of [DFBUGS-6995](https://redhat.atlassian.net/browse/DFBUGS-6995) fix to the 5.21 release branch
- Cherry-picked commit 71a7301e from DFBUGS-5052-ConfigValue
- Fixes Noobaa DB cleaner not honoring the configured value

## Changes
- deploy/internal/statefulset-core.yaml: Added configuration support for DB cleaner value
- doc/noobaa-crd.md: Updated CRD documentation with the new field
- pkg/bundle/deploy.go: Regenerated bundle with updated statefulset YAML

## Test plan
- [ ] Verify DB cleaner honors the configured value on 5.21
- [ ] Ensure no regression in statefulset deployment

Fixes: DFBUGS-5052
