### PR TITLE
Add endpointslices get/list/watch permissions to cnpg manager cluster role

### DIFF
--- a/pkg/cnpg/cnpg.go
+++ b/pkg/cnpg/cnpg.go
@@ -251,6 +251,18 @@ func LoadCnpgResources() (*CnpgResources, error) {
 	return cnpgRes, nil
 }
 
+// cnpgExtraRules returns additional RBAC rules required by the CNPG controller
+// binary that are not present in the embedded operator manifest YAML.
+func cnpgExtraRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"discovery.k8s.io"},
+			Resources: []string{"endpointslices"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+}
+
 // modifyCnpgRbac modifies the RBAC resources for CloudNativePG operator
 func modifyCnpgRbac(cnpgRes *CnpgResources) {
 
@@ -266,8 +278,9 @@ func modifyCnpgRbac(cnpgRes *CnpgResources) {
 			Name:      cnpgManagerRoleName,
 			Namespace: options.Namespace,
 		},
-		// we copy the rules from the cluster role
-		Rules: cnpgRes.CnpgManagerClusterRole.Rules,
+		// we copy the rules from the cluster role and add any extra rules
+		// that the CNPG controller needs but are not in the embedded manifest
+		Rules: append(cnpgRes.CnpgManagerClusterRole.Rules, cnpgExtraRules()...),
 	}
 
 	// add role binding for the role


### PR DESCRIPTION
### Describe the Problem
noobaa won't come up due to missing permissions.
```
.2/tools/cache/reflector.go:227\nk8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:430\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.DelayFunc.Until\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/delay.go:39\nk8s.io/client-go/tools/cache.(*Reflector).RunWithContext\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:428\nk8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/wait.go:63\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/wait.go:72"}
{"level":"error","ts":"2026-07-01T08:31:02.522364576Z","logger":"controller-runtime.cache.UnhandledError","msg":"Failed to watch","reflector":"pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:343","type":"*v1.EndpointSlice","error":"failed to list *v1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User \"system:serviceaccount:default:cnpg-manager\" cannot list resource \"endpointslices\" in API group \"discovery.k8s.io\" in the namespace \"default\"","stacktrace":"k8s.io/apimachinery/pkg/util/runtime.logError\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/runtime/runtime.go:252\nk8s.io/apimachinery/pkg/util/runtime.handleError\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/runtime/runtime.go:243\nk8s.io/apimachinery/pkg/util/runtime.HandleErrorWithContext\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/runtime/runtime.go:229\nk8s.io/client-go/tools/cache.DefaultWatchErrorHandler\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:227\nk8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:430\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.DelayFunc.Until\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/delay.go:39\nk8s.io/client-go/tools/cache.(*Reflector).RunWithContext\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:428\nk8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/wait.go:63\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/wait.go:72"}
{"level":"error","ts":"2026-07-01T08:31:32.140772798Z","logger":"controller-runtime.cache.UnhandledError","msg":"Failed to watch","reflector":"pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:343","type":"*v1.EndpointSlice","error":"failed to list *v1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User \"system:serviceaccount:default:cnpg-manager\" cannot list resource \"endpointslices\" in API group \"discovery.k8s.io\" in the namespace \"default\"","stacktrace":"k8s.io/apimachinery/pkg/util/runtime.logError\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/runtime/runtime.go:252\nk8s.io/apimachinery/pkg/util/runtime.handleError\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/runtime/runtime.go:243\nk8s.io/apimachinery/pkg/util/runtime.HandleErrorWithContext\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/runtime/runtime.go:229\nk8s.io/client-go/tools/cache.DefaultWatchErrorHandler\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:227\nk8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:430\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.DelayFunc.Until\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/delay.go:39\nk8s.io/client-go/tools/cache.(*Reflector).RunWithContext\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:428\nk8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/wait.go:63\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.36.2/pkg/util/wait/wait.go:72"}
```
### Explain the changes
1. Added endpointslice get/list/watch permissions to cnpg manager cluster role.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated permissions so the controller can read and monitor endpoint slices, improving service discovery and cluster connectivity in CloudNativePG-managed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->