### PR TITLE
SCC | Add noobaa-agent SCC

### DIFF
--- a/deploy/internal/pod-agent.yaml
+++ b/deploy/internal/pod-agent.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   labels:
     app: noobaa
+  annotations:
+    openshift.io/required-scc: noobaa-agent
   name: noobaa-agent
 spec:
   containers:
@@ -42,6 +44,7 @@ spec:
         runAsNonRoot: true
         allowPrivilegeEscalation: false
   automountServiceAccountToken: false
+  serviceAccountName: noobaa-core
   securityContext:
     runAsUser: 10001
     runAsGroup: 0

--- a/deploy/role_core.yaml
+++ b/deploy/role_core.yaml
@@ -41,6 +41,7 @@ rules:
   - security.openshift.io
   resourceNames:
   - noobaa-core
+  - noobaa-agent
   resources:
   - securitycontextconstraints
   verbs:

--- a/deploy/scc_agent.yaml
+++ b/deploy/scc_agent.yaml
@@ -1,0 +1,25 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: noobaa-agent
+allowPrivilegeEscalation: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+fsGroup:
+  type: MustRunAs
+  ranges:
+  - min: 0
+    max: 0
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4885,13 +4885,15 @@ spec:
       storage: 30Gi
 `
 
-const Sha256_deploy_internal_pod_agent_yaml = "74237f435120c893cd8e349e9ac685dd1c884e121c018f46e48228f845a51093"
+const Sha256_deploy_internal_pod_agent_yaml = "46429d12f4a438f4d3666737cd214c5c8bc2d07acf467e7b9a22439c9cc00fc6"
 
 const File_deploy_internal_pod_agent_yaml = `apiVersion: v1
 kind: Pod
 metadata:
   labels:
     app: noobaa
+  annotations:
+    openshift.io/required-scc: noobaa-agent
   name: noobaa-agent
 spec:
   containers:
@@ -4931,6 +4933,7 @@ spec:
         runAsNonRoot: true
         allowPrivilegeEscalation: false
   automountServiceAccountToken: false
+  serviceAccountName: noobaa-core
   securityContext:
     runAsUser: 10001
     runAsGroup: 0
@@ -7127,7 +7130,7 @@ subjects:
   name: custom-metrics-prometheus-adapter
 `
 
-const Sha256_deploy_role_core_yaml = "1ec420603dcec64b247852d106535a85a1a866129f78f790c2e5c9285f029ae7"
+const Sha256_deploy_role_core_yaml = "92e0178504b6d3ff202db026efe38de5cac63d29751b5e488842aa5326f36156"
 
 const File_deploy_role_core_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7172,6 +7175,7 @@ rules:
   - security.openshift.io
   resourceNames:
   - noobaa-core
+  - noobaa-agent
   resources:
   - securitycontextconstraints
   verbs:
@@ -7333,6 +7337,35 @@ seLinuxContext:
 supplementalGroups:
   type: RunAsAny
 readOnlyRootFilesystem: true
+`
+
+const Sha256_deploy_scc_agent_yaml = "17f8e599442503e38885b1c1a1bb2b615d8f93d1e12d5b0d9e2c190d0129be37"
+
+const File_deploy_scc_agent_yaml = `apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: noobaa-agent
+allowPrivilegeEscalation: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+fsGroup:
+  type: MustRunAs
+  ranges:
+  - min: 0
+    max: 0
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
 `
 
 const Sha256_deploy_scc_core_yaml = "dd3fb26a323dddbbb9f399b8ff86c41dbbfe63b3bbb0cfe79b785c68948063a8"

--- a/pkg/diagnostics/collect.go
+++ b/pkg/diagnostics/collect.go
@@ -188,7 +188,7 @@ func (c *Collector) CollectPVCs(listOptions client.ListOptions) {
 // CollectSCC collects the SCC
 func (c *Collector) CollectSCC() {
 	c.log.Println("Collecting SCC logs")
-	for _, name := range []string{"noobaa", "noobaa-endpoint"} {
+	for _, name := range []string{"noobaa", "noobaa-endpoint", "noobaa-agent"} {
 		scc := &secv1.SecurityContextConstraints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -198,6 +198,7 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 	}
 
 	util.KubeCreateOptional(util.KubeObject(bundle.File_deploy_scc_core_yaml).(*secv1.SecurityContextConstraints))
+	util.KubeCreateOptional(util.KubeObject(bundle.File_deploy_scc_agent_yaml).(*secv1.SecurityContextConstraints))
 	if err := r.ReconcileObject(r.ServiceMgmt, r.SetDesiredServiceMgmt); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Describe the Problem
Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) Enforce least-privileged Security Context Constraint (SCC) across ODF pods.

### Explain the changes
1. Pod Template (added to metadata.annotations since it is pod level)
deploy/internal/pod-agent.yaml (noobaa-agent Pod template): Add `openshift.io/required-scc: noobaa-agent`.
2. Added `serviceAccountName: noobaa-core` in `deploy/internal/pod-agent.yaml` (addressing this [comment](https://github.com/noobaa/noobaa-operator/pull/1965#discussion_r3453489230)).
3. Add the `noobaa-agent` to the `resourceNames` in the `deploy/role_core.yaml` since we use the service account of `noobaa-core` in the agent pod.
4. Created the `deploy/scc_agent.yaml` (new SCC) - it is based on noobaa-core SCC (`deploy/scc_core.yaml`) with additional `fsGroup`, since the agent-pod is using this SCC and it runs as root:
https://github.com/noobaa/noobaa-operator/blob/0926312a71bb9b22d4283332fb91592f752b5526/deploy/internal/pod-agent.yaml#L45-L49
(without this, there is an error: "...is forbidden: unable to validate against any security context constraint: provider noobaa-core: .spec.securityContext.fsGroup: Invalid value: [0]: 0 is not an allowed group").
5. Go Code Reconcilers: `pkg/system/phase2_creating.go`: under `ReconcilePhaseCreatingForMainClusters`  create the agent SCC (was needed near the noobaa-core SCC).
6. Add `noobaa-agent` to `CollectSCC`.

### Issues:
1. none

### Testing Instructions:
#### Manual Testing
##### Local Cluster:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
2. The system should be in `Ready` phase, in this case the default backingstore type is `pv-pool` so we have pods for this.
3. Check that you can see the annotation using the following examples:
- ` kubectl get pods -n test1 noobaa-default-backing-store-noobaa-pod-055b2529 -o yaml | grep scc`
(output is `openshift.io/required-scc: noobaa-agent`).

##### OCP Cluster:
Instructions are in the [commit](https://github.com/noobaa/noobaa-operator/pull/2000#issuecomment-4885611513).

- [ ] Doc added/updated
- [ ] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated OpenShift SecurityContextConstraints (SCC) for the agent pod.
* **Bug Fixes**
  * Updated the agent pod security settings to use the intended service account and SCC requirement.
  * Expanded RBAC permissions so the core role can use the new agent SCC.
  * Improved the operator’s “Creating” phase to ensure the agent SCC is established before continuing.
  * Enhanced SCC diagnostics to include the new agent SCC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->