### PR TITLE
GCP WIF (STS) | Analyze Resource | Exclude GCP WIF (STS)

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -1036,7 +1036,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	backStore := GetBackingStoreFromArgs(cmd, args)
 	secret := util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret)
 	secretRef, _ := util.GetBackingStoreSecret(backStore)
-	if !util.IsSTSClusterBS(backStore) {
+	if !util.IsAWSSTSClusterBS(backStore) {
 		if secretRef != nil {
 			secret.Name = secretRef.Name
 			secret.Namespace = secretRef.Namespace

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -253,7 +253,7 @@ func (r *Reconciler) ReconcilePhases() error {
 
 // LoadBackingStoreSecret loads the secret to the reconciler struct
 func (r *Reconciler) LoadBackingStoreSecret() error {
-	if util.IsSTSClusterBS(r.BackingStore) {
+	if util.IsAWSSTSClusterBS(r.BackingStore) {
 		return nil
 	}
 
@@ -686,7 +686,7 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 	switch r.BackingStore.Spec.Type {
 
 	case nbv1.StoreTypeAWSS3:
-		if util.IsSTSClusterBS(r.BackingStore) {
+		if util.IsAWSSTSClusterBS(r.BackingStore) {
 			conn.EndpointType = nb.EndpointTypeAwsSTS
 			conn.AWSSTSARN = *r.BackingStore.Spec.AWSS3.AWSSTSRoleARN
 		} else {
@@ -868,7 +868,7 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		return nil, util.NewPersistentError("InvalidType",
 			fmt.Sprintf("Invalid backing store type %q", r.BackingStore.Spec.Type))
 	}
-	if !util.IsSTSClusterBS(r.BackingStore) {
+	if !util.IsAWSSTSClusterBS(r.BackingStore) {
 		if !util.IsStringGraphicOrSpacesCharsOnly(string(conn.Identity)) || !util.IsStringGraphicOrSpacesCharsOnly(string(conn.Secret)) {
 			return nil, util.NewPersistentError("InvalidSecret",
 				fmt.Sprintf("Invalid secret containing non graphic characters (perhaps not base64 encoded?) %q", r.Secret.Name))

--- a/pkg/diagnostics/analyze.go
+++ b/pkg/diagnostics/analyze.go
@@ -143,14 +143,14 @@ func analyzeAllNamespaceStores(cmd *cobra.Command, collector *Collector) bool {
 }
 
 func checkIfBackingStoreTypeIsSupported(backingStore *nbv1.BackingStore) bool {
-	if util.IsSTSClusterBS(backingStore) || backingStore.Spec.Type == nbv1.StoreTypePVPool {
+	if util.IsAWSSTSClusterBS(backingStore) || backingStore.Spec.Type == nbv1.StoreTypePVPool {
 		return false
 	}
 	return true
 }
 
 func checkIfNamespaceStoreTypeIsSupported(namespaceStore *nbv1.NamespaceStore) bool {
-	if util.IsSTSClusterNS(namespaceStore) ||
+	if util.IsAWSSTSClusterNS(namespaceStore) ||
 		util.IsAzureSTSClusterNS(namespaceStore) ||
 		namespaceStore.Spec.Type == nbv1.NSStoreTypeNSFS ||
 		util.IsArchiveNamespaceStore(namespaceStore) {

--- a/pkg/diagnostics/analyze.go
+++ b/pkg/diagnostics/analyze.go
@@ -142,17 +142,23 @@ func analyzeAllNamespaceStores(cmd *cobra.Command, collector *Collector) bool {
 	return foundNamespaceStore
 }
 
+// STS BackingStore types are not supported because the job does not have the projected tokens for the STS cluster
 func checkIfBackingStoreTypeIsSupported(backingStore *nbv1.BackingStore) bool {
-	if util.IsAWSSTSClusterBS(backingStore) || backingStore.Spec.Type == nbv1.StoreTypePVPool {
+	if backingStore.Spec.Type == nbv1.StoreTypePVPool ||
+		util.IsAWSSTSClusterBS(backingStore) ||
+		util.IsAzureSTSClusterBS(backingStore) ||
+		util.IsGoogleSTSClusterBS(backingStore) {
 		return false
 	}
 	return true
 }
 
+// STS NamespaceStore types are not supported because the job does not have the projected tokens for the STS cluster
 func checkIfNamespaceStoreTypeIsSupported(namespaceStore *nbv1.NamespaceStore) bool {
-	if util.IsAWSSTSClusterNS(namespaceStore) ||
+	if namespaceStore.Spec.Type == nbv1.NSStoreTypeNSFS ||
+		util.IsAWSSTSClusterNS(namespaceStore) ||
 		util.IsAzureSTSClusterNS(namespaceStore) ||
-		namespaceStore.Spec.Type == nbv1.NSStoreTypeNSFS ||
+		util.IsGoogleSTSClusterNS(namespaceStore) ||
 		util.IsArchiveNamespaceStore(namespaceStore) {
 		return false
 	}
@@ -303,9 +309,13 @@ func setBackingStoreDetailsInJob(backingStore *nbv1.BackingStore, cmd *cobra.Com
 
 	// SecretName in the job yaml
 	secretRef, err := util.GetBackingStoreSecret(backingStore)
-	if err != nil {
-		log.Fatalf("❌ Could not get backing store secret in %s %q in Namespace %q",
-			analyzeResourceJob.Kind, analyzeResourceJob.Name, analyzeResourceJob.Namespace)
+	if err != nil || secretRef == nil || secretRef.Name == "" {
+		log.Fatalf("❌ Could not get backing store secret for %s %q in Namespace %q",
+			backingStore.Kind, backingStore.Name, backingStore.Namespace)
+	}
+	if secret, err := util.GetSecretFromSecretReference(secretRef); err != nil || secret == nil {
+		log.Fatalf("❌ Could not get Secret %q for %s %q in Namespace %q",
+			secretRef.Name, backingStore.Kind, backingStore.Name, backingStore.Namespace)
 	}
 	analyzeResourceJob.Spec.Template.Spec.Volumes[0].Secret.SecretName = secretRef.Name
 }
@@ -381,9 +391,13 @@ func setNamespacetoreDetailsInJob(namespaceStore *nbv1.NamespaceStore, cmd *cobr
 
 	// SecretName in the job yaml
 	secretRef, err := util.GetNamespaceStoreSecret(namespaceStore)
-	if err != nil {
-		log.Fatalf("❌ Could not get namespace store secret  in %s %q in Namespace %q",
-			analyzeResourceJob.Kind, analyzeResourceJob.Name, analyzeResourceJob.Namespace)
+	if err != nil || secretRef == nil || secretRef.Name == "" {
+		log.Fatalf("❌ Could not get namespace store secret for %s %q in Namespace %q",
+			namespaceStore.Kind, namespaceStore.Name, namespaceStore.Namespace)
+	}
+	if secret, err := util.GetSecretFromSecretReference(secretRef); err != nil || secret == nil {
+		log.Fatalf("❌ Could not get Secret %q for %s %q in Namespace %q",
+			secretRef.Name, namespaceStore.Kind, namespaceStore.Name, namespaceStore.Namespace)
 	}
 	analyzeResourceJob.Spec.Template.Spec.Volumes[0].Secret.SecretName = secretRef.Name
 }

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -86,10 +86,6 @@ func CmdAnalyzeBackingStore() *cobra.Command {
 		Short: "Analyze backingstore",
 		Run:   RunAnalyzeBackingStore,
 	}
-	cmd.Flags().String(
-		"bucket", "",
-		"The bucket name on the cloud",
-	)
 	cmd.Flags().String("job-resources", "", "Analyze job resources JSON")
 	cmd.Flags().String("dir", "", "collect analyze resource tar file into destination directory")
 	return cmd
@@ -102,10 +98,6 @@ func CmdAnalyzeNamespaceStore() *cobra.Command {
 		Short: "Analyze namespacestore",
 		Run:   RunAnalyzeNamespaceStore,
 	}
-	cmd.Flags().String(
-		"bucket", "",
-		"The bucket name on the cloud",
-	)
 	cmd.Flags().String("job-resources", "", "Analyze job resources JSON")
 	cmd.Flags().String("dir", "", "collect analyze resource tar file into destination directory")
 	return cmd

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -813,7 +813,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 
 	secret := util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret)
 	secretRef, _ := util.GetNamespaceStoreSecret(namespaceStore)
-	if !util.IsSTSClusterNS(namespaceStore) && !util.IsAzureSTSClusterNS(namespaceStore) {
+	if !util.IsAWSSTSClusterNS(namespaceStore) && !util.IsAzureSTSClusterNS(namespaceStore) {
 		if secretRef != nil {
 			secret.Name = secretRef.Name
 			secret.Namespace = secretRef.Namespace

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -555,7 +555,7 @@ func (r *Reconciler) ReadSystemInfo() error {
 // LoadNamespaceStoreSecret loads the secret to the reconciler struct
 func (r *Reconciler) LoadNamespaceStoreSecret() error {
 	// Skip loading for AWS STS (no secret). For Azure STS use IsAzureSTSClusterNS(); load secret when it has a ref (TenantId/AccountName in secret).
-	if util.IsSTSClusterNS(r.NamespaceStore) {
+	if util.IsAWSSTSClusterNS(r.NamespaceStore) {
 		return nil
 	}
 	if util.IsAzureSTSClusterNS(r.NamespaceStore) && (r.NamespaceStore.Spec.AzureBlob == nil || r.NamespaceStore.Spec.AzureBlob.Secret.Name == "") {
@@ -624,7 +624,7 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 	switch r.NamespaceStore.Spec.Type {
 
 	case nbv1.NSStoreTypeAWSS3:
-		if util.IsSTSClusterNS(r.NamespaceStore) {
+		if util.IsAWSSTSClusterNS(r.NamespaceStore) {
 			conn.EndpointType = nb.EndpointTypeAwsSTS
 			conn.AWSSTSARN = *r.NamespaceStore.Spec.AWSS3.AWSSTSRoleARN
 		} else {
@@ -744,7 +744,7 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 		return nil, util.NewPersistentError("InvalidType",
 			fmt.Sprintf("Invalid namespace store type %q", r.NamespaceStore.Spec.Type))
 	}
-	if util.IsSTSClusterNS(r.NamespaceStore) || util.IsAzureSTSClusterNS(r.NamespaceStore) {
+	if util.IsAWSSTSClusterNS(r.NamespaceStore) || util.IsAzureSTSClusterNS(r.NamespaceStore) {
 		if !util.IsStringGraphicOrSpacesCharsOnly(string(conn.Identity)) || !util.IsStringGraphicOrSpacesCharsOnly(string(conn.Secret)) {
 			return nil, util.NewPersistentError("InvalidSecret",
 				fmt.Sprintf("Invalid secret containing non graphic characters (perhaps not base64 encoded?) %q", r.Secret.Name))

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1192,16 +1192,16 @@ func IsFusionHCIWithScale() bool {
 	return fusionHCIWithScale
 }
 
-// IsSTSClusterBS returns true if it is running on an STS cluster
-func IsSTSClusterBS(bs *nbv1.BackingStore) bool {
+// IsAWSSTSClusterBS returns true if it is running on an STS cluster
+func IsAWSSTSClusterBS(bs *nbv1.BackingStore) bool {
 	if bs.Spec.Type == nbv1.StoreTypeAWSS3 {
 		return bs.Spec.AWSS3.AWSSTSRoleARN != nil
 	}
 	return false
 }
 
-// IsSTSClusterNS returns true if the namespace store uses AWS STS (short-lived credentials). For Azure STS use IsAzureSTSClusterNS().
-func IsSTSClusterNS(ns *nbv1.NamespaceStore) bool {
+// IsAWSSTSClusterNS returns true if the namespace store uses AWS STS (short-lived credentials). For Azure STS use IsAzureSTSClusterNS().
+func IsAWSSTSClusterNS(ns *nbv1.NamespaceStore) bool {
 	if ns.Spec.Type == nbv1.NSStoreTypeAWSS3 {
 		return ns.Spec.AWSS3.AWSSTSRoleARN != nil
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1224,6 +1224,55 @@ func IsAzureSTSClusterNS(ns *nbv1.NamespaceStore) bool {
 	return false
 }
 
+// isGoogleSTSClusterStore is a helper function that checks if a store uses GCP WIF (STS) (short-lived credentials).
+func isGoogleSTSClusterStore(isGoogleCloudStorage bool, secretRef *corev1.SecretReference, err error) bool {
+	if !isGoogleCloudStorage {
+		return false
+	}
+	if err != nil || secretRef == nil || secretRef.Name == "" {
+		return false
+	}
+	secret, err := GetSecretFromSecretReference(secretRef)
+	if err != nil {
+		return false
+	}
+	return isGoogleSTSSecret(secret)
+}
+
+// IsGoogleSTSClusterBS returns true if the backing store uses GCP WIF (STS) (short-lived credentials).
+func IsGoogleSTSClusterBS(bs *nbv1.BackingStore) bool {
+	isGoogleCloudStorage := bs.Spec.Type == nbv1.StoreTypeGoogleCloudStorage && bs.Spec.GoogleCloudStorage != nil
+	secretRef, err := GetBackingStoreSecret(bs)
+	return isGoogleSTSClusterStore(isGoogleCloudStorage, secretRef, err)
+}
+
+// IsGoogleSTSClusterNS returns true if the namespace store uses GCP WIF (STS) (short-lived credentials).
+func IsGoogleSTSClusterNS(ns *nbv1.NamespaceStore) bool {
+	isGoogleCloudStorage := ns.Spec.Type == nbv1.NSStoreTypeGoogleCloudStorage && ns.Spec.GoogleCloudStorage != nil
+	secretRef, err := GetNamespaceStoreSecret(ns)
+	return isGoogleSTSClusterStore(isGoogleCloudStorage, secretRef, err)
+}
+
+// isGoogleSTSSecret returns true if the secret contains a GCP WIF (STS) (short-lived credentials).
+func isGoogleSTSSecret(secret *corev1.Secret) bool {
+	if secret == nil {
+		return false
+	}
+	if wifJSON := secretDataString(secret, GoogleCredentialsJson); wifJSON != "" {
+		isExternalAccount, _, err := ParseGoogleCredentials(wifJSON)
+		if err == nil && isExternalAccount {
+			return true
+		}
+	}
+	if keyJSON := secretDataString(secret, GoogleServiceAccountPrivateKeyJson); keyJSON != "" {
+		isExternalAccount, _, err := ParseGoogleCredentials(keyJSON)
+		if err == nil && isExternalAccount {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseGoogleCredentials parses credential JSON and returns whether it is GCP WIF (STS) and the identity
 func ParseGoogleCredentials(credentialsJSON string) (bool, string, error) {
 	creds := &googleCredentialsJSON{}
@@ -2645,4 +2694,19 @@ func OnSignal(cb func(), signals ...os.Signal) {
 	<-signalChan
 
 	cb()
+}
+
+// secretDataString returns a secret data value by key from StringData or Data.
+// Kubernetes API reads populate Data only; callers that use KubeCheck also populate StringData.
+func secretDataString(secret *corev1.Secret, key string) string {
+	if secret == nil {
+		return ""
+	}
+	if v := secret.StringData[key]; v != "" {
+		return v
+	}
+	if v, ok := secret.Data[key]; ok {
+		return string(v)
+	}
+	return ""
 }


### PR DESCRIPTION
### Describe the Problem
Exclude GCP WIF (STS) from analyze resource, as the job does not have the projected token (and added permission in the configuration from the user).

### Explain the changes
1. Rename the functions `IsSTSClusterBS` and `IsSTSClusterNS` and add AWS to improve readability since STS clusters have more types today (`IsAWSSTSClusterBS`and `IsAWSSTSClusterNS` respectively).
Note: I intentionally saved it in a separate commit. 
2. Exclude the STS types from analyze resource:
- In `checkIfBackingStoreTypeIsSupported` added GCP WIF (STS), and also noticed that Azure STS was missing.
- In `checkIfNamespaceStoreTypeIsSupported` added.
3. Added helper functions: `isGoogleSTSClusterStore`, `IsGoogleSTSClusterBS`, `IsGoogleSTSClusterNS`, and `isGoogleSTSSecret` to check if a namespacestore and backingstore with GCP WIF (STS).
4. In `setBackingStoreDetailsInJob` and `setNamespacetoreDetailsInJob` exit and do not create the job if the secret doe not exist (fail fast).
5. Removed unused flag of bucket in analyze backingstore and namespacestore.

### Issues: 
1. none

### Testing Instructions:

1. Deploy NooBaa on Minikube after adding GCP WIF configurations - see guide "Create GCP WIF (STS) Setup On Minikube With NooBaa" ([link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_gcp_wif_setup_on_minikube_with_noobaa.md)).
2. Create GCP WIF (STS) backingstore using `nooba backingstore create google-cloud-storage-sts <backingstore-name> -n <namespace>`.
3. Create GCP WIF (STS) namespacestore with a YAML and apply it:
- Copy the name of the secret from the created backingstore that was created with the sub-command of `google-cloud-storage-sts`
- Create a target bucket on the GCP web console

```yaml
apiVersion: noobaa.io/v1alpha1
kind: NamespaceStore
metadata:
  name: <namesapcestore-name>
  namespace: test1
  finalizers:
    - noobaa.io/finalizer
spec:
  type: google-cloud-storage
  googleCloudStorage:
    targetBucket: <target-bucket-name>
    secret:
      name: <secret-name>
      namespace: test1
```

apply it: `kubectl apply -f <path-to-file>`

4. Create GCP backingstore using `nooba backingstore create google-cloud-storage <backingstore-name> -n <namespace>`.
5. Create GCP namespacestore with a YAML and apply it:
- Copy the name of the secret from the created backingstore that was created with the sub-command of `google-cloud-storage` and Create a target bucket on the GCP web console
6. Run the analyze resource: `nb diagnostics analyze resource -n test1`.
7. Check that the job runs and you can see the output from the commands and the created logs: GCP types should be analyzed, GCP WIF (STS) should not.
Note: you can also test it separately with:
- `nb diagnostics analyze backingstore <backingstore-name> -n test1`
- `nb diagnostics analyze namesapcestore <namespacestore-name> -n test1`



- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added detection for Google Cloud Workload Identity Federation (WIF) credentials for both backing stores and namespace stores.

* **Improvements**
  * Improved AWS/AWS-ST S handling by using AWS-specific STS detection when selecting secret behavior and external connection parameters.
  * Strengthened analyze diagnostics: fails earlier when secret references are missing/invalid and includes clearer resource and secret-identifying details.

* **Chores**
  * Removed the unused `--bucket` flag from diagnostics analyze commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->