### PR TITLE
Add support for TLS in CNPG

### DIFF
--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -315,6 +315,15 @@ func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
 		Enabled: true,
 	}
 
+	if r.CNPGCluster.Spec.Certificates == nil {
+		r.CNPGCluster.Spec.Certificates = &cnpgv1.CertificatesConfiguration{}
+	}
+	r.CNPGCluster.Spec.Certificates.ServerAltDNSNames = []string{
+		r.ServiceDbPg.Name,
+		r.ServiceDbPg.Name + "." + r.Request.Namespace,
+		r.ServiceDbPg.Name + "." + r.Request.Namespace + ".svc",
+	}
+
 	r.CNPGCluster.Spec.FailoverDelay = defaultFailoverDelaySec
 
 	r.setPostgresConfig()
@@ -620,6 +629,17 @@ func (r *Reconciler) setPostgresConfig() {
 	}
 	r.cnpgLog("PGTune config: memory=%dKB, cpu=%d, endpoints=%d", totalMemoryKB, cpuNum, endpointMaxCount)
 
+	// propagate TLS security settings to the PostgreSQL server
+	tlsSec := r.NooBaa.Spec.Security.APIServerSecurity
+	if tlsSec != nil && !util.IsTLSConfigDisabled() {
+		if tlsSec.TLSMinVersion != nil {
+			overrideParameters["ssl_min_protocol_version"] = string(*tlsSec.TLSMinVersion)
+		}
+		if len(tlsSec.TLSCiphers) > 0 {
+			overrideParameters["ssl_ciphers"] = util.MapCiphersToOpenSSL(tlsSec.TLSCiphers)
+		}
+	}
+
 	// apply any user-specified DBConf overrides on top of the calculated values
 	if r.NooBaa.Spec.DBSpec.DBConf != nil {
 		for k, v := range r.NooBaa.Spec.DBSpec.DBConf {
@@ -904,6 +924,7 @@ func (r *Reconciler) wasClusterSpecChanged(existingClusterSpec *cnpgv1.ClusterSp
 		!reflect.DeepEqual(existingClusterSpec.Monitoring, r.CNPGCluster.Spec.Monitoring) ||
 		!reflect.DeepEqual(existingClusterSpec.PostgresConfiguration.Parameters, r.CNPGCluster.Spec.PostgresConfiguration.Parameters) ||
 		!reflect.DeepEqual(existingClusterSpec.Backup, r.CNPGCluster.Spec.Backup) ||
+		!reflect.DeepEqual(existingClusterSpec.Certificates, r.CNPGCluster.Spec.Certificates) ||
 		existingClusterSpec.PriorityClassName != r.CNPGCluster.Spec.PriorityClassName ||
 		existingClusterSpec.FailoverDelay != r.CNPGCluster.Spec.FailoverDelay
 }

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -591,14 +591,13 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			c.Env[j].Value = ""
 			c.Env[j].ValueFrom = nil
 		case "POSTGRES_SSL_REQUIRED":
-			if r.NooBaa.Spec.ExternalPgSSLRequired {
+			if r.NooBaa.Spec.ExternalPgSSLRequired || r.shouldReconcileCNPGCluster() {
 				c.Env[j].Value = "true"
 			}
 		case "POSTGRES_SSL_UNAUTHORIZED":
-			if r.NooBaa.Spec.ExternalPgSSLUnauthorized {
+			if r.NooBaa.Spec.ExternalPgSSLUnauthorized || r.shouldReconcileCNPGCluster() {
 				c.Env[j].Value = "true"
 			}
-
 		case "POSTGRES_DBNAME_PATH":
 			c.Env[j].Value = postgresSecretMountPath + "/dbname"
 		case "POSTGRES_PASSWORD_PATH":


### PR DESCRIPTION
### Describe the Problem
NooBaa already supports TLS for external PG. We wish to have same support for internal PG as well.

### Explain the changes
CNPG has out of the box support for TLS. This PR simply does 3 things:
1. Enable TLS config in CNPG
2. Configure the k8s specific alt domains for cert generation
3. Use the same cipher etc which is used throughout other places in NooBaa


### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8867

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved database cluster certificate generation by initializing missing certificates and adding additional DNS name variants for better service discovery.
  * Kept PostgreSQL TLS settings aligned with the cluster’s API TLS configuration when TLS is enabled, including minimum TLS protocol version and configured cipher suites.
  * Updated PostgreSQL TLS environment variables so SSL is enforced when external TLS is enabled or when CNPG reconciliation is required.
  * Certificate changes now correctly trigger cluster reconciliation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->