### PR TITLE
DFBUGS-7108 | Add `ConnectAuto` instead of `Connect` To Use CLI Commands From Operator Pod 

### DIFF
--- a/pkg/cosi/cosi_bucket_access.go
+++ b/pkg/cosi/cosi_bucket_access.go
@@ -209,7 +209,7 @@ func RunStatusBucketAccessClaim(cmd *cobra.Command, args []string) {
 		log.Fatalf(`❌ Could not find COSI bucket access claim secret %q in namespace %q`, secret.Name, cosiBucketAccessClaim.Namespace)
 	}
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		util.Logger().Fatalf("❌ %s", err)
 	}

--- a/pkg/cosi/cosi_bucket_claim.go
+++ b/pkg/cosi/cosi_bucket_claim.go
@@ -206,7 +206,7 @@ func RunStatusBucketClaim(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		util.Logger().Fatalf("❌ %s", err)
 	}

--- a/pkg/cosi/cosi_cli_test.go
+++ b/pkg/cosi/cosi_cli_test.go
@@ -34,7 +34,7 @@ var _ = Describe("COSI CLI tests", func() {
 	var nsResource *nbv1.NamespaceStore
 	log := util.Logger()
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Infof("COSI bucket creation tests, can't create sysclient: err= %q", err)
 	}

--- a/pkg/cosi/cosi_test.go
+++ b/pkg/cosi/cosi_test.go
@@ -36,7 +36,7 @@ var _ = Describe("COSI driver/provisioner tests", func() {
 
 	log := util.Logger()
 	nbClient := system.GetNBClient()
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Infof("COSI bucket creation tests, can't create sysclient: err= %q", err)
 	}

--- a/pkg/noobaaaccount/noobaaaccount.go
+++ b/pkg/noobaaaccount/noobaaaccount.go
@@ -256,7 +256,7 @@ func RunUpdate(cmd *cobra.Command, args []string) {
 	noobaaAccount.Name = name
 	noobaaAccount.Namespace = options.Namespace
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Fatalf("❌ failed to run RPC call: %s", err)
 	}
@@ -303,7 +303,7 @@ func RunUpdate(cmd *cobra.Command, args []string) {
 			RunStatus(cmd, args)
 		}
 	} else {
-		sysClient, err := system.Connect(true)
+		sysClient, err := system.ConnectAuto()
 		if err != nil {
 			log.Fatalf(`❌ Unable to create RPC client %s`, err)
 		}
@@ -614,7 +614,7 @@ func GenerateAccountKeys(name string) error {
 
 	var accessKeys nb.S3AccessKeys
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}
@@ -671,7 +671,7 @@ func GenerateNonCrdAccountKeys(name string) error {
 
 	var accessKeys nb.S3AccessKeys
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}
@@ -708,7 +708,7 @@ func GenerateNonCrdAccountKeys(name string) error {
 func UpdateAccountKeys(name string, accessKeys nb.S3AccessKeys) error {
 	log := util.Logger()
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}
@@ -764,7 +764,7 @@ func UpdateAccountKeys(name string, accessKeys nb.S3AccessKeys) error {
 func UpdateNonCrdAccountKeys(name string, accessKeys nb.S3AccessKeys) error {
 	log := util.Logger()
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}

--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -443,7 +443,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		util.Logger().Fatalf("❌ %s", err)
 	}
@@ -658,7 +658,7 @@ func GenerateAccountKeys(name, accountName, appNamespace string) error {
 
 	var accessKeys nb.S3AccessKeys
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}

--- a/pkg/sts/sts.go
+++ b/pkg/sts/sts.go
@@ -71,7 +71,7 @@ func RunAssign(cmd *cobra.Command, args []string) {
 		log.Fatalf(`❌ The provided role configuration is not valid JSON`)
 	}
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Fatalf(`❌ Failed to create RPC client %s`, err)
 	}
@@ -100,7 +100,7 @@ func RunAssign(cmd *cobra.Command, args []string) {
 func RunRemove(cmd *cobra.Command, args []string) {
 	email, _ := cmd.Flags().GetString("email")
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Fatalf(`❌ Failed to create RPC client %s`, err)
 	}

--- a/pkg/system/cmd_api_call.go
+++ b/pkg/system/cmd_api_call.go
@@ -35,7 +35,7 @@ func RunAPICall(cmd *cobra.Command, args []string) {
 		apiName += "_api"
 	}
 
-	sysClient, err := Connect(true)
+	sysClient, err := ConnectAuto()
 	if err != nil {
 		log.Fatalf("❌ %s", err)
 	}

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -1229,7 +1230,7 @@ type Client struct {
 
 // GetNBClient returns an api client
 func GetNBClient() nb.Client {
-	c, err := Connect(true)
+	c, err := ConnectAuto()
 	if err != nil {
 		util.Logger().Fatalf("❌ %s", err)
 	}
@@ -1343,6 +1344,22 @@ func Connect(isExternal bool) (*Client, error) {
 		S3URL:       s3URL,
 		VectorsURL:  vectorsURL,
 	}, nil
+}
+
+// IsRunningInCluster returns true when the process runs inside a Kubernetes pod.
+// It uses rest.InClusterConfig(), which checks KUBERNETES_SERVICE_HOST/PORT and
+// the service account token/CA at /var/run/secrets/kubernetes.io/serviceaccount/.
+// KUBECONFIG does not affect this detection.
+func IsRunningInCluster() bool {
+	_, err := rest.InClusterConfig()
+	return err == nil
+}
+
+// ConnectAuto connects to the NooBaa system
+// external to cluster or internal to cluster based on the running environment
+func ConnectAuto() (*Client, error) {
+	isExternal := !IsRunningInCluster()
+	return Connect(isExternal)
 }
 
 // GetDesiredDBImage returns the desired DB image according to spec or env or default (in options)

--- a/pkg/validations/common_bucket_validations.go
+++ b/pkg/validations/common_bucket_validations.go
@@ -82,9 +82,13 @@ func ValidateReplicationPolicy(bucketName string, replicationPolicy string, upda
 	}
 
 	log.Infof("ValidateReplicationPolicy: validating replication: replicationParams: %+v", replicationParams)
-	IsExternalRPCConnection := util.IsTestEnv() || isCLI
 
-	sysClient, err := system.Connect(IsExternalRPCConnection)
+	var sysClient *system.Client
+	if isCLI {
+		sysClient, err = system.ConnectAuto()
+	} else {
+		sysClient, err = system.Connect(util.IsTestEnv())
+	}
 	if err != nil {
 		return fmt.Errorf("Provisioner Failed to validate replication of bucket %q with error: %v", bucketName, err)
 	}


### PR DESCRIPTION
### Describe the Problem
Currently, CLI commands that use `Connect` (or `GetNBClient`) hardcode the `isExternal` parameter. This leads to a panic error in case someone wants to run the CLI commands from inside the operator pod. In this PR, I added the `ConnectAuto` to replace the hardcoded `isExternal` parameter and used it mainly in the CLI commands.

### Explain the changes
1. In file `pkg/system/system.go` added `ConnectAuto` and the helper function `IsRunningInCluster`, which is the decision on whether running from inside the pod. `GetNBClient` changed to use the `ConnectAuto`.


### Issues: Fixed [DFBUGS-7108](https://redhat.atlassian.net/browse/DFBUGS-7108)
1. Before the change (example of `obc regenerate` CLI command):

<details>

<summary>Full error stuck</summary>

```
time="2026-06-15T12:26:41Z" level=panic msg="☠️  Panic Attack: [] error upgrading connection: pods \"noobaa-core-0\" is forbidden: User \"system:serviceaccount:test1:noobaa\" cannot create resource \"pods/portforward\" in API group \"\" in the namespace \"test1\""
panic: (*logrus.Entry) 0x4000dc3ab0

goroutine 1 [running]:
github.com/sirupsen/logrus.(*Entry).log(0x4000468f50, 0x0, {0x4000138620, 0xd4})
	noobaa-operator/vendor/github.com/sirupsen/logrus/entry.go:260 +0x434
github.com/sirupsen/logrus.(*Entry).Log(0x4000468f50, 0x0, {0x4000c49188?, 0x2?, 0x2?})
	noobaa-operator/vendor/github.com/sirupsen/logrus/entry.go:304 +0x60
github.com/sirupsen/logrus.(*Entry).Logf(0x4000468f50, 0x0, {0x2cf2e36?, 0x40000f0ea0?}, {0x4000c491e8?, 0x1796fd8?, 0x4000c491e8?})
	noobaa-operator/vendor/github.com/sirupsen/logrus/entry.go:349 +0x84
github.com/sirupsen/logrus.(*Entry).Panicf(...)
	noobaa-operator/vendor/github.com/sirupsen/logrus/entry.go:387
github.com/noobaa/noobaa-operator/v5/pkg/util.Panic({0x4fa2048, 0x4000dd78f0})
	noobaa-operator/pkg/util/util.go:912 +0x8c
github.com/noobaa/noobaa-operator/v5/pkg/nb.(*APIRouterPortForward).Start(0x4000e0ca80)
	noobaa-operator/pkg/nb/router.go:123 +0x634
github.com/noobaa/noobaa-operator/v5/pkg/system.Connect(0x1)
	noobaa-operator/pkg/system/system.go:1295 +0x1e0
github.com/noobaa/noobaa-operator/v5/pkg/obc.GenerateAccountKeys({0xffffea58fc8c, 0x9}, {0x400087d4f0, 0x4d}, {0x4000078010, 0x5})
	noobaa-operator/pkg/obc/obc.go:661 +0x70
github.com/noobaa/noobaa-operator/v5/pkg/obc.RunRegenerate(0x4000a62008, {0x40006af300, 0x1, 0x1})
	noobaa-operator/pkg/obc/obc.go:337 +0x4f0
github.com/spf13/cobra.(*Command).execute(0x4000a62008, {0x40006af2c0, 0x1, 0x1})
	noobaa-operator/vendor/github.com/spf13/cobra/command.go:1019 +0x7bc
github.com/spf13/cobra.(*Command).ExecuteC(0x40009c2c08)
	noobaa-operator/vendor/github.com/spf13/cobra/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
	noobaa-operator/vendor/github.com/spf13/cobra/command.go:1071
github.com/noobaa/noobaa-operator/v5/pkg/cli.Run()
	noobaa-operator/pkg/cli/cli.go:67 +0x34
main.main()
	noobaa-operator/cmd/manager/main.go:14 +0x1c
command terminated with exit code 2
```

</details>

As you can see from the error message, it is about the permission of the service account (`system:serviceaccount:test1:noobaa\`, the one related to the operator pod) creating `portforward`. In the error stuck, you can see the `Connect` function and in the code can see that it is using hard-coded `isExternal`.
https://github.com/noobaa/noobaa-operator/blob/6ae1d09b12d714560f9d990010cbf458526fc6c6/pkg/obc/obc.go#L661
Note: The original issue was on the `obc regenerate` command, but after AI reviews, I decided to extract the scope for all CLI commands. I also decided to exclude all the code that runs from the operator and leave it as-is (with hardcoded `isExternal` set to false).

### Testing Instructions:
#### Manual Tests
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
3. Create OBC, for example using the CLI command: `nb obc create shira-obc -n test1 --show-secrets`.
4. Regenerate the credentials (all options should work):
- From outside the cluster: `yes y | build/_output/bin/noobaa-operator-local -n test1 obc regenerate shira-obc` (also works when using `export KUBECONFIG=~/.kube/config`,
- From the operator pod: `kubectl -n test1 exec deploy/noobaa-operator -- /bin/sh -c 'yes y | /usr/local/bin/noobaa-operator obc regenerate shira-obc'`

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added automatic Kubernetes environment detection to choose the appropriate system connection mode at runtime (in-cluster vs external).

- **Refactor**
  - Updated system/RPC client initialization to use automatic connection logic across multiple CLI commands (including account key generation/update, status, assign/remove, and API call flows).
  - Adjusted relevant test setup to use the same automatic connection behavior.
  - Updated replication policy validation to select connection mode based on whether the call originates from the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->