### PR TITLE
Keycloak | Created cli for keycloak configuration and saved it in a secret

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -111,6 +111,50 @@ var _ = Describe("CLI tests", func() {
 		})
 	})
 
+	Context("Noobaa system oidc CLI", func() {
+		It("system oidc --help shows keycloak configuration options", func() {
+			out, err := RunCLI("system", "oidc", "--help")
+			Expect(err).To(BeNil())
+			Expect(out).To(ContainSubstring("--type"))
+			Expect(out).To(ContainSubstring("--configure"))
+			Expect(out).To(ContainSubstring("keycloak"))
+			Expect(out).To(ContainSubstring("file://"))
+		})
+
+		It("system oidc rejects unsupported provider type", func() {
+			out, err := RunCLI("system", "oidc", "--type", "unsupported", "--configure", `{}`)
+			Expect(err).NotTo(BeNil())
+			Expect(out).To(ContainSubstring("Unsupported OIDC provider type"))
+		})
+
+		It("system oidc rejects invalid JSON configuration", func() {
+			out, err := RunCLI("system", "oidc", "--type", "keycloak", "--configure", `{invalid`)
+			Expect(err).NotTo(BeNil())
+			Expect(out).To(ContainSubstring("not valid JSON"))
+		})
+
+		It("system oidc rejects empty provider in configuration", func() {
+			out, err := RunCLI("system", "oidc", "--type", "keycloak", "--configure", `{"providers":[{}]}`)
+			Expect(err).NotTo(BeNil())
+			Expect(out).To(ContainSubstring("provider[0] is empty"))
+		})
+
+		It("system oidc rejects provider with multiple missing fields", func() {
+			out, err := RunCLI("system", "oidc", "--type", "keycloak", "--configure",
+				`{"providers":[{"issuer":"example.com/realms/r"}]}`)
+			Expect(err).NotTo(BeNil())
+			Expect(out).To(ContainSubstring("provider[0] is missing required fields:"))
+			Expect(out).To(ContainSubstring("client_id"))
+			Expect(out).To(ContainSubstring("client_secret"))
+		})
+
+		It("system oidc rejects missing configuration file", func() {
+			out, err := RunCLI("system", "oidc", "--type", "keycloak", "--configure", "file:///tmp/noobaa-missing-keycloak-config.json")
+			Expect(err).NotTo(BeNil())
+			Expect(out).To(ContainSubstring("failed to read configuration file"))
+		})
+	})
+
 	Context("Noobaa CLI commands related to GCP", func() {
 		It("backingstore create google-cloud-storage --help shows GCP options", func() {
 			out, err := RunCLI("backingstore", "create", "google-cloud-storage", "--help")

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -55,6 +55,7 @@ func Cmd() *cobra.Command {
 		CmdList(),
 		CmdReconcile(),
 		CmdYaml(),
+		CmdOidc(),
 	)
 	return cmd
 }
@@ -154,6 +155,45 @@ func CmdYaml() *cobra.Command {
 		Run:   RunYaml,
 		Args:  cobra.NoArgs,
 	}
+	return cmd
+}
+
+const keycloakOIDCConfigKey = "config.json"
+
+// KeycloakOIDCProvider represents a single Keycloak OIDC provider configuration.
+type KeycloakOIDCProvider struct {
+	Issuer                     string `json:"issuer"`
+	ClientID                   string `json:"client_id"`
+	ClientSecret               string `json:"client_secret"`
+	JWKSURI                    string `json:"jwks_uri"`
+	TokenIntrospectionEndpoint string `json:"token_introspection_endpoint"`
+}
+
+// KeycloakOIDCConfig represents the Keycloak OIDC configuration stored in the secret.
+type KeycloakOIDCConfig struct {
+	Providers []KeycloakOIDCProvider `json:"providers"`
+}
+
+// CmdOidc returns a CLI command for managing OIDC configuration.
+func CmdOidc() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "oidc",
+		Short: "Manage OIDC configuration",
+		Long: "Configure OIDC providers for NooBaa STS.\n" +
+			"The configuration is stored in a Kubernetes secret and mounted into endpoint pods.",
+		Run: RunOidc,
+	}
+	cmd.Flags().String("type", "", "OIDC provider type (keycloak)")
+	cmd.Flags().String(
+		"configure",
+		"",
+		"OIDC configuration in JSON format, or a path to a JSON/txt file prefixed with file:// (e.g. file://keycloak_config.json).\n"+
+			"For Keycloak, the expected structure is:\n"+
+			`{"providers":[{"issuer":"<kc-server>:<kc-port>/realms/<realm-name>",`+
+			`"client_id":"<client-id>","client_secret":"<client-secret>",`+
+			`"jwks_uri":"http://<kc-server>:<kc-port>/realms/<realm-name>/protocol/openid-connect/certs",`+
+			`"token_introspection_endpoint":"http://<kc-server>:<kc-port>/realms/<realm-name>/protocol/openid-connect/token/introspect"}]}`,
+	)
 	return cmd
 }
 
@@ -689,6 +729,121 @@ func RunYaml(cmd *cobra.Command, args []string) {
 	sys := LoadSystemDefaults()
 	p := printers.YAMLPrinter{}
 	util.Panic(p.PrintObj(sys, os.Stdout))
+}
+
+// RunOidc runs the OIDC CLI command.
+func RunOidc(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+
+	providerType, _ := cmd.Flags().GetString("type")
+	configure, _ := cmd.Flags().GetString("configure")
+
+	if providerType == "" {
+		log.Fatalf(`❌ Missing required flag: --type %s`, cmd.UsageString())
+	}
+	if configure == "" {
+		log.Fatalf(`❌ Missing required flag: --configure %s`, cmd.UsageString())
+	}
+
+	switch providerType {
+	case "keycloak":
+		configJSON, err := readOIDCConfigInput(configure)
+		if err != nil {
+			log.Fatalf(`❌ %v`, err)
+		}
+		if err := configureKeycloakOIDC(configJSON); err != nil {
+			log.Fatalf(`❌ %v`, err)
+		}
+	default:
+		log.Fatalf(`❌ Unsupported OIDC provider type %q`, providerType)
+	}
+}
+
+func readOIDCConfigInput(configure string) (string, error) {
+	if strings.HasPrefix(configure, "file://") {
+		filePath := strings.TrimPrefix(configure, "file://")
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read configuration file %q: %w", filePath, err)
+		}
+		return string(content), nil
+	}
+	return configure, nil
+}
+
+func validateKeycloakOIDCConfig(configJSON string) (*KeycloakOIDCConfig, error) {
+	if !json.Valid([]byte(configJSON)) {
+		return nil, fmt.Errorf("the provided configuration is not valid JSON")
+	}
+
+	var config KeycloakOIDCConfig
+	if err := json.Unmarshal([]byte(configJSON), &config); err != nil {
+		return nil, fmt.Errorf("failed to parse configuration: %w", err)
+	}
+
+	if len(config.Providers) == 0 {
+		return nil, fmt.Errorf("configuration must contain at least one provider")
+	}
+
+	for i, provider := range config.Providers {
+		var missing []string
+		if provider.Issuer == "" {
+			missing = append(missing, "issuer")
+		}
+		if provider.ClientID == "" {
+			missing = append(missing, "client_id")
+		}
+		if provider.ClientSecret == "" {
+			missing = append(missing, "client_secret")
+		}
+		if provider.JWKSURI == "" {
+			missing = append(missing, "jwks_uri")
+		}
+		if provider.TokenIntrospectionEndpoint == "" {
+			missing = append(missing, "token_introspection_endpoint")
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		if len(missing) == 5 {
+			return nil, fmt.Errorf("provider[%d] is empty", i)
+		}
+		return nil, fmt.Errorf("provider[%d] is missing required fields: %s", i, strings.Join(missing, ", "))
+	}
+
+	return &config, nil
+}
+
+func configureKeycloakOIDC(configJSON string) error {
+	log := util.Logger()
+
+	sys := LoadSystemDefaults()
+	if !util.KubeCheck(sys) {
+		return fmt.Errorf("NooBaa system %q not found in namespace %q", sys.Name, sys.Namespace)
+	}
+
+	config, err := validateKeycloakOIDCConfig(configJSON)
+	if err != nil {
+		return err
+	}
+
+	normalizedJSON, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal configuration: %w", err)
+	}
+
+	secret := util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret)
+	secret.Name = options.SystemName + "-oidc-keycloak-config"
+	secret.Namespace = options.Namespace
+	secret.StringData = map[string]string{
+		keycloakOIDCConfigKey: string(normalizedJSON),
+	}
+	secret.Data = nil
+
+	util.KubeApply(secret)
+
+	log.Printf("✅ Keycloak OIDC configuration saved to secret %q", secret.Name)
+	return nil
 }
 
 // CheckNooBaaImages runs a CLI command


### PR DESCRIPTION
### Describe the Problem
There was no CLI way to configure Keycloak OIDC for NooBaa STS. Users had to manually create the Kubernetes secret with the Keycloak provider config.

### Explain the changes
1. Added `noobaa system oidc --type keycloak --configure <<configuration in json format>` CLI command.
2. Accepts inline JSON or a file path using file:// (.json or .txt with JSON content).
3. Validates the config (required fields: issuer, client_id, client_secret, jwks_uri, token_introspection_endpoint).
4. Saves the config to secret noobaa-oidc-keycloak-config under key config.json.
5. Triggers operator reconcile so endpoint pods mount the config at /etc/noobaa-server/oidc/keycloak_config/config.json.
6. Added CLI tests for help, invalid input, and missing file cases.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8956

### Testing Instructions:
1. Run unit tests: `go test ./pkg/cli/... -ginkgo.focus "system oidc"`
2. Create keycloak_config.json with a valid providers array.
3. Run:
```
noobaa system oidc \
  --type keycloak \
  --configure file://keycloak_config.json
```


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added OIDC configuration support for NooBaa systems using Keycloak.
- Introduced the `noobaa system oidc` CLI command with `--type` and `--configure`.
- Accepts inline JSON or `file://` configuration input, validates it, and saves the result to a Kubernetes Secret.

## Tests
- Added Ginkgo coverage for `--help` output and `--configure` validation failures (unsupported type, invalid JSON, missing required provider fields, and missing config file).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->