### PR TITLE
Update Archive Policy of buckets via NB CLI and bucketclass reconciler

### DIFF
--- a/pkg/bucket/bucket.go
+++ b/pkg/bucket/bucket.go
@@ -5,14 +5,15 @@ import (
 	"os"
 	"strconv"
 
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bucketclass"
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/system"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Cmd returns a CLI command
@@ -58,6 +59,10 @@ func CmdUpdate() *cobra.Command {
 		"Set quota max objects quantity config to requested bucket")
 	cmd.Flags().String("max-size", "",
 		"Set quota max size config to requested bucket")
+	cmd.Flags().String("deep-archive-resource", "",
+		"Set or update the deep archive NamespaceStore resource for the bucket's archive policy")
+	cmd.Flags().Bool("remove-archive-policy", false,
+		"Remove the archive policy from the bucket")
 	return cmd
 }
 
@@ -151,17 +156,28 @@ func RunUpdate(cmd *cobra.Command, args []string) {
 	}
 	maxSize, _ := cmd.Flags().GetString("max-size")
 	maxObjects, _ := cmd.Flags().GetString("max-objects")
+	deepArchiveResource, _ := cmd.Flags().GetString("deep-archive-resource")
+	removeArchivePolicy, _ := cmd.Flags().GetBool("remove-archive-policy")
+
+	if deepArchiveResource != "" && removeArchivePolicy {
+		log.Fatalf(`❌ Cannot use both --deep-archive-resource and --remove-archive-policy`)
+	}
 
 	updateParams := nb.CreateBucketParams{
 		Name:         bucketName,
 		ForceMd5Etag: forceMd5EtagPtr,
 	}
 
-	if maxSize != "" || maxObjects != "" {
-		bucketInfo, err := nbClient.ReadBucketAPI(nb.ReadBucketParams{Name: bucketName})
+	needBucketRead := maxSize != "" || maxObjects != ""
+	var bucketInfo nb.BucketInfo
+	if needBucketRead {
+		bucketInfo, err = nbClient.ReadBucketAPI(nb.ReadBucketParams{Name: bucketName})
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf(`❌ Could not read bucket %q: %v`, bucketName, err)
 		}
+	}
+
+	if maxSize != "" || maxObjects != "" {
 		quota, err := mergeQuotaForUpdate(bucketInfo.Quota, bucketName, maxSize, maxObjects)
 		if err != nil {
 			log.Fatalf(`❌ Could not update bucket "%q" quota validation failed %q`, bucketName, err)
@@ -170,6 +186,30 @@ func RunUpdate(cmd *cobra.Command, args []string) {
 			log.Fatalf(`❌ Could not update bucket "%q" quota validation failed %v`, bucketName, err)
 		}
 		updateParams.Quota = &quota
+	}
+
+	if deepArchiveResource != "" {
+		ns := &nbv1.NamespaceStore{
+			TypeMeta:   metav1.TypeMeta{Kind: "NamespaceStore"},
+			ObjectMeta: metav1.ObjectMeta{Name: deepArchiveResource, Namespace: options.Namespace},
+		}
+		if !util.KubeCheck(ns) {
+			log.Fatalf(`❌ Could not update bucket %q archive policy: NamespaceStore %q not found in namespace %q`,
+				bucketName, deepArchiveResource, options.Namespace)
+		}
+		if !util.IsArchiveNamespaceStore(ns) {
+			log.Fatalf(`❌ Could not update bucket %q archive policy: NamespaceStore %q must have spec.archive=true`,
+				bucketName, deepArchiveResource)
+		}
+		updateParams.ArchivePolicy = &nb.ArchivePolicyConfig{
+			DeepArchiveResource: &nb.NamespaceResourceFullConfig{
+				Resource: deepArchiveResource,
+			},
+		}
+	}
+
+	if removeArchivePolicy {
+		updateParams.RemoveArchivePolicy = true
 	}
 
 	err = nbClient.UpdateBucketAPI(updateParams)
@@ -223,6 +263,12 @@ func RunStatus(cmd *cobra.Command, args []string) {
 	if b.PolicyModes != nil {
 		fmt.Printf("  %-22s : %s\n", "ResiliencyStatus", b.PolicyModes.ResiliencyStatus)
 		fmt.Printf("  %-22s : %s\n", "QuotaStatus", b.PolicyModes.QuotaStatus)
+	}
+	if b.ArchivePolicy != nil && b.ArchivePolicy.DeepArchiveResource != nil {
+		fmt.Printf("  %-22s : %s\n", "Archive Resource", b.ArchivePolicy.DeepArchiveResource.Resource)
+		if b.ArchivePolicy.DeepArchiveResource.Path != "" {
+			fmt.Printf("  %-22s : %s\n", "Archive Path", b.ArchivePolicy.DeepArchiveResource.Path)
+		}
 	}
 	if b.Undeletable != "" {
 		fmt.Printf("  %-22s : %s\n", "Undeletable", b.Undeletable)

--- a/pkg/bucket/bucket_test.go
+++ b/pkg/bucket/bucket_test.go
@@ -1,11 +1,67 @@
 package bucket
 
 import (
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("CmdUpdate", func() {
+	It("should register the deep-archive-resource flag", func() {
+		cmd := CmdUpdate()
+		f := cmd.Flags().Lookup("deep-archive-resource")
+		Expect(f).NotTo(BeNil())
+		Expect(f.DefValue).To(Equal(""))
+	})
+})
+
+var _ = Describe("IsArchiveNamespaceStore for deep archive update", func() {
+	It("should return true when archive is set", func() {
+		ns := &nbv1.NamespaceStore{
+			Spec: nbv1.NamespaceStoreSpec{
+				Type:    nbv1.NSStoreTypeS3Compatible,
+				Archive: true,
+			},
+		}
+		Expect(util.IsArchiveNamespaceStore(ns)).To(BeTrue())
+	})
+
+	It("should return false when archive is not set on s3-compatible store", func() {
+		ns := &nbv1.NamespaceStore{
+			Spec: nbv1.NamespaceStoreSpec{
+				Type:    nbv1.NSStoreTypeS3Compatible,
+				Archive: false,
+			},
+		}
+		Expect(util.IsArchiveNamespaceStore(ns)).To(BeFalse())
+	})
+
+	It("should return false when archive is not set on aws-s3 store", func() {
+		ns := &nbv1.NamespaceStore{
+			Spec: nbv1.NamespaceStoreSpec{
+				Type:    nbv1.NSStoreTypeAWSS3,
+				Archive: false,
+			},
+		}
+		Expect(util.IsArchiveNamespaceStore(ns)).To(BeFalse())
+	})
+
+	It("should return false when archive is set but type is not s3-compatible", func() {
+		ns := &nbv1.NamespaceStore{
+			Spec: nbv1.NamespaceStoreSpec{
+				Type:    nbv1.NSStoreTypeAWSS3,
+				Archive: true,
+			},
+		}
+		Expect(util.IsArchiveNamespaceStore(ns)).To(BeFalse())
+	})
+
+	It("should return false for a nil NamespaceStore", func() {
+		Expect(util.IsArchiveNamespaceStore(nil)).To(BeFalse())
+	})
+})
 
 var _ = Describe("mergeQuotaForUpdate", func() {
 	Context("when only max-objects is set and a size quota already exists", func() {

--- a/pkg/bucketclass/reconciler.go
+++ b/pkg/bucketclass/reconciler.go
@@ -2,6 +2,7 @@ package bucketclass
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -382,9 +383,65 @@ func (r *Reconciler) UpdateBucketClass(bucketNames []string) error {
 		}
 		util.KubeUpdate(r.BucketClass)
 		return util.NewPersistentError("InvalidConfReverting", fmt.Sprintf("Unable to change bucketclass due to error: %v", result.ErrorMessage))
-		// return fmt.Errorf("Failed to update bucket class %q with error: %v - Reverting back", r.BucketClass.Name, result.ErrorMessage)
+	}
+
+	if err := r.updateArchivePolicyForExistingBuckets(bucketNames); err != nil {
+		return err
 	}
 
 	log.Infof("✅ Successfully updated bucket class %q", r.BucketClass.Name)
 	return nil
+}
+
+// updateArchivePolicyForExistingBuckets applies the BucketClass archive policy to
+// existing buckets that do not yet have one. Per the update semantics:
+//   - Adding an archive policy to a BucketClass that had none affects existing buckets.
+//   - Changing or removing an existing archive policy only affects new OBCs.
+//
+// To distinguish these cases without access to the old BucketClass spec, we read each
+// bucket and only apply the archive policy when the bucket has no archive policy set.
+func (r *Reconciler) updateArchivePolicyForExistingBuckets(bucketNames []string) error {
+	if r.BucketClass.Spec.ArchivePolicy == nil {
+		return nil
+	}
+
+	log := r.Logger
+	archiveResource := r.BucketClass.Spec.ArchivePolicy.DeepArchiveResource
+	if archiveResource == "" {
+		return nil
+	}
+
+	var errs []error
+	for _, bucketName := range bucketNames {
+		bucketInfo, err := r.NBClient.ReadBucketAPI(nb.ReadBucketParams{Name: bucketName})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to read bucket %q for archive policy update: %w", bucketName, err))
+			continue
+		}
+
+		if bucketInfo.ArchivePolicy != nil {
+			log.Infof("Bucket %q already has an archive policy, skipping (change/removal only affects new OBCs)", bucketName)
+			continue
+		}
+
+		err = r.NBClient.UpdateBucketAPI(nb.CreateBucketParams{
+			Name: bucketName,
+			ArchivePolicy: &nb.ArchivePolicyConfig{
+				DeepArchiveResource: &nb.NamespaceResourceFullConfig{
+					Resource: archiveResource,
+				},
+			},
+		})
+		if err != nil {
+			var rpcErr *nb.RPCError
+			if errors.As(err, &rpcErr) && rpcErr.RPCCode == "BUCKET_HAS_ARCHIVED_OBJECTS" {
+				log.Warnf("Skipping archive policy for bucket %q: %s", bucketName, rpcErr.Message)
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to apply archive policy to bucket %q: %w", bucketName, err))
+			continue
+		}
+		log.Infof("✅ Applied archive policy to existing bucket %q", bucketName)
+	}
+	return errors.Join(errs...)
 }

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -341,13 +341,14 @@ type CreateSystemReply struct {
 
 // CreateBucketParams is the params of bucket_api.create_bucket() and bucket_api.update_bucket().
 type CreateBucketParams struct {
-	Name          string               `json:"name"`
-	Tiering       string               `json:"tiering,omitempty"`
-	ForceMd5Etag  *bool                `json:"force_md5_etag,omitempty"`
-	BucketClaim   *BucketClaimInfo     `json:"bucket_claim,omitempty"`
-	Namespace     *NamespaceBucketInfo `json:"namespace,omitempty"`
-	Quota         *QuotaConfig         `json:"quota,omitempty"`
-	ArchivePolicy *ArchivePolicyConfig `json:"archive_policy,omitempty"`
+	Name                string               `json:"name"`
+	Tiering             string               `json:"tiering,omitempty"`
+	ForceMd5Etag        *bool                `json:"force_md5_etag,omitempty"`
+	BucketClaim         *BucketClaimInfo     `json:"bucket_claim,omitempty"`
+	Namespace           *NamespaceBucketInfo `json:"namespace,omitempty"`
+	Quota               *QuotaConfig         `json:"quota,omitempty"`
+	ArchivePolicy       *ArchivePolicyConfig `json:"archive_policy,omitempty"`
+	RemoveArchivePolicy bool                 `json:"remove_archive_policy,omitempty"`
 }
 
 // QuotaConfig quota configuration

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1689,7 +1689,7 @@ func GetAWSRegion() (string, error) {
 
 // IsArchiveNamespaceStore returns true when the store is configured for archive (cold storage) use.
 func IsArchiveNamespaceStore(ns *nbv1.NamespaceStore) bool {
-	return ns != nil && ns.Spec.Archive
+	return ns != nil && ns.Spec.Type == nbv1.NSStoreTypeS3Compatible && ns.Spec.Archive
 }
 
 // IsValidS3BucketName checks the name according to


### PR DESCRIPTION
### Describe the Problem

### Explain the changes
1. Added to `nb bucket update` an option to update/remove archive policy that calls update_bucket api.
2. Added changes to bucketclass reconciler for updating archive policy.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added deep-archive policy updates to bucket updates via `--deep-archive-resource`.
  * Added `--remove-archive-policy` to explicitly remove an archive policy.
  * `bucket status` now shows deep-archive archive resource/path details when configured.
  * BucketClass reconciliation now applies deep-archive policy to existing buckets that don’t have one yet.
* **Bug Fixes**
  * Deep-archive setup now validates archive-enabled S3-compatible namespace stores only.
  * Rejects using deep-archive setup and archive-policy removal flags together.
* **Tests**
  * Added coverage for new flags and deep-archive eligibility/update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->