### PR TITLE
implement noobaa core HA

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1080,6 +1080,11 @@ spec:
                       cleanup confirmation
                     type: string
                 type: object
+              coreHA:
+                description: |-
+                  CoreHA (optional) enables noobaa-core high availability (2 replicas with Kubernetes lease leader election).
+                  When true, two core pods are used with lease leader election. When false or omitted, a single core pod is used.
+                type: boolean
               corePriorityClassName:
                 description: CorePriorityClassName (optional) overrides the priority
                   class for the core pod

--- a/deploy/internal/lease-core.yaml
+++ b/deploy/internal/lease-core.yaml
@@ -1,0 +1,8 @@
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: noobaa-core-lease
+  labels:
+    app: noobaa
+spec:
+  leaseDurationSeconds: 20

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -26,6 +26,8 @@ spec:
       volumes:
         - name: logs
           emptyDir: {}
+        - name: core-run
+          emptyDir: {}
         - name: mgmt-secret
           secret:
             secretName: noobaa-mgmt-serving-cert
@@ -62,6 +64,8 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: /log
+            - name: core-run
+              mountPath: /var/run/noobaa
             - name: mgmt-secret
               mountPath: /etc/mgmt-secret
               readOnly: true
@@ -138,6 +142,8 @@ spec:
               value: postgres
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
+            - name: NOOBAA_CORE_LEASE_NAME
+              value: ""
             - name: NODE_EXTRA_CA_CERTS
             - name: TLS_MIN_VERSION
             - name: TLS_CIPHERS

--- a/deploy/role_core.yaml
+++ b/deploy/role_core.yaml
@@ -55,3 +55,13 @@ rules:
   - update
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -101,6 +101,11 @@ type NooBaaSpec struct {
 	// +optional
 	CoreResources *corev1.ResourceRequirements `json:"coreResources,omitempty"`
 
+	// CoreHA (optional) enables noobaa-core high availability (2 replicas with Kubernetes lease leader election).
+	// When true, two core pods are used with lease leader election. When false or omitted, a single core pod is used.
+	// +optional
+	CoreHA *bool `json:"coreHA,omitempty"`
+
 	// CorePriorityClassName (optional) overrides the priority class for the core pod
 	// +optional
 	CorePriorityClassName string `json:"corePriorityClassName,omitempty"`

--- a/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/noobaa/v1alpha1/zz_generated.deepcopy.go
@@ -1404,6 +1404,11 @@ func (in *NooBaaSpec) DeepCopyInto(out *NooBaaSpec) {
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CoreHA != nil {
+		in, out := &in.CoreHA, &out.CoreHA
+		*out = new(bool)
+		**out = **in
+	}
 	if in.LogResources != nil {
 		in, out := &in.LogResources, &out.LogResources
 		*out = new(v1.ResourceRequirements)

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1511,7 +1511,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "ad028fe4d9fedbfb0fb4d4369e605e1cf6b56d69f6b5bb6d760341c5673509e5"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "2c9a7049e4ab48103350e4be0cc47d31d29e1eaf95de128d988e04e8b02fbf23"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -2595,6 +2595,11 @@ spec:
                       cleanup confirmation
                     type: string
                 type: object
+              coreHA:
+                description: |-
+                  CoreHA (optional) enables noobaa-core high availability (2 replicas with Kubernetes lease leader election).
+                  When true, two core pods are used with lease leader election. When false or omitted, a single core pod is used.
+                type: boolean
               corePriorityClassName:
                 description: CorePriorityClassName (optional) overrides the priority
                   class for the core pod
@@ -4869,6 +4874,18 @@ metadata:
 data: {}
 `
 
+const Sha256_deploy_internal_lease_core_yaml = "827119b06080bda366eae9423f3fe39b7317c67cdd176af06f1acf2c7cd4d3a9"
+
+const File_deploy_internal_lease_core_yaml = `apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: noobaa-core-lease
+  labels:
+    app: noobaa
+spec:
+  leaseDurationSeconds: 20
+`
+
 const Sha256_deploy_internal_nsfs_pvc_cr_yaml = "6dd65ca7d324991b813f209ec6a8a6bcf6c2c9a9f45c519ad3fba51e25042f07"
 
 const File_deploy_internal_nsfs_pvc_cr_yaml = `apiVersion: v1
@@ -5594,7 +5611,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "4ef493f94d8f81746f9d8904085de093b4ed37ee15d0767cc563f7aa89c86de8"
+const Sha256_deploy_internal_statefulset_core_yaml = "6f033e808d7efbacce6063b6f4b8cc9748d0ab42d7e4a4a290ac059af501d262"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5623,6 +5640,8 @@ spec:
       serviceAccountName: noobaa-core
       volumes:
         - name: logs
+          emptyDir: {}
+        - name: core-run
           emptyDir: {}
         - name: mgmt-secret
           secret:
@@ -5660,6 +5679,8 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: /log
+            - name: core-run
+              mountPath: /var/run/noobaa
             - name: mgmt-secret
               mountPath: /etc/mgmt-secret
               readOnly: true
@@ -5736,6 +5757,8 @@ spec:
               value: postgres
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
+            - name: NOOBAA_CORE_LEASE_NAME
+              value: ""
             - name: NODE_EXTRA_CA_CERTS
             - name: TLS_MIN_VERSION
             - name: TLS_CIPHERS
@@ -7125,7 +7148,7 @@ subjects:
   name: custom-metrics-prometheus-adapter
 `
 
-const Sha256_deploy_role_core_yaml = "1ec420603dcec64b247852d106535a85a1a866129f78f790c2e5c9285f029ae7"
+const Sha256_deploy_role_core_yaml = "61e993aa27c5064894ff6ce897331135370118b19219ba07dc720992749d8130"
 
 const File_deploy_role_core_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7184,6 +7207,16 @@ rules:
   - update
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
 `
 
 const Sha256_deploy_role_db_yaml = "bc7eeca1125dfcdb491ab8eb69e3dcbce9f004a467b88489f85678b3c6872cce"

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -23,11 +23,17 @@ func CmdInstall() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install the operator and create the noobaa system",
-		Run:   RunInstall,
-		Args:  cobra.NoArgs,
+		Long: `Install the operator and create the NooBaa system.
+
+Core HA is disabled by default (single noobaa-core pod).
+Use --core-ha=true to enable 2 noobaa-core pods with Kubernetes lease leader election
+(requires a matching noobaa-core image).`,
+		Run:  RunInstall,
+		Args: cobra.NoArgs,
 	}
 	cmd.Flags().Bool("use-obc-cleanup-policy", false, "Create NooBaa system with obc cleanup policy")
 	cmd.Flags().Bool("use-standalone-db", false, "Create NooBaa system with standalone DB (Legacy)")
+	system.AddCoreHAFlags(cmd)
 	cmd.Flags().Bool("no-wait", false, "Don't wait for the system to be ready. Exit after applying the changes")
 	cmd.AddCommand(
 		CmdYaml(),

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -78,6 +78,13 @@ var PostgresMajorVersion = 16
 // PostgresInstances is the default number of postgres instances in a managed postgres cluster
 var PostgresInstances = 2
 
+// CoreHAReplicaCount is the noobaa-core StatefulSet replica count when core HA is enabled.
+const CoreHAReplicaCount int32 = 2
+
+// CoreHA is the default for spec.coreHA on new systems (install/system create).
+// Override with --core-ha=true when using a noobaa-core image with lease HA support.
+var CoreHA = false
+
 // Psql12Image is the default postgres12 db image url
 // currently it can not be overridden.
 var Psql12Image = "centos/postgresql-12-centos7"

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -214,9 +214,25 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 			if numRunningPods != 0 {
 				return fmt.Errorf("waiting for noobaa-core and noobaa-endpoint pods to be terminated before upgrade. %d pods are still running", numRunningPods)
 			}
+		// when enabling core HA on a running system, stop core pods before creating the lease.
+		} else if needsCoreStoppedBeforeHAEnable(r) {
+			numRunningPods, err := r.stopCorePodsAndGetNumRunning()
+			if err != nil {
+				return fmt.Errorf("got error stopping noobaa-core pods before enabling HA. error: %v", err)
+			}
+			if numRunningPods != 0 {
+				return fmt.Errorf("waiting for noobaa-core pods to be terminated before enabling HA. %d pods are still running", numRunningPods)
+			}
 		}
 	}
 
+	if isCoreHAEnabled(r.NooBaa) {
+		if err := r.ReconcileObject(r.CoreLease, r.SetDesiredCoreLease); err != nil {
+			return err
+		}
+	} else if util.KubeCheckQuiet(r.CoreLease) {
+		util.KubeDelete(r.CoreLease)
+	}
 	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
 		return err
 	}
@@ -597,7 +613,12 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			c.Env[j].Value = postgresSecretMountPath + "/host"
 		case "POSTGRES_CONNECTION_STRING_PATH":
 			c.Env[j].Value = postgresSecretMountPath + "/db_url"
-
+		case "NOOBAA_CORE_LEASE_NAME":
+			if isCoreHAEnabled(r.NooBaa) {
+				c.Env[j].Value = r.CoreLease.Name
+			} else {
+				c.Env[j].Value = ""
+			}
 		case "NODE_EXTRA_CA_CERTS":
 			c.Env[j].Value = r.ApplyCAsToPods
 		case "GUARANTEED_LOGS_PATH":
@@ -659,6 +680,8 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 		oneReplica := int32(1)
 		r.CoreApp.Spec.Replicas = &oneReplica
 	}
+	desiredCoreReplicas := getDesiredCoreReplicas(r.NooBaa)
+	r.CoreApp.Spec.Replicas = &desiredCoreReplicas
 
 	// adding the missing Volumes from default podSpec
 	podSpec.Volumes = r.DefaultCoreApp.Volumes
@@ -1649,6 +1672,45 @@ func (r *Reconciler) RestartDbPods() error {
 			util.KubeDeleteNoPolling(&pod)
 		}
 	}
+	return nil
+}
+
+func isCoreHAEnabled(nooBaa *nbv1.NooBaa) bool {
+	return nooBaa.Spec.CoreHA != nil && *nooBaa.Spec.CoreHA
+}
+
+func isCoreLeaseConfiguredOnDeployed(r *Reconciler) bool {
+	for i := range r.CoreApp.Spec.Template.Spec.Containers {
+		c := &r.CoreApp.Spec.Template.Spec.Containers[i]
+		if c.Name != "core" {
+			continue
+		}
+		env := util.GetEnvVariable(&c.Env, "NOOBAA_CORE_LEASE_NAME")
+		return env != nil && env.Value != ""
+	}
+	return false
+}
+
+// needsCoreStoppedBeforeHAEnable reports whether the deployed core StatefulSet must be
+// scaled down before creating the lease and applying the HA pod template.
+func needsCoreStoppedBeforeHAEnable(r *Reconciler) bool {
+	return isCoreHAEnabled(r.NooBaa) && !isCoreLeaseConfiguredOnDeployed(r)
+}
+
+func getDesiredCoreReplicas(nooBaa *nbv1.NooBaa) int32 {
+	if isCoreHAEnabled(nooBaa) {
+		return options.CoreHAReplicaCount
+	}
+	return 1
+}
+
+// SetDesiredCoreLease updates the core Lease as desired for reconciling
+func (r *Reconciler) SetDesiredCoreLease() error {
+	if r.CoreLease.Labels == nil {
+		r.CoreLease.Labels = map[string]string{}
+	}
+	r.CoreLease.Labels["app"] = "noobaa"
+	r.CoreLease.Labels["noobaa-core-lease"] = r.Request.Name
 	return nil
 }
 

--- a/pkg/system/phase2_creating_test.go
+++ b/pkg/system/phase2_creating_test.go
@@ -1,6 +1,17 @@
 package system
 
-import "testing"
+import (
+	"testing"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func boolPtr(v bool) *bool {
+	return &v
+}
 
 func TestValidateAzureSTSParams(t *testing.T) {
 	tests := []struct {
@@ -62,5 +73,89 @@ func TestValidateAzureSTSParams(t *testing.T) {
 				t.Errorf("validateAzureSTSParams() = %v, want %v", got, tt.wantOK)
 			}
 		})
+	}
+}
+
+func TestIsCoreHAEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		coreHA *bool
+		want   bool
+	}{
+		{name: "nil is disabled", coreHA: nil, want: false},
+		{name: "false is disabled", coreHA: boolPtr(false), want: false},
+		{name: "true is enabled", coreHA: boolPtr(true), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nb := &nbv1.NooBaa{Spec: nbv1.NooBaaSpec{CoreHA: tt.coreHA}}
+			if got := isCoreHAEnabled(nb); got != tt.want {
+				t.Errorf("isCoreHAEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsCoreLeaseConfiguredOnDeployed(t *testing.T) {
+	tests := []struct {
+		name     string
+		leaseEnv string
+		want     bool
+	}{
+		{name: "empty lease env", leaseEnv: "", want: false},
+		{name: "lease env set", leaseEnv: "noobaa-core-lease", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := reconcilerWithCoreLeaseEnv(tt.leaseEnv)
+			if got := isCoreLeaseConfiguredOnDeployed(r); got != tt.want {
+				t.Errorf("isCoreLeaseConfiguredOnDeployed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDesiredCoreReplicas(t *testing.T) {
+	tests := []struct {
+		name   string
+		coreHA *bool
+		want   int32
+	}{
+		{name: "HA disabled", coreHA: boolPtr(false), want: 1},
+		{name: "HA enabled", coreHA: boolPtr(true), want: options.CoreHAReplicaCount},
+		{name: "HA unset", coreHA: nil, want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nb := &nbv1.NooBaa{Spec: nbv1.NooBaaSpec{CoreHA: tt.coreHA}}
+			if got := getDesiredCoreReplicas(nb); got != tt.want {
+				t.Errorf("getDesiredCoreReplicas() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func reconcilerWithCoreLeaseEnv(leaseEnv string) *Reconciler {
+	return &Reconciler{
+		NooBaa: &nbv1.NooBaa{
+			Spec: nbv1.NooBaaSpec{},
+		},
+		CoreApp: &appsv1.StatefulSet{
+			Spec: appsv1.StatefulSetSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "db"},
+							{
+								Name: "core",
+								Env: []corev1.EnvVar{
+									{Name: "NOOBAA_CORE_LEASE_NAME", Value: leaseEnv},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -27,11 +27,11 @@ func (r *Reconciler) ReconcilePhaseConnecting() error {
 		r.CheckServiceStatus(r.ServiceMgmt, r.RouteMgmt, &r.NooBaa.Status.Services.ServiceMgmt, "mgmt-https")
 	}
 
-	// wait for noobaa core statefulset to be ready before proceeding
+	// wait for at least one ready core pod (HA: only the primary becomes Ready; standbys stay not Ready)
 	if r.CoreApp.Spec.Replicas == nil {
 		return fmt.Errorf("noobaa core statefulset replicas is nil, cannot proceed")
-	} else if r.CoreApp.Status.ReadyReplicas < *r.CoreApp.Spec.Replicas {
-		return fmt.Errorf("waiting for noobaa core pod to be ready, currently ready replicas: %d, expected: %d",
+	} else if r.CoreApp.Status.ReadyReplicas < 1 {
+		return fmt.Errorf("waiting for noobaa core pod to be ready, currently ready replicas: %d, expected: at least 1 (%d configured)",
 			r.CoreApp.Status.ReadyReplicas, *r.CoreApp.Spec.Replicas)
 	}
 

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -73,6 +74,7 @@ type Reconciler struct {
 	NooBaa                    *nbv1.NooBaa
 	ServiceAccount            *corev1.ServiceAccount
 	CoreApp                   *appsv1.StatefulSet
+	CoreLease                 *coordinationv1.Lease
 	CoreAppConfig             *corev1.ConfigMap
 	DefaultCoreApp            *corev1.PodSpec
 	PostgresDBConf            *corev1.ConfigMap
@@ -160,6 +162,7 @@ func NewReconciler(
 		NooBaa:                    util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml).(*nbv1.NooBaa),
 		ServiceAccount:            util.KubeObject(bundle.File_deploy_service_account_yaml).(*corev1.ServiceAccount),
 		CoreApp:                   util.KubeObject(bundle.File_deploy_internal_statefulset_core_yaml).(*appsv1.StatefulSet),
+		CoreLease:                 util.KubeObject(bundle.File_deploy_internal_lease_core_yaml).(*coordinationv1.Lease),
 		CoreAppConfig:             util.KubeObject(bundle.File_deploy_internal_configmap_empty_yaml).(*corev1.ConfigMap),
 		PostgresDBConf:            util.KubeObject(bundle.File_deploy_internal_configmap_postgres_db_yaml).(*corev1.ConfigMap),
 		NooBaaPostgresDB:          util.KubeObject(bundle.File_deploy_internal_statefulset_postgres_db_yaml).(*appsv1.StatefulSet),
@@ -216,6 +219,7 @@ func NewReconciler(
 	r.NooBaa.Namespace = r.Request.Namespace
 	r.ServiceAccount.Namespace = r.Request.Namespace
 	r.CoreApp.Namespace = r.Request.Namespace
+	r.CoreLease.Namespace = r.Request.Namespace
 	r.CoreAppConfig.Namespace = r.Request.Namespace
 	r.PostgresDBConf.Namespace = r.Request.Namespace
 	r.NooBaaPostgresDB.Namespace = r.Request.Namespace
@@ -269,6 +273,7 @@ func NewReconciler(
 	r.NooBaa.Name = r.Request.Name
 	r.ServiceAccount.Name = r.Request.Name
 	r.CoreApp.Name = r.Request.Name + "-core"
+	r.CoreLease.Name = r.Request.Name + "-core-lease"
 	r.CoreAppConfig.Name = "noobaa-config"
 	r.NooBaaPostgresDB.Name = r.Request.Name + "-db-pg"
 	r.ServiceMgmt.Name = r.Request.Name + "-mgmt"
@@ -756,6 +761,23 @@ func (r *Reconciler) isObjectUpdated(result controllerutil.OperationResult) bool
 // Own sets the object owner references to the noobaa system
 func (r *Reconciler) Own(obj metav1.Object) {
 	util.Panic(controllerutil.SetControllerReference(r.NooBaa, obj, r.Scheme))
+}
+
+// stopCorePodsAndGetNumRunning scales the core StatefulSet to 0 and returns the number of still-running core pods.
+func (r *Reconciler) stopCorePodsAndGetNumRunning() (int, error) {
+	zeroReplicas := int32(0)
+	if err := r.ReconcileObject(r.CoreApp, func() error {
+		r.CoreApp.Spec.Replicas = &zeroReplicas
+		return nil
+	}); err != nil {
+		r.Logger.Errorf("got error stopping noobaa-core pods. error: %v", err)
+		return -1, err
+	}
+	corePodsList := &corev1.PodList{}
+	if !util.KubeList(corePodsList, client.InNamespace(r.Request.Namespace), client.MatchingLabels{"noobaa-core": r.Request.Name}) {
+		return -1, fmt.Errorf("got error listing noobaa-core pods")
+	}
+	return len(corePodsList.Items), nil
 }
 
 // stopNoobaaPodsAndGetNumRunningPods stops the noobaa pods and returns the number of running pods

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -67,14 +67,20 @@ func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a noobaa system",
-		Run:   RunCreate,
-		Args:  cobra.NoArgs,
+		Long: `Create a NooBaa system.
+
+Core HA is disabled by default (single noobaa-core pod).
+Use --core-ha=true to enable 2 noobaa-core pods with Kubernetes lease leader election
+(requires a matching noobaa-core image).`,
+		Run:  RunCreate,
+		Args: cobra.NoArgs,
 	}
 	cmd.Flags().String("core-resources", "", "Core resources JSON")
 	cmd.Flags().String("db-resources", "", "DB resources JSON")
 	cmd.Flags().String("endpoint-resources", "", "Endpoint resources JSON")
 	cmd.Flags().Bool("use-standalone-db", false, "Create NooBaa system with standalone DB (Legacy)")
 	cmd.Flags().Bool("use-obc-cleanup-policy", false, "Create NooBaa system with obc cleanup policy")
+	AddCoreHAFlags(cmd)
 	return cmd
 }
 
@@ -197,6 +203,15 @@ func CmdOidc() *cobra.Command {
 	return cmd
 }
 
+// AddCoreHAFlags registers the core HA flag on install/create (local to those commands, like use-standalone-db).
+func AddCoreHAFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(
+		&options.CoreHA, "core-ha",
+		options.CoreHA,
+		"Enable noobaa-core HA (2 pods with lease leader election). Default: false. Use --core-ha=true to enable",
+	)
+}
+
 // LoadSystemDefaults loads a noobaa system CR from bundled yamls
 // and apply's changes from CLI flags to the defaults.
 func LoadSystemDefaults() *nbv1.NooBaa {
@@ -212,6 +227,8 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 	sys.Spec.LoadBalancerSourceSubnets.S3 = options.S3LoadBalancerSourceSubnets
 	sys.Spec.LoadBalancerSourceSubnets.STS = options.STSLoadBalancerSourceSubnets
 	sys.Spec.LoadBalancerSourceSubnets.Vectors = options.VectorsLoadBalancerSourceSubnets
+	coreHA := options.CoreHA
+	sys.Spec.CoreHA = &coreHA
 
 	LoadConfigMapFromFlags()
 
@@ -442,6 +459,10 @@ func RunCreate(cmd *cobra.Command, args []string) {
 			}
 		}
 		util.Panic(json.Unmarshal([]byte(endpointResourcesJSON), &sys.Spec.Endpoints.Resources))
+	}
+	if cmd.Flags().Changed("core-ha") {
+		coreHA, _ := cmd.Flags().GetBool("core-ha")
+		sys.Spec.CoreHA = &coreHA
 	}
 
 	if options.PostgresDbURL != "" {
@@ -1268,9 +1289,9 @@ func CheckWaitingFor(sys *nbv1.NooBaa) error {
 	if coreApp.Spec.Replicas != nil {
 		desiredReplicas = *coreApp.Spec.Replicas
 	}
-	if coreApp.Status.Replicas != desiredReplicas {
+	if coreApp.Status.ReadyReplicas < 1 {
 		log.Printf(`⏳ System Phase is %q. StatefulSet %q is not yet ready:`+
-			` ReadyReplicas %d/%d`,
+			` ReadyReplicas %d, need at least 1 (%d configured)`,
 			sys.Status.Phase,
 			coreAppName,
 			coreApp.Status.ReadyReplicas,
@@ -1287,22 +1308,15 @@ func CheckWaitingFor(sys *nbv1.NooBaa) error {
 	if corePodErr != nil {
 		return corePodErr
 	}
-	if len(corePodList.Items) != int(desiredReplicas) {
-		return fmt.Errorf("Can't find the core pods")
-	}
-	corePod := &corePodList.Items[0]
-	if corePod.Status.Phase != corev1.PodRunning {
-		log.Printf(`⏳ System Phase is %q. Pod %q is not yet ready: %s`,
-			sys.Status.Phase, corePod.Name, util.GetPodStatusLine(corePod))
+	if len(corePodList.Items) == 0 {
+		log.Printf(`⏳ System Phase is %q. No core pods found yet (want %d)`,
+			sys.Status.Phase, desiredReplicas)
 		return nil
 	}
-	for i := range corePod.Status.ContainerStatuses {
-		c := &corePod.Status.ContainerStatuses[i]
-		if !c.Ready {
-			log.Printf(`⏳ System Phase is %q. Container %q is not yet ready: %s`,
-				sys.Status.Phase, c.Name, util.GetContainerStatusLine(c))
-			return nil
-		}
+	if len(corePodList.Items) != int(desiredReplicas) {
+		log.Printf(`⏳ System Phase is %q. Found %d core pods, want %d`,
+			sys.Status.Phase, len(corePodList.Items), desiredReplicas)
+		return nil
 	}
 
 	log.Printf(`⏳ System Phase is %q. Waiting for phase ready ...`, sys.Status.Phase)

--- a/test/cli/test_cli_functions.sh
+++ b/test/cli/test_cli_functions.sh
@@ -326,11 +326,28 @@ function check_core_config_map {
     check_change_debug_level_in_config_map
 }
 
+function get_running_core_pod {
+    ${kubectl} get pod -l noobaa-core=noobaa \
+        --field-selector=status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+function get_core_noobaa_log_level {
+    local core_pod
+    core_pod=$(get_running_core_pod)
+    if [ -z "${core_pod}" ]; then
+        return 1
+    fi
+    ${kubectl} exec "${core_pod}" -c core -- printenv NOOBAA_LOG_LEVEL 2>/dev/null
+}
+
 function check_change_debug_level_in_config_map {
     local cm_debug_level="all"
     local patch='{"data":{"NOOBAA_LOG_LEVEL":"all"}}'
     local timeout=0
-    local core_debug_level=$(kuberun silence exec noobaa-core-0 -- printenv NOOBAA_LOG_LEVEL)
+    local core_debug_level=""
+
+    core_debug_level=$(get_core_noobaa_log_level || true)
 
     kuberun silence patch configmap noobaa-config -p ${patch}
 
@@ -339,7 +356,7 @@ function check_change_debug_level_in_config_map {
         echo_time "💬  Waiting for NOOBAA_LOG_LEVEL core env var to match the noobaa-config"
         timeout=$((timeout+10))
         sleep 10
-        core_debug_level=$(kuberun silence exec noobaa-core-0 -- printenv NOOBAA_LOG_LEVEL)
+        core_debug_level=$(get_core_noobaa_log_level || true)
         if [ ${timeout} -ge 180 ] 
         then
             echo_time "❌  reached the timeout for waiting to the update"


### PR DESCRIPTION
### Describe the Problem

Today the noobaa-core control plane runs as a single pod. If that pod fails or its node goes down, the system has no core redundancy until Kubernetes reschedules it.

Core HA support was added in noobaa-core (see https://github.com/noobaa/noobaa-core/pull/9765). The operator still needed changes to deploy and manage that setup.

### Explain the changes
This PR adds optional noobaa-core HA to the operator:
1. New spec.coreHA field on the NooBaa CR for enabling disabling core HA (Disabled by default for new installs).
2. When enabled, the operator runs 2 core pods and creates a Kubernetes Lease for leader election.
3. change RBAC to give core and operator required permissions to handle the lease
4. send core pods the lease name via NOOBAA_CORE_LEASE_NAME. if empty or not sent, core assumes HA is disabled
5. When HA is turned off, the operator scales back to 1 core pod and removes the lease.
6. Safe transition when enabling HA on an existing system: core pods are stopped before the lease is created.
7. Readiness checks updated so the system can become ready with at least one healthy core pod (not requiring both).
8. new cli install flag `--core-ha` to modify noobaa CR to disable / enable core HA during installation
9. Unit tests for the new HA reconcile helpers.  

### Issues
1. part of https://redhat.atlassian.net/browse/RHSTOR-7491

###Gaps
1. change cli port to connect through mgmnt service instead of directly to noobaa-core-0
2. missing node anti-affinity for core-pods to run on different nodes
3. since core changes are not in, core currently ignores the lease, causing two active core pods. default feature to be disabled. can enable once core changes are in

core side changes: https://github.com/noobaa/noobaa-core/pull/9765 


### Testing Instructions:
1. 

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional core high-availability setting for new installations.
  * Support now includes two-core operation with lease-based leader election when enabled.

* **Bug Fixes**
  * Improved core startup and readiness handling so the system can work correctly with HA-enabled pods.
  * Updated checks to detect the active core pod dynamically instead of assuming a fixed pod name.

* **Documentation**
  * Expanded installation and configuration help text to explain the new core HA option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->