### PR TITLE
[Backport to 5.20 ] Harden CNPG PostgreSQL config for replica HA stability

### DIFF
--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -22,6 +22,8 @@ const (
 
 	noobaaDBUser = "noobaa"
 	noobaaDBName = "nbcore"
+
+	defaultFailoverDelaySec = int32(30)
 )
 
 // ReconcileCNPGCluster reconciles the CNPG cluster
@@ -273,6 +275,8 @@ func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
 	}
 	r.CNPGCluster.Spec.Monitoring.EnablePodMonitor = disableMonStr != "true" //nolint:staticcheck // SA1019 ignore
 
+	r.CNPGCluster.Spec.FailoverDelay = defaultFailoverDelaySec
+
 	r.setPostgresConfig()
 
 	// TODO: consider specifying a separate WAL storage configuration in Spec.WalStorage
@@ -402,6 +406,9 @@ func (r *Reconciler) setPostgresConfig() {
 		"work_mem":                     "1747kB",
 		"min_wal_size":                 "2GB",
 		"max_wal_size":                 "8GB",
+		"wal_level":                    "replica",
+		"wal_sender_timeout":           "60s",
+		"wal_receiver_timeout":         "60s",
 		// setting pg_stat_statements config
 		// cnpg operator will automatically add the extension to the DB (https://cloudnative-pg.io/documentation/1.25/postgresql_conf/#enabling-pg_stat_statements)
 		"pg_stat_statements.track": "all",
@@ -419,6 +426,9 @@ func (r *Reconciler) setPostgresConfig() {
 		}
 	}
 
+	// wal_keep_size = 12% of data volume, capped at 16GB (min 1GB)
+	overrideParameters["wal_keep_size"] = calculateWalKeepSize(r.CNPGCluster.Spec.StorageConfiguration.Size)
+
 	// set any parameters from DBSpec.DBConf in overrideParameters
 	if r.NooBaa.Spec.DBSpec.DBConf != nil {
 		for k, v := range r.NooBaa.Spec.DBSpec.DBConf {
@@ -435,6 +445,45 @@ func (r *Reconciler) setPostgresConfig() {
 	}
 
 	r.CNPGCluster.Spec.PostgresConfiguration.Parameters = desiredParameters
+}
+
+// formatBytesKB formats a value in kilobytes to a human-readable string,
+// choosing the largest whole unit (GB, MB, or kB).
+func formatBytesKB(kb int64) string {
+	const (
+		mbInKB = int64(1024)
+		gbInKB = int64(1024 * 1024)
+	)
+	if kb >= gbInKB && kb%gbInKB == 0 {
+		return fmt.Sprintf("%dGB", kb/gbInKB)
+	}
+	if kb >= mbInKB && kb%mbInKB == 0 {
+		return fmt.Sprintf("%dMB", kb/mbInKB)
+	}
+	return fmt.Sprintf("%dkB", kb)
+}
+
+// calculateWalKeepSize computes wal_keep_size as 12% of the data PVC size,
+// capped at 16GB. Falls back to "6GB" if the volume size cannot be parsed.
+func calculateWalKeepSize(dataVolumeSize string) string {
+	const (
+		walKeepFractionPercent = 12
+		maxWalKeepSizeMB       = int64(16 * 1024) // 16GB in MB
+		minWalKeepSizeMB       = int64(1024)      // 1GB minimum
+	)
+	qty, err := resource.ParseQuantity(dataVolumeSize)
+	if err != nil {
+		return "6GB"
+	}
+	volMB := qty.Value() / (1024 * 1024)
+	walKeepMB := volMB * int64(walKeepFractionPercent) / 100
+	if walKeepMB > maxWalKeepSizeMB {
+		walKeepMB = maxWalKeepSizeMB
+	}
+	if walKeepMB < minWalKeepSizeMB {
+		walKeepMB = minWalKeepSizeMB
+	}
+	return formatBytesKB(walKeepMB * 1024)
 }
 
 func getDesiredMajorVersion(dbSpec *nbv1.NooBaaDBSpec) int {
@@ -545,5 +594,6 @@ func (r *Reconciler) wasClusterSpecChanged(existingClusterSpec *cnpgv1.ClusterSp
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.Size, r.CNPGCluster.Spec.StorageConfiguration.Size) ||
 		!reflect.DeepEqual(existingClusterSpec.StorageConfiguration.PersistentVolumeClaimTemplate, r.CNPGCluster.Spec.StorageConfiguration.PersistentVolumeClaimTemplate) ||
 		!reflect.DeepEqual(existingClusterSpec.Monitoring, r.CNPGCluster.Spec.Monitoring) ||
-		!reflect.DeepEqual(existingClusterSpec.PostgresConfiguration.Parameters, r.CNPGCluster.Spec.PostgresConfiguration.Parameters)
+		!reflect.DeepEqual(existingClusterSpec.PostgresConfiguration.Parameters, r.CNPGCluster.Spec.PostgresConfiguration.Parameters) ||
+		existingClusterSpec.FailoverDelay != r.CNPGCluster.Spec.FailoverDelay
 }

--- a/pkg/system/db_reconciler_test.go
+++ b/pkg/system/db_reconciler_test.go
@@ -1,0 +1,50 @@
+package system
+
+import "testing"
+
+func TestFormatBytesKB(t *testing.T) {
+	tests := []struct {
+		kb   int64
+		want string
+	}{
+		{1024 * 1024, "1GB"},
+		{4 * 1024 * 1024, "4GB"},
+		{256 * 1024, "256MB"},
+		{512 * 1024, "512MB"},
+		{16 * 1024, "16MB"},
+		{4096, "4MB"},
+		{1966, "1966kB"},
+		{1024, "1MB"},
+	}
+	for _, tt := range tests {
+		got := formatBytesKB(tt.kb)
+		if got != tt.want {
+			t.Errorf("formatBytesKB(%d) = %q, want %q", tt.kb, got, tt.want)
+		}
+	}
+}
+
+func TestCalculateWalKeepSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		volSize  string
+		expected string
+	}{
+		{"50Gi default", "50Gi", "6GB"},
+		{"100Gi", "100Gi", "12GB"},
+		{"200Gi hits 16GB cap", "200Gi", "16GB"},
+		{"500Gi hits 16GB cap", "500Gi", "16GB"},
+		{"10Gi small", "10Gi", "1228MB"},
+		{"5Gi hits 1GB min", "5Gi", "1GB"},
+		{"invalid falls back", "invalid", "6GB"},
+		{"empty falls back", "", "6GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateWalKeepSize(tt.volSize)
+			if got != tt.expected {
+				t.Errorf("calculateWalKeepSize(%q) = %q, want %q", tt.volSize, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
(cherry picked from commit 6dd707d2b49ce7f60f140e0b1d5d0b2db3fa29c2)

### Explain the changes
Add WAL retention, replication timeout, and failover delay settings to prevent stuck-replica and bootstrap-gap failures observed in production.

- Add wal_keep_size computed as 12% of data PVC size (min 1GB, max 16GB)
- Set wal_level: replica to reduce ~10-30% WAL overhead from unused logical decoding
- Set wal_sender_timeout and wal_receiver_timeout to 60s (PostgreSQL upstream defaults)
- Set failoverDelay: 30 to avoid unnecessary failovers on brief blips
- Track FailoverDelay in wasClusterSpecChanged for propagation to existing clusters
- Add unit tests for calculateWalKeepSize and formatBytesKB

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-7331

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
