### PR TITLE
GCP WIF (STS) | Add Examples in Docs

### DIFF
--- a/doc/backing-store-crd.md
+++ b/doc/backing-store-crd.md
@@ -350,6 +350,52 @@ spec:
 type: azure-blob
 ```
 
+### GCP
+```shell
+noobaa backingstore create google-cloud-storage gcp-bs --target-bucket personal-bucket --private-key-json-file '/example/path'
+```
+```yaml
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  finalizers:
+  - noobaa.io/finalizer
+  labels:
+    app: noobaa
+  name: gcp-bs
+  namespace: app-namespace
+spec:
+  googleCloudStorage:
+    secret:
+      name: backing-store-google-cloud-storage-gcp-bs
+      namespace: secret-namespace
+    targetBucket: personal-bucket
+  type: google-cloud-storage
+```
+
+### GCP WIF (STS)
+```shell
+noobaa backingstore create google-cloud-storage-sts gcp-bs-sts --project-number='123456789' --pool-id='my-pool' --provider-id='my-provider' --service-account-email='noobaa-wif-sa@my-project.iam.gserviceaccount.com' --target-bucket personal-bucket
+```
+```yaml
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  finalizers:
+  - noobaa.io/finalizer
+  labels:
+    app: noobaa
+  name: gcp-bs-sts
+  namespace: app-namespace
+spec:
+  googleCloudStorage:
+    secret:
+      name: backing-store-google-cloud-storage-gcp-bs-sts
+      namespace: secret-namespace
+    targetBucket: personal-bucket
+  type: google-cloud-storage
+```
+
 ### Persistent Volume Pool
 ```shell
 noobaa backingstore create pv-pool pv-backingstore --num-volumes 3 --pv-size-gb 17 --storage-class local-path


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661)

### Explain the changes
1. Added examples for GCP and GCP WIF (STS) in the docs in `doc/backing-store-crd.md`.

### Issues: 
1. It was a comment that was raised by CodeRabbit ([link](https://github.com/noobaa/noobaa-operator/pull/1931#pullrequestreview-4444525762)).

### Testing Instructions:
1. none

- [X] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new BackingStore example subsections for **Google Cloud Storage** and **Google Cloud Storage with Workload Identity Federation (GCP WIF/STS)**.
  * Included corresponding `noobaa backingstore create` CLI commands and sample BackingStore CR YAMLs.
  * Expanded examples with bucket target configuration and explicit secret references, plus WIF/STS flags where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->