### PR TITLE
Intorduced performanceProfile to NooBaa CR

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1938,6 +1938,16 @@ spec:
                   update the admin account with new BackingStore/NamespaceStore in order to delete the DefaultBackingStore/DefaultNamespaceStore
                 nullable: true
                 type: boolean
+              performanceProfile:
+                description: |-
+                  PerformanceProfile (optional) selects a bundle of resource and count
+                  settings for the core, db and endpoint components.
+                  Explicit per-component resource/count fields take precedence over the profile.
+                enum:
+                - default
+                - mixed-workload
+                - small-objects
+                type: string
               pvPoolDefaultStorageClass:
                 description: |-
                   PVPoolDefaultStorageClass (optional) overrides the default cluster StorageClass for the pv-pool volumes.

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -257,6 +257,13 @@ type NooBaaSpec struct {
 	// BucketNotifications (optional) controls bucket notification options
 	// +optional
 	BucketNotifications BucketNotificationsSpec `json:"bucketNotifications,omitempty"`
+
+	// PerformanceProfile (optional) selects a bundle of resource and count
+	// settings for the core, db and endpoint components.
+	// Explicit per-component resource/count fields take precedence over the profile.
+	// +optional
+	// +kubebuilder:validation:Enum=default;mixed-workload;small-objects
+	PerformanceProfile PerformanceProfileType `json:"performanceProfile,omitempty"`
 }
 
 // Affinity is a group of affinity scheduling rules.
@@ -874,4 +881,17 @@ const (
 
 	// BucketLoggingTypeGuaranteed is guaranteed
 	BucketLoggingTypeGuaranteed BucketLoggingTypes = "guaranteed"
+)
+
+// PerformanceProfileType is a string enum type for selecting a performance profile.
+type PerformanceProfileType string
+
+// These are the valid PerformanceProfileType values:
+const (
+	// PerformanceProfileDefault is the default profile
+	PerformanceProfileDefault PerformanceProfileType = "default"
+	// PerformanceProfileMixedWorkload is for mixed workload
+	PerformanceProfileMixedWorkload PerformanceProfileType = "mixed-workload"
+	// PerformanceProfileSmallObjects is for small objects workload
+	PerformanceProfileSmallObjects PerformanceProfileType = "small-objects"
 )

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1509,7 +1509,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "c94929c02dc22efe29d4317da49bc6111d6ba26430e00b0cc5325189324372f9"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "7abaa6838d2c6b96fe7f2c337447bfbbcb0109ec12f84048c1026b54d57c0528"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -3451,6 +3451,16 @@ spec:
                   update the admin account with new BackingStore/NamespaceStore in order to delete the DefaultBackingStore/DefaultNamespaceStore
                 nullable: true
                 type: boolean
+              performanceProfile:
+                description: |-
+                  PerformanceProfile (optional) selects a bundle of resource and count
+                  settings for the core, db and endpoint components.
+                  Explicit per-component resource/count fields take precedence over the profile.
+                enum:
+                - default
+                - mixed-workload
+                - small-objects
+                type: string
               pvPoolDefaultStorageClass:
                 description: |-
                   PVPoolDefaultStorageClass (optional) overrides the default cluster StorageClass for the pv-pool volumes.

--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -263,12 +263,10 @@ func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
 	}
 
 	// update number of instances
-	r.CNPGCluster.Spec.Instances = getDesiredInstances(dbSpec)
+	r.CNPGCluster.Spec.Instances = getDBInstances(r.NooBaa)
 
 	// update db resources
-	if dbSpec.DBResources != nil {
-		r.CNPGCluster.Spec.Resources = *dbSpec.DBResources
-	}
+	r.CNPGCluster.Spec.Resources = getDBResources(r.NooBaa)
 
 	// update db volume resources
 	// update the storage configuration
@@ -588,21 +586,19 @@ func (r *Reconciler) setPostgresConfig() {
 
 	totalMemoryKB := defaultCalcMemoryKB
 	cpuNum := defaultCalcCPU
-	dbResources := r.NooBaa.Spec.DBSpec.DBResources
-	if dbResources != nil {
-		if !dbResources.Limits.Memory().IsZero() {
-			totalMemoryKB = dbResources.Limits.Memory().Value() / 1024
-		} else if !dbResources.Requests.Memory().IsZero() {
-			totalMemoryKB = dbResources.Requests.Memory().Value() / 1024
-		}
-		if !dbResources.Limits.Cpu().IsZero() {
-			cpuNum = dbResources.Limits.Cpu().MilliValue() / 1000
-		} else if !dbResources.Requests.Cpu().IsZero() {
-			cpuNum = dbResources.Requests.Cpu().MilliValue() / 1000
-		}
-		if cpuNum < 1 {
-			cpuNum = 1
-		}
+	dbResources := getDBResources(r.NooBaa)
+	if !dbResources.Limits.Memory().IsZero() {
+		totalMemoryKB = dbResources.Limits.Memory().Value() / 1024
+	} else if !dbResources.Requests.Memory().IsZero() {
+		totalMemoryKB = dbResources.Requests.Memory().Value() / 1024
+	}
+	if !dbResources.Limits.Cpu().IsZero() {
+		cpuNum = dbResources.Limits.Cpu().MilliValue() / 1000
+	} else if !dbResources.Requests.Cpu().IsZero() {
+		cpuNum = dbResources.Requests.Cpu().MilliValue() / 1000
+	}
+	if cpuNum < 1 {
+		cpuNum = 1
 	}
 
 	for k, v := range calculatePGConfig(totalMemoryKB, cpuNum, int(endpointMaxCount), r.CNPGCluster.Spec.StorageConfiguration.Size) {
@@ -771,14 +767,6 @@ func getDesiredDbImage(dbSpec *nbv1.NooBaaDBSpec) string {
 		desiredDbImage = *dbSpec.DBImage
 	}
 	return desiredDbImage
-}
-
-func getDesiredInstances(dbSpec *nbv1.NooBaaDBSpec) int {
-	desiredInstances := options.PostgresInstances
-	if dbSpec.Instances != nil {
-		desiredInstances = *dbSpec.Instances
-	}
-	return desiredInstances
 }
 
 func setDesiredStorageConf(storageConfiguration *cnpgv1.StorageConfiguration, dbSpec *nbv1.NooBaaDBSpec) error {

--- a/pkg/system/performance_profiles.go
+++ b/pkg/system/performance_profiles.go
@@ -1,0 +1,136 @@
+package system
+
+import (
+	"github.com/sirupsen/logrus"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type performanceProfile struct {
+	coreResources     corev1.ResourceRequirements
+	dbResources       corev1.ResourceRequirements
+	endpointResources corev1.ResourceRequirements
+	endpointMinCount  int32
+	endpointMaxCount  int32
+	dbInstances       int
+	pvPoolNumVolumes  int
+}
+
+func profileResources(cpuReq, cpuLim, memReq, memLim string) corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(cpuReq),
+			corev1.ResourceMemory: resource.MustParse(memReq),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(cpuLim),
+			corev1.ResourceMemory: resource.MustParse(memLim),
+		},
+	}
+}
+
+var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
+	nbv1.PerformanceProfileDefault: {
+		coreResources:     profileResources("500m", "1", "1Gi", "4Gi"),
+		dbResources:       profileResources("1", "1", "2Gi", "2Gi"),
+		endpointResources: profileResources("500m", "2", "1Gi", "3Gi"),
+		endpointMinCount:  1,
+		endpointMaxCount:  2,
+		dbInstances:       2,
+		pvPoolNumVolumes:  3,
+	},
+	nbv1.PerformanceProfileMixedWorkload: {
+		coreResources:     profileResources("1", "2", "2Gi", "4Gi"),
+		dbResources:       profileResources("4", "4", "8Gi", "8Gi"),
+		endpointResources: profileResources("2", "4", "2Gi", "4Gi"),
+		endpointMinCount:  2,
+		endpointMaxCount:  4,
+		dbInstances:       2,
+		pvPoolNumVolumes:  3,
+	},
+	nbv1.PerformanceProfileSmallObjects: {
+		coreResources:     profileResources("1", "2", "2Gi", "6Gi"),
+		dbResources:       profileResources("6", "6", "16Gi", "16Gi"),
+		endpointResources: profileResources("2", "4", "2Gi", "4Gi"),
+		endpointMinCount:  2,
+		endpointMaxCount:  4,
+		dbInstances:       2,
+		pvPoolNumVolumes:  3,
+	},
+}
+
+func lookupProfile(nb *nbv1.NooBaa) performanceProfile {
+	profileType := nb.Spec.PerformanceProfile
+	if profile, ok := performanceProfiles[profileType]; ok {
+		return profile
+	}
+	if profileType != "" {
+		logrus.Warnf("Unknown performanceProfile %q, falling back to %q", profileType, nbv1.PerformanceProfileDefault)
+	}
+	return performanceProfiles[nbv1.PerformanceProfileDefault]
+}
+
+func getCoreResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {
+	if nb.Spec.CoreResources != nil {
+		return *nb.Spec.CoreResources
+	}
+	return lookupProfile(nb).coreResources
+}
+
+func getDBResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {
+	if nb.Spec.DBSpec != nil && nb.Spec.DBSpec.DBResources != nil {
+		return *nb.Spec.DBSpec.DBResources
+	}
+	return lookupProfile(nb).dbResources
+}
+
+func getEndpointResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {
+	if nb.Spec.Endpoints != nil && nb.Spec.Endpoints.Resources != nil {
+		return *nb.Spec.Endpoints.Resources
+	}
+	return lookupProfile(nb).endpointResources
+}
+
+func getDBInstances(nb *nbv1.NooBaa) int {
+	if nb.Spec.DBSpec != nil && nb.Spec.DBSpec.Instances != nil {
+		return *nb.Spec.DBSpec.Instances
+	}
+	return lookupProfile(nb).dbInstances
+}
+
+// getPVPoolNumVolumes determines the NumVolumes for the default pv-pool backingstore.
+// Rules:
+// - New deployment (existingVolumes <= 0): use profile value
+// - Existing + "default" profile (or unset): keep current (no migration)
+// - Existing + non-default profile: max(current, profile value) — never decrease
+func getPVPoolNumVolumes(nb *nbv1.NooBaa, existingVolumes int) int {
+	profile := lookupProfile(nb)
+	if existingVolumes <= 0 {
+		return profile.pvPoolNumVolumes
+	}
+	profileType := nb.Spec.PerformanceProfile
+	if profileType == "" || profileType == nbv1.PerformanceProfileDefault {
+		return existingVolumes
+	}
+	if profile.pvPoolNumVolumes > existingVolumes {
+		return profile.pvPoolNumVolumes
+	}
+	return existingVolumes
+}
+
+func getEndpointMinMax(nb *nbv1.NooBaa) (int32, int32) {
+	profile := lookupProfile(nb)
+	minCount := profile.endpointMinCount
+	maxCount := profile.endpointMaxCount
+	if nb.Spec.Endpoints != nil {
+		if nb.Spec.Endpoints.MinCount > 0 {
+			minCount = nb.Spec.Endpoints.MinCount
+		}
+		if nb.Spec.Endpoints.MaxCount > 0 {
+			maxCount = nb.Spec.Endpoints.MaxCount
+		}
+	}
+	return minCount, maxCount
+}

--- a/pkg/system/performance_profiles_test.go
+++ b/pkg/system/performance_profiles_test.go
@@ -1,0 +1,565 @@
+package system
+
+import (
+	"testing"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestLookupProfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  nbv1.PerformanceProfileType
+		expected performanceProfile
+	}{
+		{
+			name:     "default profile",
+			profile:  nbv1.PerformanceProfileDefault,
+			expected: performanceProfiles[nbv1.PerformanceProfileDefault],
+		},
+		{
+			name:     "mixed-workload profile",
+			profile:  nbv1.PerformanceProfileMixedWorkload,
+			expected: performanceProfiles[nbv1.PerformanceProfileMixedWorkload],
+		},
+		{
+			name:     "small-objects profile",
+			profile:  nbv1.PerformanceProfileSmallObjects,
+			expected: performanceProfiles[nbv1.PerformanceProfileSmallObjects],
+		},
+		{
+			name:     "unset profile falls back to default",
+			profile:  "",
+			expected: performanceProfiles[nbv1.PerformanceProfileDefault],
+		},
+		{
+			name:     "unknown profile falls back to default",
+			profile:  nbv1.PerformanceProfileType("unknown"),
+			expected: performanceProfiles[nbv1.PerformanceProfileDefault],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nb := &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: tt.profile,
+				},
+			}
+			got := lookupProfile(nb)
+			assertPerformanceProfile(t, got, tt.expected)
+		})
+	}
+}
+
+func TestGetCoreResources(t *testing.T) {
+	explicit := profileResources("3", "3", "3Gi", "3Gi")
+
+	tests := []struct {
+		name     string
+		nb       *nbv1.NooBaa
+		expected corev1.ResourceRequirements
+	}{
+		{
+			name: "default profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileDefault,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileDefault].coreResources,
+		},
+		{
+			name: "mixed-workload profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileMixedWorkload].coreResources,
+		},
+		{
+			name: "small-objects profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileSmallObjects].coreResources,
+		},
+		{
+			name: "explicit core resources override profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+					CoreResources:      &explicit,
+				},
+			},
+			expected: explicit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getCoreResources(tt.nb)
+			assertResourceRequirements(t, got, tt.expected)
+		})
+	}
+}
+
+func TestGetDBResources(t *testing.T) {
+	explicitCNPG := profileResources("5", "5", "5Gi", "5Gi")
+
+	tests := []struct {
+		name     string
+		nb       *nbv1.NooBaa
+		expected corev1.ResourceRequirements
+	}{
+		{
+			name: "default profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileDefault,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileDefault].dbResources,
+		},
+		{
+			name: "mixed-workload profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileMixedWorkload].dbResources,
+		},
+		{
+			name: "small-objects profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileSmallObjects].dbResources,
+		},
+		{
+			name: "dbSpec dbResources override profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+					DBSpec: &nbv1.NooBaaDBSpec{
+						DBResources: &explicitCNPG,
+					},
+				},
+			},
+			expected: explicitCNPG,
+		},
+		{
+			name: "legacy dbResources does not override profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+					DBResources:        &explicitCNPG,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileSmallObjects].dbResources,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDBResources(tt.nb)
+			assertResourceRequirements(t, got, tt.expected)
+		})
+	}
+}
+
+func TestGetEndpointResources(t *testing.T) {
+	explicit := profileResources("3", "3", "3Gi", "3Gi")
+
+	tests := []struct {
+		name     string
+		nb       *nbv1.NooBaa
+		expected corev1.ResourceRequirements
+	}{
+		{
+			name: "default profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileDefault,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileDefault].endpointResources,
+		},
+		{
+			name: "mixed-workload profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileMixedWorkload].endpointResources,
+		},
+		{
+			name: "small-objects profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileSmallObjects].endpointResources,
+		},
+		{
+			name: "explicit endpoint resources override profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+					Endpoints: &nbv1.EndpointsSpec{
+						Resources: &explicit,
+					},
+				},
+			},
+			expected: explicit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getEndpointResources(tt.nb)
+			assertResourceRequirements(t, got, tt.expected)
+		})
+	}
+}
+
+func TestGetDBInstances(t *testing.T) {
+	explicitInstances := 5
+
+	tests := []struct {
+		name     string
+		nb       *nbv1.NooBaa
+		expected int
+	}{
+		{
+			name: "default profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileDefault,
+				},
+			},
+			expected: 2,
+		},
+		{
+			name: "mixed-workload profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+				},
+			},
+			expected: 2,
+		},
+		{
+			name: "explicit dbSpec instances override profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+					DBSpec: &nbv1.NooBaaDBSpec{
+						Instances: &explicitInstances,
+					},
+				},
+			},
+			expected: explicitInstances,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDBInstances(tt.nb)
+			if got != tt.expected {
+				t.Errorf("getDBInstances() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetPVPoolNumVolumes(t *testing.T) {
+	tests := []struct {
+		name            string
+		profile         nbv1.PerformanceProfileType
+		existingVolumes int
+		expected        int
+	}{
+		{
+			name:            "new deployment with default profile",
+			profile:         nbv1.PerformanceProfileDefault,
+			existingVolumes: 0,
+			expected:        3,
+		},
+		{
+			name:            "new deployment with mixed-workload profile",
+			profile:         nbv1.PerformanceProfileMixedWorkload,
+			existingVolumes: 0,
+			expected:        3,
+		},
+		{
+			name:            "existing with default profile keeps current",
+			profile:         nbv1.PerformanceProfileDefault,
+			existingVolumes: 1,
+			expected:        1,
+		},
+		{
+			name:            "existing with unset profile keeps current",
+			profile:         "",
+			existingVolumes: 1,
+			expected:        1,
+		},
+		{
+			name:            "existing with mixed-workload profile increases",
+			profile:         nbv1.PerformanceProfileMixedWorkload,
+			existingVolumes: 1,
+			expected:        3,
+		},
+		{
+			name:            "existing with mixed-workload profile never decreases",
+			profile:         nbv1.PerformanceProfileMixedWorkload,
+			existingVolumes: 5,
+			expected:        5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nb := &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: tt.profile,
+				},
+			}
+			got := getPVPoolNumVolumes(nb, tt.existingVolumes)
+			if got != tt.expected {
+				t.Errorf("getPVPoolNumVolumes() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetEndpointMinMax(t *testing.T) {
+	tests := []struct {
+		name        string
+		nb          *nbv1.NooBaa
+		expectedMin int32
+		expectedMax int32
+	}{
+		{
+			name: "default profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileDefault,
+				},
+			},
+			expectedMin: 1,
+			expectedMax: 2,
+		},
+		{
+			name: "mixed-workload profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+				},
+			},
+			expectedMin: 2,
+			expectedMax: 4,
+		},
+		{
+			name: "small-objects profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+				},
+			},
+			expectedMin: 2,
+			expectedMax: 4,
+		},
+		{
+			name: "explicit endpoint min/max override profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileSmallObjects,
+					Endpoints: &nbv1.EndpointsSpec{
+						MinCount: 5,
+						MaxCount: 10,
+					},
+				},
+			},
+			expectedMin: 5,
+			expectedMax: 10,
+		},
+		{
+			name: "zero min count falls back to profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+					Endpoints: &nbv1.EndpointsSpec{
+						MinCount: 0,
+						MaxCount: 4,
+					},
+				},
+			},
+			expectedMin: 2,
+			expectedMax: 4,
+		},
+		{
+			name: "zero max count falls back to profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+					Endpoints: &nbv1.EndpointsSpec{
+						MinCount: 2,
+						MaxCount: 0,
+					},
+				},
+			},
+			expectedMin: 2,
+			expectedMax: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMin, gotMax := getEndpointMinMax(tt.nb)
+			if gotMin != tt.expectedMin || gotMax != tt.expectedMax {
+				t.Errorf("getEndpointMinMax() = (%d, %d), want (%d, %d)", gotMin, gotMax, tt.expectedMin, tt.expectedMax)
+			}
+		})
+	}
+}
+
+func TestGetResourcesPrecedencePerComponent(t *testing.T) {
+	explicitCore := profileResources("3", "3", "3Gi", "3Gi")
+	explicitDB := profileResources("5", "5", "5Gi", "5Gi")
+	explicitEndpoint := profileResources("7", "7", "7Gi", "7Gi")
+
+	nb := &nbv1.NooBaa{
+		Spec: nbv1.NooBaaSpec{
+			PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+			CoreResources:      &explicitCore,
+			DBSpec: &nbv1.NooBaaDBSpec{
+				DBResources: &explicitDB,
+			},
+			Endpoints: &nbv1.EndpointsSpec{
+				Resources: &explicitEndpoint,
+			},
+		},
+	}
+
+	assertResourceRequirements(t, getCoreResources(nb), explicitCore)
+	assertResourceRequirements(t, getDBResources(nb), explicitDB)
+	assertResourceRequirements(t, getEndpointResources(nb), explicitEndpoint)
+}
+
+func assertPerformanceProfile(t *testing.T, got, want performanceProfile) {
+	t.Helper()
+	assertResourceRequirements(t, got.coreResources, want.coreResources)
+	assertResourceRequirements(t, got.dbResources, want.dbResources)
+	assertResourceRequirements(t, got.endpointResources, want.endpointResources)
+	if got.endpointMinCount != want.endpointMinCount {
+		t.Errorf("endpointMinCount = %d, want %d", got.endpointMinCount, want.endpointMinCount)
+	}
+	if got.endpointMaxCount != want.endpointMaxCount {
+		t.Errorf("endpointMaxCount = %d, want %d", got.endpointMaxCount, want.endpointMaxCount)
+	}
+	if got.dbInstances != want.dbInstances {
+		t.Errorf("dbInstances = %d, want %d", got.dbInstances, want.dbInstances)
+	}
+	if got.pvPoolNumVolumes != want.pvPoolNumVolumes {
+		t.Errorf("pvPoolNumVolumes = %d, want %d", got.pvPoolNumVolumes, want.pvPoolNumVolumes)
+	}
+}
+
+func assertResourceRequirements(t *testing.T, got, want corev1.ResourceRequirements) {
+	t.Helper()
+	assertResourceList(t, got.Requests, want.Requests, "requests")
+	assertResourceList(t, got.Limits, want.Limits, "limits")
+}
+
+func assertResourceList(t *testing.T, got, want corev1.ResourceList, listName string) {
+	t.Helper()
+	for name, wantQty := range want {
+		gotQty, ok := got[name]
+		if !ok {
+			t.Errorf("%s missing resource %q", listName, name)
+			continue
+		}
+		if gotQty.Cmp(wantQty) != 0 {
+			t.Errorf("%s[%q] = %s, want %s", listName, name, gotQty.String(), wantQty.String())
+		}
+	}
+	for name := range got {
+		if _, ok := want[name]; !ok {
+			qty := got[name]
+			t.Errorf("%s has unexpected resource %q = %s", listName, name, qty.String())
+		}
+	}
+}
+
+func TestProfileResourcesValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile nbv1.PerformanceProfileType
+		core    [4]string
+		db      [4]string
+		endpoint [4]string
+	}{
+		{
+			name:    "default",
+			profile: nbv1.PerformanceProfileDefault,
+			core:    [4]string{"500m", "1", "1Gi", "4Gi"},
+			db:      [4]string{"1", "1", "2Gi", "2Gi"},
+			endpoint: [4]string{"500m", "2", "1Gi", "3Gi"},
+		},
+		{
+			name:    "mixed-workload",
+			profile: nbv1.PerformanceProfileMixedWorkload,
+			core:    [4]string{"1", "2", "2Gi", "4Gi"},
+			db:      [4]string{"4", "4", "8Gi", "8Gi"},
+			endpoint: [4]string{"2", "4", "2Gi", "4Gi"},
+		},
+		{
+			name:    "small-objects",
+			profile: nbv1.PerformanceProfileSmallObjects,
+			core:    [4]string{"1", "2", "2Gi", "6Gi"},
+			db:      [4]string{"6", "6", "16Gi", "16Gi"},
+			endpoint: [4]string{"2", "4", "2Gi", "4Gi"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := performanceProfiles[tt.profile]
+			assertResourceQuantity(t, profile.coreResources, tt.core)
+			assertResourceQuantity(t, profile.dbResources, tt.db)
+			assertResourceQuantity(t, profile.endpointResources, tt.endpoint)
+		})
+	}
+}
+
+func assertResourceQuantity(t *testing.T, resources corev1.ResourceRequirements, values [4]string) {
+	t.Helper()
+	cpuReq := resource.MustParse(values[0])
+	cpuLim := resource.MustParse(values[1])
+	memReq := resource.MustParse(values[2])
+	memLim := resource.MustParse(values[3])
+
+	if resources.Requests.Cpu().Cmp(cpuReq) != 0 {
+		t.Errorf("cpu request = %s, want %s", resources.Requests.Cpu().String(), cpuReq.String())
+	}
+	if resources.Limits.Cpu().Cmp(cpuLim) != 0 {
+		t.Errorf("cpu limit = %s, want %s", resources.Limits.Cpu().String(), cpuLim.String())
+	}
+	if resources.Requests.Memory().Cmp(memReq) != 0 {
+		t.Errorf("memory request = %s, want %s", resources.Requests.Memory().String(), memReq.String())
+	}
+	if resources.Limits.Memory().Cmp(memLim) != 0 {
+		t.Errorf("memory limit = %s, want %s", resources.Limits.Memory().String(), memLim.String())
+	}
+}

--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -158,12 +158,12 @@ func (r *Reconciler) CheckSystemCR() error {
 	// Verify the endpoints spec
 	endpointsSpec := r.NooBaa.Spec.Endpoints
 	if endpointsSpec != nil {
-		if endpointsSpec.MinCount <= 0 {
+		minCount, maxCount := getEndpointMinMax(r.NooBaa)
+		if minCount <= 0 {
 			return util.NewPersistentError("InvalidEndpointsConfiguration",
 				"Invalid endpoint min count (must be greater than 0)")
 		}
-		// Validate bounds on endpoint counts
-		if endpointsSpec.MinCount > endpointsSpec.MaxCount {
+		if minCount > maxCount {
 			return util.NewPersistentError("InvalidEndpointsConfiguration",
 				"Invalid endpoint maximum count (must be higher than or equal to minimum count)")
 		}

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -697,9 +697,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 			util.ReflectEnvVariable(&c.Env, "HTTPS_PROXY")
 			util.ReflectEnvVariable(&c.Env, "NO_PROXY")
 
-			if r.NooBaa.Spec.CoreResources != nil {
-				c.Resources = *r.NooBaa.Spec.CoreResources
-			}
+			c.Resources = getCoreResources(r.NooBaa)
 
 			if r.shouldReconcileCNPGCluster() {
 				dbSecretVolumeMounts := []corev1.VolumeMount{{

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -356,9 +356,7 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 		switch c.Name {
 		case "endpoint":
 			c.Image = r.NooBaa.Status.ActualImage
-			if endpointsSpec != nil && endpointsSpec.Resources != nil {
-				c.Resources = *endpointsSpec.Resources
-			}
+			c.Resources = getEndpointResources(r.NooBaa)
 			mgmtBaseAddr := ""
 			s3BaseAddr := ""
 			syslogBaseAddr := ""
@@ -1034,9 +1032,13 @@ func (r *Reconciler) preparePVPoolBackingStore() error {
 
 	// create backing store
 	defaultPVSize := int64(50) * 1024 * 1024 * 1024 // 50GB
+	existingVolumes := 0
+	if r.DefaultBackingStore.Spec.PVPool != nil {
+		existingVolumes = r.DefaultBackingStore.Spec.PVPool.NumVolumes
+	}
 	r.DefaultBackingStore.Spec.Type = nbv1.StoreTypePVPool
 	r.DefaultBackingStore.Spec.PVPool = &nbv1.PVPoolSpec{}
-	r.DefaultBackingStore.Spec.PVPool.NumVolumes = 1
+	r.DefaultBackingStore.Spec.PVPool.NumVolumes = getPVPoolNumVolumes(r.NooBaa, existingVolumes)
 	r.DefaultBackingStore.Spec.PVPool.VolumeResources = &corev1.VolumeResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceStorage: *resource.NewQuantity(defaultPVSize, resource.BinarySI),

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -41,11 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	defaultEndpointMinCount int32 = 1
-	defaultEndpointMaxCount int32 = 2
-)
-
 var (
 	// ReadmeReady is a template for system.status.readme
 	ReadmeReady = template.Must(template.New("system_status_readme_ready").
@@ -807,8 +802,5 @@ func (r *Reconciler) GetAffinity() *corev1.Affinity {
 }
 
 func (r *Reconciler) getEndpointMinMaxCount() (int32, int32) {
-	if r.NooBaa.Spec.Endpoints != nil {
-		return r.NooBaa.Spec.Endpoints.MinCount, r.NooBaa.Spec.Endpoints.MaxCount
-	}
-	return defaultEndpointMinCount, defaultEndpointMaxCount
+	return getEndpointMinMax(r.NooBaa)
 }


### PR DESCRIPTION
### Describe the Problem

NooBaa currently requires users to manually configure resource requests/limits and pod counts for each component (core, DB, endpoints) individually. There is no way to select a pre-defined resource bundle that matches a particular workload pattern, forcing every deployment to hand-tune multiple fields.

Relates to [RHSTOR-8629](https://redhat.atlassian.net/browse/RHSTOR-8629).

### Explain the Changes
1. Added `spec.performanceProfile` field to the NooBaa CR with kubebuilder validation enum (`default`, `mixed-workload`, `small-objects`)
2. Created `pkg/system/performance_profiles.go` with a profile lookup table and getter functions (`getCoreResources`, `getDBResources`, `getEndpointResources`, `getDBInstances`, `getEndpointMinMax`, `getPVPoolNumVolumes`) that implement per-knob precedence: explicit spec field > profile value > base manifest value
3. Wired profile-aware getters into `phase2_creating.go` (core container), `db_reconciler.go` (CNPG instances + resources + PG tuning), `phase4_configuring.go` (endpoint container + default pv-pool NumVolumes), and `reconciler.go` (endpoint min/max counts)
4. Updated `phase1_verifying.go` endpoint validation to use resolved profile values, allowing users to set `spec.endpoints.resources` without needing to also specify `minCount`/`maxCount`
5. Default pv-pool backing store `NumVolumes` is now profile-driven (3 for all profiles) with increase-only semantics — existing deployments on the default profile keep their current count
6. Legacy `spec.dbResources` (standalone StatefulSet path) is unaffected by profiles — only the CNPG path (`spec.dbSpec.dbResources`) participates in profile resolution
7. Regenerated CRD and bundle (`make gen-api && make gen`)

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-9144

### Testing Instructions:
1. Run unit tests: `go test ./pkg/system/ -run 'TestLookupProfile|TestGetCoreResources|TestGetDBResources|TestGetEndpointResources|TestGetDBInstances|TestGetEndpointMinMax|TestGetPVPoolNumVolumes|TestProfileResourceValues' -v`
2. Deploy a NooBaa CR with `spec.performanceProfile: mixed-workload` and verify core/DB/endpoint pods get the expected resource requests/limits from the profile table
3. Deploy a NooBaa CR with `spec.performanceProfile: small-objects` AND an explicit `spec.coreResources` override — verify the explicit value wins for core while DB/endpoint use the profile
4. Deploy with `spec.endpoints.resources` set but no `minCount`/`maxCount` — verify validation passes and counts come from the profile
5. Verify existing deployments without a profile set continue to behave as before (default profile applies)

- [ ] Doc added/updated
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `spec.performanceProfile` to NooBaa with `default`, `mixed-workload`, and `small-objects`.
  * Selected profiles provide bundled resource defaults for core, database, and endpoint components (explicit per-component values still take precedence); unknown/non-set values fall back to `default`.
* **Bug Fixes**
  * Endpoint min/max validation and scaling now consistently use the profile-aware calculations.
  * Database instance/resource derivation, endpoint resources, and PV pool `NumVolumes` sizing now follow the selected profile (including “never decrease” behavior for existing volumes).
* **Tests**
  * Added coverage for profile selection, overrides, resource computation, PV sizing, and endpoint min/max logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->