### PR TITLE
CLI | Remove Printed Log in `bucketclass` CLI

### DIFF
--- a/pkg/validations/bucketclass_validation.go
+++ b/pkg/validations/bucketclass_validation.go
@@ -225,7 +225,6 @@ func ValidateNamespacePolicy(namespacePolicy *nbv1.NamespacePolicy, namespace st
 // store exists, is ready, and is of a supported type.
 func ValidateVectorPolicy(vectorPolicy *nbv1.VectorPolicy, placementPolicy *nbv1.PlacementPolicy, namespacePolicy *nbv1.NamespacePolicy, namespace string) error {
 	log := util.Logger()
-	log.Infof("validating vector policy %+v", vectorPolicy)
 	if vectorPolicy == nil {
 		return nil
 	}


### PR DESCRIPTION
### Describe the Problem
Noticed a printed log and suggested removing the printed log line.

### Explain the changes
1. Remove the printed log `validating vector policy` as it is also printed as part of the bucketclass CLI command.

### Issues: 
1. Before the change:
`nb bucketclass create placement-bucketclass bc-shira --backingstores=shira-gcp-sts -n test1`
```
INFO[0000] ✅ Exists: NooBaa "noobaa"
INFO[0000] validating vector policy <nil>
INFO[0000] ✅ Exists: BackingStore "shira-gcp-sts"
INFO[0000] ✅ Created: BucketClass "bc-shira"
```
Notice the line: `validating vector policy <nil>`

### Testing Instructions:
Deploy NooBaa on local cluster -> Create backingstore -> Create bucketclass - expect not to see the line "validating vector policy" as part of the output.

Attaching the steps that I run during validation:
1. Deploy NooBaa on Minikube after adding GCP WIF configurations - see guide "Create GCP WIF (STS) Setup On Minikube With NooBaa" ([link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_gcp_wif_setup_on_minikube_with_noobaa.md)).
2. Create GCP WIF (STS) backing using the CLI `nooba backingstore create google-cloud-storage-sts shira-gcp-sts -n test1`
3. Create Bucketclass: `nb bucketclass create placement-bucketclass bc-shira --backingstores=shira-gcp-sts -n test1`

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary informational logging during bucket class validation, keeping the same validation behavior and error responses unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->