### PR TITLE
Update ContainerImageTag to master-20260630

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20260603"
+	ContainerImageTag = "master-20260630"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions


### PR DESCRIPTION
Automated update of ContainerImageTag to master-20260630 in options.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default NooBaa container image tag to a newer release, so new deployments now use the latest default image.
  * The computed default image reference now points to the updated tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->