### PR TITLE
SCC | Add SCC (`openshift.io/required-scc`) Annotations (core and endpoint)

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -21,6 +21,7 @@ spec:
         app: noobaa
       annotations:
         noobaa.io/configmap-hash: ""
+        openshift.io/required-scc: noobaa-endpoint
     spec:
       # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa-endpoint

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -20,6 +20,7 @@ spec:
         noobaa-mgmt: noobaa
       annotations:
         noobaa.io/configmap-hash: ""
+        openshift.io/required-scc: noobaa-core
     spec:
       # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa-core

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4358,7 +4358,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "558ec22578b22c3ac3a6d6b72fa95a7122739014ded0a73adbac319aa4457aed"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "e028fd7874ebec9b0b63f84ed2f9b3648a8785c7f0cd99b49d8de4a28b7d1910"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4383,6 +4383,7 @@ spec:
         app: noobaa
       annotations:
         noobaa.io/configmap-hash: ""
+        openshift.io/required-scc: noobaa-endpoint
     spec:
       # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa-endpoint
@@ -5599,7 +5600,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "4ef493f94d8f81746f9d8904085de093b4ed37ee15d0767cc563f7aa89c86de8"
+const Sha256_deploy_internal_statefulset_core_yaml = "cc38a4b3cd26c43156962823645c43be26e39ed57a7205d6b390c7849c39651b"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5623,6 +5624,7 @@ spec:
         noobaa-mgmt: noobaa
       annotations:
         noobaa.io/configmap-hash: ""
+        openshift.io/required-scc: noobaa-core
     spec:
       # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
       serviceAccountName: noobaa-core

--- a/pkg/diagnostics/collect.go
+++ b/pkg/diagnostics/collect.go
@@ -188,7 +188,7 @@ func (c *Collector) CollectPVCs(listOptions client.ListOptions) {
 // CollectSCC collects the SCC
 func (c *Collector) CollectSCC() {
 	c.log.Println("Collecting SCC logs")
-	for _, name := range []string{"noobaa", "noobaa-endpoint", "noobaa-agent"} {
+	for _, name := range []string{"noobaa", "noobaa-endpoint", "noobaa-core", "noobaa-agent"} {
 		scc := &secv1.SecurityContextConstraints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -844,6 +844,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	}
 
 	r.CoreApp.Spec.Template.Annotations["noobaa.io/configmap-hash"] = r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"]
+	r.CoreApp.Spec.Template.Annotations[secv1.RequiredSCCAnnotation] = "noobaa-core"
 
 	// we want to check that the cm exists and also that it has data in it
 	if util.KubeCheckQuiet(r.CaBundleConf) && len(r.CaBundleConf.Data) > 0 {

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -481,6 +481,7 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 			}
 
 			r.DeploymentEndpoint.Spec.Template.Annotations["noobaa.io/configmap-hash"] = r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"]
+			r.DeploymentEndpoint.Spec.Template.Annotations[secv1.RequiredSCCAnnotation] = "noobaa-endpoint"
 
 			r.addContainerPortsIfNotExist(c, []corev1.ContainerPort{
 				{


### PR DESCRIPTION
### Describe the Problem
Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) Enforce least-privileged Security Context Constraint (SCC) across ODF pods.

### Explain the changes
Worked according to the design doc:
1. YAML Manifests (added to the `spec.template.metadata.annotations`, so pods will inherit this):
- `deploy/internal/statefulset-core.yaml` (noobaa-core StatefulSet): Add `openshift.io/required-scc: noobaa-core`
- `deploy/internal/deployment-endpoint.yaml` (noobaa-endpoint Deployment): Add `openshift.io/required-scc: noobaa-endpoint`
2. Go Code Reconcilers:
- `pkg/system/phase2_creating.go`: under `SetDesiredCoreApp ` set the annotation.
- `pkg/system/phase4_configuring.go`: under `SetDesiredDeploymentEndpoint` set the annotation.
3. Add `noobaa-core` to `CollectSCC` (it already had `noobaa-endpoint`).

### Issues: 
1. none

### Testing Instructions:
#### Manual Testing
##### Local Cluster:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
2. Check that you can see the annotation using the following examples:
- ` kubectl -n test1  get statefulset noobaa-core -o jsonpath='{.spec.template.metadata.annotations}'`
- `kubectl -n test1  get deployment noobaa-endpoint -o jsonpath='{.spec.template.metadata.annotations}'`

#### OCP Cluster
Detailed instructions are in the [comment](https://github.com/noobaa/noobaa-operator/pull/1965#issuecomment-4779109588) below.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift/Kubernetes manifests and operator-managed templates to explicitly request the appropriate Security Context Constraints (SCC) for NooBaa components, including the endpoint, metrics adapter, agent, core, database, and operator.
  * Hardened SCC configuration by adding `seccompProfiles: runtime/default`.
  * Adjusted core and database SCC behavior (e.g., `runAsUser` and `fsGroup`) and applied `restricted-v2` where applicable to maintain intended security posture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->