### PR TITLE
GCP WIF (STS) | Namespacestore CLI (Hidden)

### DIFF
--- a/pkg/namespacestore/namespacestore.go
+++ b/pkg/namespacestore/namespacestore.go
@@ -59,6 +59,7 @@ func CmdCreate() *cobra.Command {
 		CmdCreateAWSS3(),
 		CmdCreateAWSSTSS3(),
 		CmdCreateGoogleCloudStorage(),
+		CmdCreateGoogleCloudStorageSTS(),
 		CmdCreateS3Compatible(),
 		CmdCreateIBMCos(),
 		CmdCreateAzureBlob(),
@@ -143,6 +144,41 @@ func CmdCreateGoogleCloudStorage() *cobra.Command {
 	cmd.Flags().String(
 		"secret-name", "",
 		`The name of a secret for authentication - should have `+util.GoogleServiceAccountPrivateKeyJson+` property`,
+	)
+	return cmd
+}
+
+// CmdCreateGoogleCloudStorageSTS returns a CLI command
+func CmdCreateGoogleCloudStorageSTS() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true, //TODO: remove once we want to expose it.
+		Use:    "google-cloud-storage-sts <namespace-store-name>",
+		Short:  "Create google-cloud-storage namespace store using GCP WIF (STS, short-lived credentials)",
+		Run:    RunCreateGoogleCloudStorageSTS,
+	}
+	cmd.Flags().String(
+		"target-bucket", "",
+		"The target bucket name on Google cloud storage",
+	)
+	cmd.Flags().String(
+		"service-account-email", "",
+		"The GCP service account email to impersonate",
+	)
+	cmd.Flags().String(
+		"project-number", "",
+		"The GCP project number (numeric string, e.g. 123456789; not the project ID)",
+	)
+	cmd.Flags().String(
+		"pool-id", "",
+		"The GCP workload identity pool ID",
+	)
+	cmd.Flags().String(
+		"provider-id", "",
+		"The GCP workload identity provider ID",
+	)
+	cmd.Flags().String(
+		"secret-name", "",
+		`The name of a secret for authentication - should have `+util.GoogleCredentialsJson+` property (external_account JSON)`,
 	)
 	return cmd
 }
@@ -586,6 +622,42 @@ func RunCreateGoogleCloudStorage(cmd *cobra.Command, args []string) {
 		} else {
 			util.VerifyCredsInSecret(secretName, options.Namespace, mandatoryProperties)
 			util.VerifyGoogleCredentialsJSONTypeInSecret(secretName, options.Namespace, false)
+			secret.Name = secretName
+			secret.Namespace = options.Namespace
+		}
+
+		namespaceStore.Spec.GoogleCloudStorage = &nbv1.GoogleCloudStorageSpec{
+			TargetBucket: targetBucket,
+			Secret: corev1.SecretReference{
+				Name:      secret.Name,
+				Namespace: secret.Namespace,
+			},
+		}
+	})
+}
+
+// RunCreateGoogleCloudStorageSTS runs a CLI command
+func RunCreateGoogleCloudStorageSTS(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+	createCommon(cmd, args, nbv1.NSStoreTypeGoogleCloudStorage, func(namespaceStore *nbv1.NamespaceStore, secret *corev1.Secret) {
+		targetBucket := util.GetFlagStringOrPrompt(cmd, "target-bucket")
+		secretName, _ := cmd.Flags().GetString("secret-name")
+		mandatoryProperties := []string{util.GoogleCredentialsJson}
+
+		if secretName == "" {
+			projectNumber := util.GetFlagStringOrPrompt(cmd, "project-number")
+			poolID := util.GetFlagStringOrPrompt(cmd, "pool-id")
+			providerID := util.GetFlagStringOrPrompt(cmd, "provider-id")
+			serviceAccountEmail := util.GetFlagStringOrPrompt(cmd, "service-account-email")
+			credentialsJSON, err := util.BuildGoogleWIFCredentialsJSON(projectNumber,
+				poolID, providerID, serviceAccountEmail)
+			if err != nil {
+				log.Fatalf("Failed to build GCP WIF credentials: %v", err)
+			}
+			secret.StringData[util.GoogleCredentialsJson] = credentialsJSON
+		} else {
+			util.VerifyCredsInSecret(secretName, options.Namespace, mandatoryProperties)
+			util.VerifyGoogleCredentialsJSONTypeInSecret(secretName, options.Namespace, true)
 			secret.Name = secretName
 			secret.Namespace = options.Namespace
 		}


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661)

### Explain the changes
1. Add a hidden CLI command in the code as we have for `google-cloud-storage` for `google-cloud-storage-sts`.

### Issues:
1. none

### Testing Instructions:
1. Deploy NooBaa on Minikube after adding GCP WIF configurations - see guide "Create GCP WIF (STS) Setup On Minikube With NooBaa" ([link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_gcp_wif_setup_on_minikube_with_noobaa.md)).
2. Change the line: `Hidden: true` to be `false`, and then run `make cli DOCKER_DEFAULT_PLATFORM=linux/arm64 GOARCH=arm64`.
3. Create a namespacestore using the CLI (expect the namespacestore to be `Ready`): `nb namespacestore create google-cloud-storage-sts shira-ns-gcp-sts -n test1 --project-number='<project-number>' --pool-id='<pool-id>' --provider-id='<provider-id>' --service-account-email='<service-account-email>'`

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hidden `create` option for creating Google Cloud Storage namespace stores using Workload Identity Federation.
  * Supports specifying the target bucket plus required GCP workload identity inputs (service account email, project number, pool ID, provider ID) and an optional credentials secret name.
  * If no secret is provided, the command can generate and store the required credentials automatically.
  * Validates that any provided secret contains credentials in the expected Workload Identity format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->