### PR TITLE
Fix cluster role for PV

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -24,9 +24,16 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - persistentvolumes
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
       - configmaps
       - secrets
-      - persistentvolumes
     verbs:
       - "*"
   - apiGroups:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -2,7 +2,7 @@ package bundle
 
 const Version = "5.23.0"
 
-const Sha256_deploy_cluster_role_yaml = "6417dcd3e52c38e04ba6b70b7e22985f0f7ddf1edec96287fcc0cb5f42b30c04"
+const Sha256_deploy_cluster_role_yaml = "9c0ac29295c67349acc345029b8b2e3de01a512d5dc92e31b17938b52f41c60d"
 
 const File_deploy_cluster_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30,9 +30,16 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - persistentvolumes
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
       - configmaps
       - secrets
-      - persistentvolumes
     verbs:
       - "*"
   - apiGroups:


### PR DESCRIPTION
### Describe the Problem
Currently noobaa operator asks for all the permissions over the PV resource while that is not necessarily needed.

### Explain the changes
This PR reduces the permissions to just `get`, `list`, and `watch`.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened access controls for persistent volumes to only allow viewing actions (get/list/watch) instead of broader permissions.
  * Kept config map and secret access unchanged, while separating their permissions from the persistent volume rule for clearer, safer scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->