### PR TITLE
GCP WIF (STS) | Validate GCP WIF (STS) Params And Secret Type

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -759,9 +759,14 @@ func RunCreateGoogleCloudStorage(cmd *cobra.Command, args []string) {
 			if err != nil {
 				log.Fatalf("Failed to parse json file %q: %v", privateKeyJSONFile, err)
 			}
+			credentialsType, ok := privateKeyJSON["type"].(string)
+			if !ok || credentialsType != "service_account" {
+				log.Fatalf("GCP credentials JSON 'type' field must be a string with value %q", "service_account")
+			}
 			secret.StringData[util.GoogleServiceAccountPrivateKeyJson] = string(bytes)
 		} else {
 			util.VerifyCredsInSecret(secretName, options.Namespace, mandatoryProperties)
+			util.VerifyGoogleCredentialsJSONTypeInSecret(secretName, options.Namespace, false)
 			secret.Name = secretName
 			secret.Namespace = options.Namespace
 		}
@@ -797,6 +802,7 @@ func RunCreateGoogleCloudStorageSTS(cmd *cobra.Command, args []string) {
 			secret.StringData[util.GoogleCredentialsJson] = credentialsJSON
 		} else {
 			util.VerifyCredsInSecret(secretName, options.Namespace, mandatoryProperties)
+			util.VerifyGoogleCredentialsJSONTypeInSecret(secretName, options.Namespace, true)
 			secret.Name = secretName
 			secret.Namespace = options.Namespace
 		}

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -832,17 +832,11 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 
 	case nbv1.StoreTypeGoogleCloudStorage:
 		conn.Endpoint = "https://www.googleapis.com"
-		var googleCredentialsJSON string
-		if wifCredentialsJSON := r.Secret.StringData[util.GoogleCredentialsJson]; wifCredentialsJSON != "" {
-			googleCredentialsJSON = wifCredentialsJSON
-		} else {
-			googleCredentialsJSON = r.Secret.StringData[util.GoogleServiceAccountPrivateKeyJson]
-			if googleCredentialsJSON == "" {
-				return nil, util.NewPersistentError("InvalidGoogleSecret", fmt.Sprintf(
-					"Invalid secret for google type %q expected JSON in data.GoogleCredentialsJson or data.GoogleServiceAccountPrivateKeyJson",
-					r.Secret.Name,
-				))
-			}
+		googleCredentialsJSON, err := util.GoogleCredentialsFromStoreSecret(r.Secret)
+		if err != nil {
+			return nil, util.NewPersistentError("InvalidGoogleSecret", fmt.Sprintf(
+				"Invalid google credentials secret: %v", err,
+			))
 		}
 
 		isGoogleExternalAccountJSON, identity, err := util.ParseGoogleCredentials(googleCredentialsJSON)

--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -578,9 +578,14 @@ func RunCreateGoogleCloudStorage(cmd *cobra.Command, args []string) {
 			if err != nil {
 				log.Fatalf("Failed to parse json file %q: %v", privateKeyJSONFile, err)
 			}
+			credentialsType, ok := privateKeyJSON["type"].(string)
+			if !ok || credentialsType != "service_account" {
+				log.Fatalf("GCP credentials JSON 'type' field must be a string with value %q", "service_account")
+			}
 			secret.StringData[util.GoogleServiceAccountPrivateKeyJson] = string(bytes)
 		} else {
 			util.VerifyCredsInSecret(secretName, options.Namespace, mandatoryProperties)
+			util.VerifyGoogleCredentialsJSONTypeInSecret(secretName, options.Namespace, false)
 			secret.Name = secretName
 			secret.Namespace = options.Namespace
 		}

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -712,17 +712,11 @@ func (r *Reconciler) MakeExternalConnectionParams() (*nb.AddExternalConnectionPa
 
 	case nbv1.NSStoreTypeGoogleCloudStorage:
 		conn.Endpoint = "https://www.googleapis.com"
-		var googleCredentialsJSON string
-		if wifCredentialsJSON := r.Secret.StringData[util.GoogleCredentialsJson]; wifCredentialsJSON != "" {
-			googleCredentialsJSON = wifCredentialsJSON
-		} else {
-			googleCredentialsJSON = r.Secret.StringData[util.GoogleServiceAccountPrivateKeyJson]
-			if googleCredentialsJSON == "" {
-				return nil, util.NewPersistentError("InvalidGoogleSecret", fmt.Sprintf(
-					"Invalid secret for google type %q expected JSON in data.GoogleCredentialsJson or data.GoogleServiceAccountPrivateKeyJson",
-					r.Secret.Name,
-				))
-			}
+		googleCredentialsJSON, err := util.GoogleCredentialsFromStoreSecret(r.Secret)
+		if err != nil {
+			return nil, util.NewPersistentError("InvalidGoogleSecret", fmt.Sprintf(
+				"Invalid google credentials secret: %v", err,
+			))
 		}
 
 		isGoogleExternalAccountJSON, identity, err := util.ParseGoogleCredentials(googleCredentialsJSON)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -102,6 +102,10 @@ func CmdRun() *cobra.Command {
 
 // RunUpgrade runs a CLI command
 func RunUpgrade(cmd *cobra.Command, args []string) {
+	if err := validateGCPWIFFlags(cmd); err != nil {
+		util.Logger().Fatalf("Invalid GCP WIF (STS) upgrade flags: %v", err)
+	}
+
 	c := LoadOperatorConf(cmd)
 	util.KubeApply(c.NS)
 	util.KubeApply(c.SA)
@@ -210,6 +214,10 @@ func RunUpgrade(cmd *cobra.Command, args []string) {
 
 // RunInstall runs a CLI command
 func RunInstall(cmd *cobra.Command, args []string) {
+	if err := validateGCPWIFFlags(cmd); err != nil {
+		util.Logger().Fatalf("Invalid GCP WIF (STS) install flags: %v", err)
+	}
+
 	c := LoadOperatorConf(cmd)
 	util.KubeCreateSkipExisting(c.NS)
 	util.KubeCreateSkipExisting(c.SA)
@@ -693,6 +701,14 @@ func AdmissionWebhookSetup(c *Conf) {
 
 func configureClusterRole(cr *rbacv1.ClusterRole) {
 	cr.Name = options.SubDomainNS()
+}
+
+func validateGCPWIFFlags(cmd *cobra.Command) error {
+	projectNumber, _ := cmd.Flags().GetString("google-cloud-project-number")
+	poolID, _ := cmd.Flags().GetString("google-cloud-pool-id")
+	providerID, _ := cmd.Flags().GetString("google-cloud-provider-id")
+	serviceAccountEmail, _ := cmd.Flags().GetString("google-cloud-service-account-email")
+	return util.ValidateGCPWIFParams(projectNumber, poolID, providerID, serviceAccountEmail)
 }
 
 // appendGCPWIFEnvVars appends GCP WIF (STS) environment variables to the operator container

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -1180,12 +1180,11 @@ func (r *Reconciler) ReconcileGCPCredentials() error {
 			gcpProjectNumberEnvVar, projectNumber, gcpPoolIdEnvVar, poolId,
 			gcpProviderIdEnvVar, providerId, gcpServiceAccountEmailEnvVar, serviceAccountEmail,
 		)
-		if projectNumber != "" && poolId != "" && providerId != "" && serviceAccountEmail != "" {
-			r.IsGCPSTSCluster = true
-		} else {
-			r.Logger.Errorf("One or more required param missing for GCP WIF (STS)")
-			return fmt.Errorf("One or more required param missing for GCP WIF (STS)")
+		if err := util.ValidateGCPWIFParams(projectNumber, poolId, providerId, serviceAccountEmail); err != nil {
+			r.Logger.Errorf("Invalid GCP WIF (STS) parameters: %v", err)
+			return fmt.Errorf("invalid GCP WIF (STS) parameters: %w", err)
 		}
+		r.IsGCPSTSCluster = true
 	}
 
 	r.Logger.Info("Running on GCP. will create a CredentialsRequest resource")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -102,6 +102,8 @@ const (
 	GoogleImpersonationURLPrefix = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
 	GoogleImpersonationURLSuffix = ":generateAccessToken"
 
+	gcpServiceAccountEmailSuffix = ".iam.gserviceaccount.com"
+
 	// GoogleServiceAccountPrivateKeyJson is the secret data key for classic GCP (service_account) credentials.
 	GoogleServiceAccountPrivateKeyJson = "GoogleServiceAccountPrivateKeyJson"
 	// GoogleCredentialsJson is the secret data key for GCP WIF (external_account) credentials.
@@ -147,6 +149,15 @@ var AccessKeyRegexp, _ = regexp.Compile(`^[a-zA-Z0-9]{20}$`)
 // SecretKeyRegexp validates secret keys, which are 40 characters long and may include alphanumeric characters '+' and '/'
 var SecretKeyRegexp, _ = regexp.Compile(`^[a-zA-Z0-9+/]{40}$`)
 
+var (
+	// project number should be a numeric string
+	gcpProjectNumberRegexp = regexp.MustCompile(`^[0-9]+$`)
+	// pool ID and provider ID contain only lowercase alphanumeric characters and dashes, and start and end with an alphanumeric character
+	gcpWIFPoolOrProviderIDRegexp = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{2,30}[a-z0-9])?$`)
+	// service account ID contains lowercase alphanumeric characters and dashes
+	gcpServiceAccountIDRegexp = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])$`)
+)
+
 // IsValidationError check if err is of type ValidationError
 func IsValidationError(err error) bool {
 	_, ok := err.(ValidationError)
@@ -177,13 +188,13 @@ var (
 	// MapStorTypeToMandatoryProperties holds a map of store type -> credentials mandatory properties
 	// note that this map holds the mandatory properties for both backingstores and namespacestores
 	MapStorTypeToMandatoryProperties = map[string][]string{
-		"aws-s3":        {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},         // backingstores and namespacestores
-		"s3-compatible": {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},         // backingstores and namespacestores
-		"ibm-cos":       {"IBM_COS_ACCESS_KEY_ID", "IBM_COS_SECRET_ACCESS_KEY"}, // backingstores and namespacestores
+		"aws-s3":               {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},              // backingstores and namespacestores
+		"s3-compatible":        {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},              // backingstores and namespacestores
+		"ibm-cos":              {"IBM_COS_ACCESS_KEY_ID", "IBM_COS_SECRET_ACCESS_KEY"},      // backingstores and namespacestores
 		"google-cloud-storage": {GoogleCredentialsJson, GoogleServiceAccountPrivateKeyJson}, // backingstores and namespacestores
-		"azure-blob": {"AccountName", "AccountKey"}, // backingstores and namespacestores
-		"pv-pool":    {},                            // backingstores
-		"nsfs":       {},                            // namespacestores
+		"azure-blob":           {"AccountName", "AccountKey"},                               // backingstores and namespacestores
+		"pv-pool":              {},                                                          // backingstores
+		"nsfs":                 {},                                                          // namespacestores
 	}
 )
 
@@ -1286,6 +1297,33 @@ func ParseGoogleCredentials(credentialsJSON string) (bool, string, error) {
 	return creds.Type == "external_account", identity, nil
 }
 
+// GoogleCredentialsFromStoreSecret returns GCP credentials JSON from a backing store or namespace store secret.
+// Exactly one of GoogleCredentialsJson (WIF) or GoogleServiceAccountPrivateKeyJson (classic) must be set.
+func GoogleCredentialsFromStoreSecret(secret *corev1.Secret) (string, error) {
+	if secret == nil {
+		return "", ValidationError{Msg: "invalid google secret: secret is nil"}
+	}
+	wifJSON := secretDataString(secret, GoogleCredentialsJson)
+	serviceAccountJSON := secretDataString(secret, GoogleServiceAccountPrivateKeyJson)
+	if wifJSON != "" && serviceAccountJSON != "" {
+		return "", ValidationError{Msg: fmt.Sprintf(
+			"secret %q in namespace %q must not contain both %q and %q; use %q for GCP WIF (STS) external_account or %q for service_account",
+			secret.Name, secret.Namespace, GoogleCredentialsJson, GoogleServiceAccountPrivateKeyJson,
+			GoogleCredentialsJson, GoogleServiceAccountPrivateKeyJson,
+		)}
+	}
+	if wifJSON != "" {
+		return wifJSON, nil
+	}
+	if serviceAccountJSON != "" {
+		return serviceAccountJSON, nil
+	}
+	return "", ValidationError{Msg: fmt.Sprintf(
+		"Invalid secret for google type %q in namespace %q expected JSON in data.GoogleCredentialsJson or data.GoogleServiceAccountPrivateKeyJson",
+		secret.Name, secret.Namespace,
+	)}
+}
+
 // googleIdentityFromCredentials returns the identity.
 // - For GCP (service_account type in JSON) - it uses private_key_id
 // - For GCP STS (external_account type in JSON) it uses the email from service_account_impersonation_url.
@@ -1338,11 +1376,8 @@ func BuildGoogleWIFCredentialsJSON(projectNumber, poolID, providerID, serviceAcc
 	providerID = strings.TrimSpace(providerID)
 	serviceAccountEmail = strings.TrimSpace(serviceAccountEmail)
 
-	if projectNumber == "" || poolID == "" || providerID == "" || serviceAccountEmail == "" {
-		return "", fmt.Errorf("project number, pool id, provider id, and service account email are required")
-	}
-	if !strings.Contains(serviceAccountEmail, "@") {
-		return "", fmt.Errorf("invalid service_account_impersonation_url: malformed service account email %q", serviceAccountEmail)
+	if err := ValidateGCPWIFParamFormats(projectNumber, poolID, providerID, serviceAccountEmail); err != nil {
+		return "", err
 	}
 
 	googleExternalAccountCredentialType := "external_account"
@@ -1369,18 +1404,131 @@ func BuildGoogleWIFCredentialsJSON(projectNumber, poolID, providerID, serviceAcc
 }
 
 // GcpProjectIDFromServiceAccountEmail returns the GCP project ID from a service account email
+// the format is: SERVICE_ACCOUNT_NAME@PROJECT_ID.iam.gserviceaccount.com
 // (e.g. "noobaa-wif-sa@my-project.iam.gserviceaccount.com" -> "my-project").
 func GcpProjectIDFromServiceAccountEmail(email string) (string, error) {
-	const suffix = ".iam.gserviceaccount.com"
 	at := strings.LastIndex(email, "@")
 	if at < 0 {
 		return "", fmt.Errorf("invalid GCP service account email %q", email)
 	}
-	projectID := strings.TrimSuffix(email[at+1:], suffix)
+	projectID := strings.TrimSuffix(email[at+1:], gcpServiceAccountEmailSuffix)
 	if projectID == "" {
 		return "", fmt.Errorf("invalid GCP service account email %q", email)
 	}
 	return projectID, nil
+}
+
+// ValidateGCPProjectNumber validates a GCP project number (numeric string, not project ID).
+func ValidateGCPProjectNumber(projectNumber, fieldName string) error {
+	projectNumber = strings.TrimSpace(projectNumber)
+	if projectNumber == "" {
+		return ValidationError{Msg: fmt.Sprintf("%s is required and must be non-empty", fieldName)}
+	}
+	if !gcpProjectNumberRegexp.MatchString(projectNumber) {
+		return ValidationError{Msg: fmt.Sprintf("%s must be a numeric GCP project number (digits only), not a project ID", fieldName)}
+	}
+	return nil
+}
+
+// ValidateGCPWIFPoolOrProviderID validates a GCP workload identity pool ID or provider ID
+func ValidateGCPWIFPoolOrProviderID(resourceID, fieldName string) error {
+	const (
+		minLen           = 4
+		maxLen           = 32
+		reservedIDPrefix = "gcp-"
+	)
+
+	resourceID = strings.TrimSpace(resourceID)
+	if resourceID == "" {
+		return ValidationError{Msg: fmt.Sprintf("%s is required and must be non-empty", fieldName)}
+	}
+	if len(resourceID) < minLen || len(resourceID) > maxLen {
+		return ValidationError{Msg: fmt.Sprintf("%s must be %d-%d characters", fieldName, minLen, maxLen)}
+	}
+	if strings.HasPrefix(resourceID, reservedIDPrefix) {
+		return ValidationError{Msg: fmt.Sprintf("%s must not start with %q (reserved by Google)", fieldName, reservedIDPrefix)}
+	}
+	if !gcpWIFPoolOrProviderIDRegexp.MatchString(resourceID) {
+		return ValidationError{Msg: fmt.Sprintf("%s must contain only lowercase letters, digits, and hyphens [a-z0-9-]", fieldName)}
+	}
+	return nil
+}
+
+// ValidateGCPServiceAccountEmail validates a user-managed GCP service account.
+func ValidateGCPServiceAccountEmail(email, fieldName string) error {
+	const (
+		accountIDMinLen = 6
+		accountIDMaxLen = 30
+	)
+
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return ValidationError{Msg: fmt.Sprintf("%s is required and must be non-empty", fieldName)}
+	}
+	if !strings.HasSuffix(email, gcpServiceAccountEmailSuffix) {
+		return ValidationError{Msg: fmt.Sprintf("%s must end with %q", fieldName, gcpServiceAccountEmailSuffix)}
+	}
+	if strings.Count(email, "@") != 1 {
+		return ValidationError{Msg: fmt.Sprintf("%s must be a valid GCP service account email (exactly one @)", fieldName)}
+	}
+
+	serviceAccountID, domain, ok := strings.Cut(email, "@")
+	if !ok || serviceAccountID == "" {
+		return ValidationError{Msg: fmt.Sprintf("%s must be a valid GCP service account email (missing service account ID)", fieldName)}
+	}
+	if strings.TrimSuffix(domain, gcpServiceAccountEmailSuffix) == "" {
+		return ValidationError{Msg: fmt.Sprintf("%s must be a valid GCP service account email (missing project ID)", fieldName)}
+	}
+	if len(serviceAccountID) < accountIDMinLen || len(serviceAccountID) > accountIDMaxLen {
+		return ValidationError{Msg: fmt.Sprintf("%s account ID must be %d-%d characters", fieldName, accountIDMinLen, accountIDMaxLen)}
+	}
+	if !gcpServiceAccountIDRegexp.MatchString(serviceAccountID) {
+		return ValidationError{Msg: fmt.Sprintf("%s must be a valid GCP service account email (account ID: lowercase letters, digits, hyphens)", fieldName)}
+	}
+	return nil
+}
+
+// ValidateGCPWIFParamFormats validates GCP WIF (STS) parameter formats.
+// All four parameters must be non-empty before calling this function.
+func ValidateGCPWIFParamFormats(projectNumber, poolID, providerID, serviceAccountEmail string) error {
+	if err := ValidateGCPProjectNumber(projectNumber, "project-number"); err != nil {
+		return err
+	}
+	if err := ValidateGCPWIFPoolOrProviderID(poolID, "pool-id"); err != nil {
+		return err
+	}
+	if err := ValidateGCPWIFPoolOrProviderID(providerID, "provider-id"); err != nil {
+		return err
+	}
+	if err := ValidateGCPServiceAccountEmail(serviceAccountEmail, "service-account-email"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateGCPWIFParams validates completeness and format of GCP WIF (STS) parameters.
+// If any parameter is set, all four must be set and valid. If none are set, validation passes.
+func ValidateGCPWIFParams(projectNumber, poolID, providerID, serviceAccountEmail string) error {
+	count := 0
+	if projectNumber != "" {
+		count++
+	}
+	if poolID != "" {
+		count++
+	}
+	if providerID != "" {
+		count++
+	}
+	if serviceAccountEmail != "" {
+		count++
+	}
+	if count == 0 {
+		return nil
+	}
+	if count != 4 {
+		return ValidationError{Msg: "when any GCP WIF (STS) parameter is set, all four are required: project-number, pool-id, provider-id, service-account-email"}
+	}
+	return ValidateGCPWIFParamFormats(projectNumber, poolID, providerID, serviceAccountEmail)
 }
 
 // IsAzurePlatformNonGovernment returns true if this cluster is running on Azure and also not on azure government\DOD cloud
@@ -1689,6 +1837,40 @@ func IsStringGraphicOrSpacesCharsOnly(s string) bool {
 		}
 	}
 	return true
+}
+
+// ValidateGoogleCredentialsJSONType checks that credentials JSON is valid and matches
+// the expected type: service_account for long-lived creds, external_account for GCP WIF (STS).
+func ValidateGoogleCredentialsJSONType(credentialsJSON string, expectedSTS bool) error {
+	isSTS, _, err := ParseGoogleCredentials(credentialsJSON)
+	if err != nil {
+		return err
+	}
+	if expectedSTS && !isSTS {
+		return ValidationError{Msg: fmt.Sprintf("GCP credentials JSON type must be %q for WIF (STS)", "external_account")}
+	}
+	if !expectedSTS && isSTS {
+		return ValidationError{Msg: fmt.Sprintf("GCP credentials JSON type must be %q for long-lived credentials", "service_account")}
+	}
+	return nil
+}
+
+// VerifyGoogleCredentialsJSONTypeInSecret validates credential JSON type in an existing secret.
+// Call VerifyCredsInSecret first for existence and mandatory key checks.
+func VerifyGoogleCredentialsJSONTypeInSecret(secretName, namespace string, expectSTS bool) {
+	secret := KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret)
+	secret.Name = secretName
+	secret.Namespace = namespace
+	if !KubeCheck(secret) {
+		log.Fatalf("secret %q does not exist", secretName)
+	}
+	credentialsJSON, err := GoogleCredentialsFromStoreSecret(secret)
+	if err != nil {
+		log.Fatalf("❌ secret %q: %v", secret.Name, err)
+	}
+	if err := ValidateGoogleCredentialsJSONType(credentialsJSON, expectSTS); err != nil {
+		log.Fatalf("❌ secret %q: %v", secret.Name, err)
+	}
 }
 
 // VerifyCredsInSecret throws fatal error when a given secret doesn't contain the mandatory properties

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -231,6 +233,161 @@ func TestParseGoogleCredentials(t *testing.T) {
 	}
 }
 
+func TestGoogleCredentialsFromStoreSecret(t *testing.T) {
+	validExternalAccountJSON := fmt.Sprintf(
+		`{"type":"external_account","service_account_impersonation_url":%q}`,
+		googleImpersonationURL(googleWIFServiceAccountEmail),
+	)
+	validServiceAccountJSON := fmt.Sprintf(`{"type":"service_account","private_key_id":%q}`, googleServiceAccountKeyID)
+
+	tests := []struct {
+		name          string
+		secret        *corev1.Secret
+		expectedJSON  string
+		expectedErr   bool
+	}{
+		{
+			name: "only WIF key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "gcp-wif"},
+				StringData: map[string]string{GoogleCredentialsJson: validExternalAccountJSON},
+			},
+			expectedJSON: validExternalAccountJSON,
+		},
+		{
+			name: "only classic key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "gcp-classic"},
+				StringData: map[string]string{GoogleServiceAccountPrivateKeyJson: validServiceAccountJSON},
+			},
+			expectedJSON: validServiceAccountJSON,
+		},
+		{
+			name: "both keys",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "gcp-both"},
+				StringData: map[string]string{
+					GoogleCredentialsJson:              validExternalAccountJSON,
+					GoogleServiceAccountPrivateKeyJson: validServiceAccountJSON,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "CCO service_account.json with WIF key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "noobaa-gcp-bucket-creds", Namespace: "openshift-storage"},
+				StringData: map[string]string{
+					"service_account.json":  validExternalAccountJSON,
+					GoogleCredentialsJson: validExternalAccountJSON,
+				},
+			},
+			expectedJSON: validExternalAccountJSON,
+		},
+		{
+			name: "CCO service_account.json with classic key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "noobaa-gcp-bucket-creds", Namespace: "openshift-storage"},
+				StringData: map[string]string{
+					"service_account.json":             validServiceAccountJSON,
+					GoogleServiceAccountPrivateKeyJson: validServiceAccountJSON,
+				},
+			},
+			expectedJSON: validServiceAccountJSON,
+		},
+		{
+			name:        "nil secret",
+			secret:      nil,
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotJSON, err := GoogleCredentialsFromStoreSecret(tc.secret)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("GoogleCredentialsFromStoreSecret expected error")
+				}
+				if !IsValidationError(err) {
+					t.Fatalf("GoogleCredentialsFromStoreSecret expected ValidationError, got %T", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GoogleCredentialsFromStoreSecret unexpected error: %v", err)
+			}
+			if gotJSON != tc.expectedJSON {
+				t.Fatalf("expected JSON %q, got %q", tc.expectedJSON, gotJSON)
+			}
+		})
+	}
+}
+
+func TestValidateGoogleCredentialsJSONType(t *testing.T) {
+	validExternalAccountJSON := fmt.Sprintf(
+		`{"type":"external_account","service_account_impersonation_url":%q}`,
+		googleImpersonationURL(googleWIFServiceAccountEmail),
+	)
+	validServiceAccountJSON := fmt.Sprintf(`{"type":"service_account","private_key_id":%q}`, googleServiceAccountKeyID)
+
+	tests := []struct {
+		name        string
+		json        string
+		expectSTS   bool
+		expectedErr bool
+		errContains string
+	}{
+		{
+			name:      "service_account for GCP long-lived",
+			json:      validServiceAccountJSON,
+			expectSTS: false,
+		},
+		{
+			name:      "external_account for GCP WIF (STS)",
+			json:      validExternalAccountJSON,
+			expectSTS: true,
+		},
+		{
+			name:        "GCP WIF (STS) secret used with GCP long-lived command",
+			json:        validExternalAccountJSON,
+			expectSTS:   false,
+			expectedErr: true,
+			errContains: "service_account",
+		},
+		{
+			name:        "GCP long-lived secret used with GCP WIF (STS) command",
+			json:        validServiceAccountJSON,
+			expectSTS:   true,
+			expectedErr: true,
+			errContains: "external_account",
+		},
+		{
+			name:        "invalid JSON",
+			json:        `{`,
+			expectSTS:   false,
+			expectedErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGoogleCredentialsJSONType(tt.json, tt.expectSTS)
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got %v", tt.errContains, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 // TestGoogleIdentityFromCredentials tests googleIdentityFromCredentials function
 func TestGoogleIdentityFromCredentials(t *testing.T) {
 	tests := []struct {
@@ -431,31 +588,31 @@ func TestBuildGoogleWIFCredentialsJSON(t *testing.T) {
 
 func TestGcpProjectIDFromServiceAccountEmail(t *testing.T) {
 	tests := []struct {
-		name          string
-		email         string
+		name              string
+		email             string
 		expectedProjectID string
 		expectedErr       bool
 	}{
 		{
-			name:          "valid GCP service account email",
-			email:         "noobaa-wif-sa@my-project.iam.gserviceaccount.com",
+			name:              "valid GCP service account email",
+			email:             "noobaa-wif-sa@my-project.iam.gserviceaccount.com",
 			expectedProjectID: "my-project",
 		},
 		{
-			name:    "missing at sign",
-			email:   "invalid-email",
+			name:        "missing at sign",
+			email:       "invalid-email",
 			expectedErr: true,
 		},
 		// GcpProjectIDFromServiceAccountEmail only strips .iam.gserviceaccount.com;
 		// other domains pass through the part after @ unchanged (no format validation).
 		{
-			name:          "non-GCP domain",
-			email:         "sa@other-domain.com",
+			name:              "non-GCP domain",
+			email:             "sa@other-domain.com",
 			expectedProjectID: "other-domain.com",
 		},
 		{
-			name:    "empty domain after at sign",
-			email:   "sa@",
+			name:        "empty domain after at sign",
+			email:       "sa@",
 			expectedErr: true,
 		},
 	}
@@ -474,6 +631,143 @@ func TestGcpProjectIDFromServiceAccountEmail(t *testing.T) {
 			}
 			if got != tc.expectedProjectID {
 				t.Fatalf("GcpProjectIDFromServiceAccountEmail expected project ID %q, got %q", tc.expectedProjectID, got)
+			}
+		})
+	}
+}
+
+func TestValidateGCPWIFParams(t *testing.T) {
+	valid := struct {
+		projectNumber       string
+		poolID              string
+		providerID          string
+		serviceAccountEmail string
+	}{
+		projectNumber:       "123456789",
+		poolID:              "my-pool",
+		providerID:          "my-provider",
+		serviceAccountEmail: "noobaa-wif-sa@my-project.iam.gserviceaccount.com",
+	}
+
+	tests := []struct {
+		name                string
+		projectNumber       string
+		poolID              string
+		providerID          string
+		serviceAccountEmail string
+		expectedErr         bool
+		errContains         string
+	}{
+		{
+			name: "none set",
+		},
+		{
+			name:                "all four valid",
+			projectNumber:       valid.projectNumber,
+			poolID:              valid.poolID,
+			providerID:          valid.providerID,
+			serviceAccountEmail: valid.serviceAccountEmail,
+		},
+		{
+			name:          "only project-number",
+			projectNumber: valid.projectNumber,
+			expectedErr:   true,
+			errContains:   "all four are required",
+		},
+		{
+			name:          "three of four",
+			projectNumber: valid.projectNumber,
+			poolID:        valid.poolID,
+			providerID:    valid.providerID,
+			expectedErr:   true,
+			errContains:   "all four are required",
+		},
+		{
+			name:                "non-numeric project number",
+			projectNumber:       "my-project",
+			poolID:              valid.poolID,
+			providerID:          valid.providerID,
+			serviceAccountEmail: valid.serviceAccountEmail,
+			expectedErr:         true,
+			errContains:         "numeric GCP project number",
+		},
+		{
+			name:                "pool-id too short",
+			projectNumber:       valid.projectNumber,
+			poolID:              "abc",
+			providerID:          valid.providerID,
+			serviceAccountEmail: valid.serviceAccountEmail,
+			expectedErr:         true,
+			errContains:         "pool-id must be 4-32",
+		},
+		{
+			name:                "pool-id reserved gcp- prefix",
+			projectNumber:       valid.projectNumber,
+			poolID:              "gcp-pool",
+			providerID:          valid.providerID,
+			serviceAccountEmail: valid.serviceAccountEmail,
+			expectedErr:         true,
+			errContains:         "gcp-",
+		},
+		{
+			name:                "provider-id invalid characters",
+			projectNumber:       valid.projectNumber,
+			poolID:              valid.poolID,
+			providerID:          "My_Provider",
+			serviceAccountEmail: valid.serviceAccountEmail,
+			expectedErr:         true,
+			errContains:         "provider-id must contain only lowercase letters, digits, and hyphens",
+		},
+		{
+			name:                "invalid service account email suffix",
+			projectNumber:       valid.projectNumber,
+			poolID:              valid.poolID,
+			providerID:          valid.providerID,
+			serviceAccountEmail: "noobaa-wif-sa@my-project.example.com",
+			expectedErr:         true,
+			errContains:         ".iam.gserviceaccount.com",
+		},
+		{
+			name:                "service account email missing project ID",
+			projectNumber:       valid.projectNumber,
+			poolID:              valid.poolID,
+			providerID:          valid.providerID,
+			serviceAccountEmail: "noobaa-wif-sa@.iam.gserviceaccount.com",
+			expectedErr:         true,
+			errContains:         "missing project ID",
+		},
+		{
+			name:                "service account email extra at-sign in domain",
+			projectNumber:       valid.projectNumber,
+			poolID:              valid.poolID,
+			providerID:          valid.providerID,
+			serviceAccountEmail: "noobaa-wif-sa@my@project.iam.gserviceaccount.com",
+			expectedErr:         true,
+			errContains:         "exactly one @",
+		},
+		{
+			name:                "whitespace-only counts as set — all four required",
+			projectNumber:       " ",
+			poolID:              " ",
+			providerID:          " ",
+			serviceAccountEmail: " ",
+			expectedErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGCPWIFParams(tt.projectNumber, tt.poolID, tt.providerID, tt.serviceAccountEmail)
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got %v", tt.errContains, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661), this PR handles the gaps in the parameter validations that we had before, which were basic, and that the secret that was passed as a parameter was not checked for the specific type.

### Explain the changes
1. In backingstore and namespacestore CLI commands related to `google-cloud-storage` (not STS) that the `private-key-json-file` flag check that it matches the type, and if the ' secret_name ' flag is passed, validate that it matches the type.
2. To fail fast, validate the passed parameters related to GCP WIF (STS) when we use them in `install`/`upgrade` commands and `backingstore create google-cloud-storage-sts`.
3. Also, fail fast when the parameters are passed for the default backing store.
4. In the `util` package, add the regex for the parameters that we validate (see below the source information) to avoid passing parameters that are invalid to the Google SDK (also, fail fast and have a proper error message). In addition, add the function `GoogleCredentialsFromStoreSecret` so a valid secret would contain only one property that is for GCP or GCP WIF (STS). 
5.  Add AI-generated tests for new util functions.

<details>
<summary>Reference for the regex and validation logic</summary>

- Pool ID ([link1](https://docs.cloud.google.com/iam/docs/create-managed-workload-identities), [link2](https://docs.cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools/create)):

> must be between 4 and 32 characters long, contain only lowercase alphanumeric characters and dashes, and start and end with an alphanumeric character

> The prefix gcp- is reserved for use by Google, and may not be specified.

- Provider ID ([link](https://docs.cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools/create)):

> The ID for the provider, which becomes the final component of the resource name. This value must be 4-32 characters, and may contain the characters [a-z0-9-]. The prefix gcp- is reserved for use by Google, and may not be specified.

- Service account ([link1](https://docs.cloud.google.com/iam/docs/service-accounts-create), [link2](https://docs.cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/create))

> The ID must be between 6 and 30 characters, and can contain lowercase alphanumeric characters and dashes. After you create a service account, you cannot change its name.
> 
> The service account's name appears in the email address that is provisioned during creation, in the format `SERVICE_ACCOUNT_NAME@PROJECT_ID.iam.gserviceaccount.com`

</details>

### Issues: Fixed #1933
1. A comment from Code Rabbit was raised, which opened a gap to fix the suggested.

### Testing Instructions:
#### Unit Tests:
Please run: `go test -mod=vendor -count=1 -v ./pkg/util -run 'TestValidateGCPWIFParams|TestValidateGoogleCloudStorageCredentialsJSON|TestGoogleCredentialsFromStoreSecret'`

#### Manual Tests
1. Deploy NooBaa on Minikube after adding GCP WIF configurations - see guide "Create GCP WIF (STS) Setup On Minikube With NooBaa" ([link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_gcp_wif_setup_on_minikube_with_noobaa.md)).
3. Try to test the parameter validation for fail fast, for example:
- `nb install` without `--google-cloud-pool-id` with the rest of GCP WIF (STS) flags:
```shell
FATA[0000] Invalid GCP WIF (STS) install flags: when any GCP WIF (STS) parameter is set, all four are required: project-number, pool-id, provider-id, service-account-email
```

- `nb install` with invalid (no `@`) `--google-cloud-service-account-email` with the rest of GCP WIF (STS) flags:
```shell
FATA[0000] Invalid GCP WIF (STS) install flags: service-account-email must be a valid GCP service account email
```

- `nb backingstore create google-cloud-storage-sts shira-gcp-sts -n test1` with `_` as `project-number`:
```shell
FATA[0023] Failed to build GCP WIF credentials: project-number must be a numeric GCP project number (digits only), not a project ID
```

- `nb backingstore create google-cloud-storage-sts <bs-name> -n test1 --target-bucket <target-bucket-name> --secret-name <secret-of-GCP-non-STS>`
```shell
FATA[0000] ❌ secret "shira-gcp-secret-2": GCP credentials JSON type must be "external_account" for WIF (STS)
```

- `nb backingstore create google-cloud-storage <bs-name> -n test1 --target-bucket <target-bucket-name> --secret-name <secret-of-GCP-WIF-STS>`
```shell
FATA[0000] ❌ secret "gcp-wif-creds": GCP credentials JSON type must be "service_account" for long-lived credentials
``` 
4. Create a secret that contains both `GoogleServiceAccountPrivateKeyJson` and `GoogleCredentialsJson` and expect the backingstore creation to fail: `nb backingstore create google-cloud-storage-sts shira-gcp-sts-02 -n test1 --target-bucket shira-gcp-04 --secret-name gcp-both-keys-test`
```shell
INFO[0000] ✅ Exists: NooBaa "noobaa"
INFO[0000] ✅ Exists: Secret "gcp-both-keys-test"
INFO[0000] ✅ Exists: Secret "gcp-both-keys-test"
FATA[0000] ❌ secret "gcp-both-keys-test": secret "gcp-both-keys-test" in namespace "test1" must not contain both "GoogleCredentialsJson" and "GoogleServiceAccountPrivateKeyJson"; use "GoogleCredentialsJson" for GCP WIF (STS) external_account or "GoogleServiceAccountPrivateKeyJson" for service_account
```

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened Google Cloud service-account credential handling by validating the credentials JSON `type` before storing or using it.
  * Strengthened Workload Identity Federation (WIF/STS) input validation for install/upgrade and reconciliation, including clearer invalid-parameter handling and stricter formatting checks.
  * When using referenced secrets, the CLI now verifies the stored credentials JSON `type` matches the expected mode.

* **Tests**
  * Expanded test coverage for Google credentials JSON `type` validation and WIF/STS parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->