### PR TITLE
Add dev-env and mini-env performance profiles for CLI deployments

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1948,6 +1948,8 @@ spec:
                 - default
                 - mixed-workload
                 - small-objects
+                - dev-env
+                - mini-env
                 type: string
               pvPoolDefaultStorageClass:
                 description: |-

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -262,7 +262,7 @@ type NooBaaSpec struct {
 	// settings for the core, db and endpoint components.
 	// Explicit per-component resource/count fields take precedence over the profile.
 	// +optional
-	// +kubebuilder:validation:Enum=default;mixed-workload;small-objects
+	// +kubebuilder:validation:Enum=default;mixed-workload;small-objects;dev-env;mini-env
 	PerformanceProfile PerformanceProfileType `json:"performanceProfile,omitempty"`
 }
 
@@ -894,4 +894,8 @@ const (
 	PerformanceProfileMixedWorkload PerformanceProfileType = "mixed-workload"
 	// PerformanceProfileSmallObjects is for small objects workload
 	PerformanceProfileSmallObjects PerformanceProfileType = "small-objects"
+	// PerformanceProfileDevEnv is for development environments with moderate resources
+	PerformanceProfileDevEnv PerformanceProfileType = "dev-env"
+	// PerformanceProfileMiniEnv is for low-resource environments with minimal footprint
+	PerformanceProfileMiniEnv PerformanceProfileType = "mini-env"
 )

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1511,7 +1511,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "ad028fe4d9fedbfb0fb4d4369e605e1cf6b56d69f6b5bb6d760341c5673509e5"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "88be0872b57677c437aeb656eac747cd13871d9b2733d41b0b2ec5b2d4ea7603"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -3463,6 +3463,8 @@ spec:
                 - default
                 - mixed-workload
                 - small-objects
+                - dev-env
+                - mini-env
                 type: string
               pvPoolDefaultStorageClass:
                 description: |-

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -76,7 +76,7 @@ var DBImage = "quay.io/sclorg/postgresql-16-c9s"
 var PostgresMajorVersion = 16
 
 // PostgresInstances is the default number of postgres instances in a managed postgres cluster
-var PostgresInstances = 2
+var PostgresInstances = 1
 
 // Psql12Image is the default postgres12 db image url
 // currently it can not be overridden.
@@ -187,7 +187,7 @@ var AWSSTSARN = ""
 var CnpgVersion = "1.27.0"
 
 // CnpgImage is the container image url of cloudnative-pg operator
-var CnpgImage = "quay.io/noobaa/cloudnative-pg-noobaa:v1.25.0"
+var CnpgImage = "quay.io/rhceph-dev/odf4-odf-cloudnative-pg-rhel9-operator:v4.22"
 
 // UseCnpgApiGroup indicates if the original CloudNativePG API group should be used for the installation manifests
 // Relevant for the CLI commands. during reconciliation we look at the env variable USE_CNPG_API_GROUP to determine
@@ -292,6 +292,10 @@ func init() {
 	FlagSet.IntVar(
 		&DBVolumeSizeGB, "db-volume-size-gb",
 		DBVolumeSizeGB, "The database volume size in GB",
+	)
+	FlagSet.IntVar(
+		&PostgresInstances, "postgres-instances",
+		PostgresInstances, "The number of postgres instances",
 	)
 	FlagSet.StringVar(
 		&DBStorageClass, "db-storage-class",

--- a/pkg/system/performance_profiles.go
+++ b/pkg/system/performance_profiles.go
@@ -10,6 +10,7 @@ import (
 
 type performanceProfile struct {
 	coreResources     corev1.ResourceRequirements
+	logResources      *corev1.ResourceRequirements
 	dbResources       corev1.ResourceRequirements
 	endpointResources corev1.ResourceRequirements
 	endpointMinCount  int32
@@ -59,6 +60,34 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 		dbInstances:       2,
 		pvPoolNumVolumes:  3,
 	},
+	nbv1.PerformanceProfileDevEnv: {
+		coreResources:     profileResources("500m", "500m", "1Gi", "1Gi"),
+		dbResources:       profileResources("1", "1", "2Gi", "2Gi"),
+		endpointResources: profileResources("500m", "500m", "500Mi", "500Mi"),
+		endpointMinCount:  1,
+		endpointMaxCount:  1,
+		dbInstances:       1,
+		pvPoolNumVolumes:  1,
+	},
+	nbv1.PerformanceProfileMiniEnv: {
+		coreResources: profileResources("100m", "100m", "1Gi", "1Gi"),
+		logResources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+		},
+		dbResources:       profileResources("100m", "100m", "500Mi", "500Mi"),
+		endpointResources: profileResources("100m", "100m", "500Mi", "500Mi"),
+		endpointMinCount:  1,
+		endpointMaxCount:  1,
+		dbInstances:       1,
+		pvPoolNumVolumes:  1,
+	},
 }
 
 func lookupProfile(nb *nbv1.NooBaa) performanceProfile {
@@ -77,6 +106,13 @@ func getCoreResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {
 		return *nb.Spec.CoreResources
 	}
 	return lookupProfile(nb).coreResources
+}
+
+func getLogResources(nb *nbv1.NooBaa) *corev1.ResourceRequirements {
+	if nb.Spec.LogResources != nil {
+		return nb.Spec.LogResources
+	}
+	return lookupProfile(nb).logResources
 }
 
 func getDBResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -783,8 +783,8 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 				c.Image = r.NooBaa.Status.ActualImage
 			}
 
-			if r.NooBaa.Spec.LogResources != nil {
-				c.Resources = *r.NooBaa.Spec.LogResources
+			if logResources := getLogResources(r.NooBaa); logResources != nil {
+				c.Resources = *logResources
 			} else {
 				var reqCPU, reqMem resource.Quantity
 				reqCPU, _ = resource.ParseQuantity("200m")

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -265,71 +265,10 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 		sys.Spec.PVPoolDefaultStorageClass = &sc
 	}
 	if options.MiniEnv {
-		coreResourceList := corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(100), resource.Milli),
-			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(1), resource.Giga),
-		}
-		logResourceList := corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(50), resource.Milli),
-			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(200), resource.Mega),
-		}
-		dbResourceList := corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(100), resource.Milli),
-			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(500), resource.Mega),
-		}
-		endpointResourceList := corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(100), resource.Milli),
-			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(500), resource.Mega),
-		}
-		sys.Spec.CoreResources = &corev1.ResourceRequirements{
-			Requests: coreResourceList,
-			Limits:   coreResourceList,
-		}
-		sys.Spec.LogResources = &corev1.ResourceRequirements{
-			Requests: logResourceList,
-			Limits:   logResourceList,
-		}
-		sys.Spec.DBResources = &corev1.ResourceRequirements{
-			Requests: dbResourceList,
-			Limits:   dbResourceList,
-		}
-		sys.Spec.Endpoints = &nbv1.EndpointsSpec{
-			MinCount: 1,
-			MaxCount: 1,
-			Resources: &corev1.ResourceRequirements{
-				Requests: endpointResourceList,
-				Limits:   endpointResourceList,
-			}}
+		sys.Spec.PerformanceProfile = nbv1.PerformanceProfileMiniEnv
 	}
 	if options.DevEnv {
-		coreResourceList := corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(500), resource.Milli),
-			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(1), resource.Giga),
-		}
-		dbResourceList := corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(1000), resource.Milli),
-			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(2), resource.Giga),
-		}
-		endpointResourceList := corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(500), resource.Milli),
-			corev1.ResourceMemory: *resource.NewScaledQuantity(int64(500), resource.Mega),
-		}
-		sys.Spec.CoreResources = &corev1.ResourceRequirements{
-			Requests: coreResourceList,
-			Limits:   coreResourceList,
-		}
-		sys.Spec.DBResources = &corev1.ResourceRequirements{
-			Requests: dbResourceList,
-			Limits:   dbResourceList,
-		}
-		sys.Spec.Endpoints = &nbv1.EndpointsSpec{
-			MinCount: 1,
-			MaxCount: 1,
-			Resources: &corev1.ResourceRequirements{
-				Requests: endpointResourceList,
-				Limits:   endpointResourceList,
-			},
-		}
+		sys.Spec.PerformanceProfile = nbv1.PerformanceProfileDevEnv
 	}
 	for _, componentName := range []string{"core", "db", "endpoints"} {
 		if viper.IsSet(fmt.Sprintf("resources.%s", componentName)) {


### PR DESCRIPTION
### Describe the Problem

The `--dev` and `--mini` CLI flags hardcoded resource values inline in
`system.go`, bypassing the performance profile system. This meant they
couldn't leverage profile-only settings like `pvPoolNumVolumes` and
`dbInstances`, and the resource definitions were duplicated outside the
centralized profile map.

### Explain the Changes
1. Added `dev-env` and `mini-env` performance profile types to `noobaa_types.go`
   with kubebuilder enum validation.
2. Added corresponding profile entries in `performance_profiles.go` with resource
   values matching the previous inline definitions (mini-env: minimal footprint
   with 100m CPU / 500Mi memory for most components; dev-env: moderate resources
   with 500m-1 CPU / 500Mi-2Gi memory). Both profiles set `dbInstances: 1` and
   `pvPoolNumVolumes: 1`.
3. Added a `logResources` field to the `performanceProfile` struct (as a pointer,
   only set by mini-env) and a `getLogResources()` accessor function.
4. Updated `phase2_creating.go` to use `getLogResources()` so the log-processor
   container picks up profile-defined log resources during reconciliation.
5. Replaced ~60 lines of inline resource construction in `system.go` with
   single-line `sys.Spec.PerformanceProfile` assignments.  
6. Change default CNPG image to `quay.io/rhceph-dev/odf4-odf-cloudnative-pg-rhel9-operator:v4.22` 
7. Added an option `--postgres-instances` to set the number of DB instances and changed the dev/mini envs to run with a single instance.

### Issues: Fixed #xxx / Gap #xxx
1.

### Testing Instructions:
1. Deploy with `noobaa install --mini` and verify core/db/endpoint pods use
   mini-env resource values (100m CPU, 500Mi-1Gi memory) and log-processor
   uses 50m CPU / 200Mi memory.
2. Deploy with `noobaa install --dev` and verify pods use dev-env resource
   values (500m-1 CPU, 500Mi-2Gi memory).
3. Deploy without flags and verify the default profile is applied unchanged.
4. Verify the default pv-pool backingstore is created with `NumVolumes: 1`
   when using `--mini` or `--dev`.
5. Verify that setting explicit resource overrides on the CR spec still takes
   precedence over the profile values.

- [ ] Doc added/updated
- [ ] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added two new performance profile options: `dev-env` and `mini-env`.
  * Updated the CRD and bundled deployment schema to accept the new profile values.

* **Improvements**
  * Enhanced log resource configuration for the log processor to follow the selected performance profile (or use explicitly provided log settings when set).
  * Updated mini/dev default resource sizing to follow the chosen performance profile automatically.

* **Updates**
  * Changed the default managed Postgres instance count to `1` and added a `--postgres-instances` CLI option.
  * Updated the default CloudNativePG operator image tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->