### PR TITLE
Fix - use scheme with `https` (not `HTTPS`)

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -1781,7 +1781,7 @@ func (r *Reconciler) setDesiredServiceMonitorS3() error {
 // setServiceMonitorEndpointsToHTTPS updates all endpoints to use the given HTTPS
 // port name and sets the scheme to "https", ensuring upgrades from HTTP work correctly.
 func (r *Reconciler) setServiceMonitorEndpointsToHTTPS(endpoints []monitoringv1.Endpoint, portName string) {
-	schemeHTTPS := monitoringv1.SchemeHTTPS
+	schemeHTTPS := monitoringv1.Scheme("https")
 	for i := range endpoints {
 		endpoints[i].Port = portName
 		endpoints[i].Scheme = &schemeHTTPS


### PR DESCRIPTION
### Describe the Problem
After I had issues on my machine and created a new cluster in a new namespace I noticed that I couldn't install noobaa system - it was stuck in configuring.

### Explain the changes
1. Use `https` instead of `HTTPS` in the endpoint's schema.

### Issues: Fixed #xxx / Gap #xxx
1. Currently, I couldn't install NooBaa, I saw in the operator logs:
```
time="2026-07-02T11:25:33Z" level=error msg="ReconcileObject: Error ServiceMonitor  ServiceMonitor.monitoring.coreos.com \"noobaa-mgmt-service-monitor\" is invalid: [spec.endpoints[0].scheme: Unsupported value: \"HTTPS\": supported values: \"http\", \"https\", spec.endpoints[1].scheme: Unsupported value: \"HTTPS\": supported values: \"http\", \"https\", spec.endpoints[2].scheme: Unsupported value: \"HTTPS\": supported values: \"http\", \"https\"]" sys=test1/noobaa
time="2026-07-02T11:25:33Z" level=info msg="SetPhase: temporary error during phase \"Configuring\"" sys=test1/noobaa
```
2. I run: `oc explain servicemonitor.spec.endpoints.scheme`
```
GROUP:      monitoring.coreos.com
KIND:       ServiceMonitor
VERSION:    v1

FIELD: scheme <string>
ENUM:
    http
    https

DESCRIPTION:
    HTTP scheme to use for scraping. `http` and `https` are the expected values
    unless you rewrite the `__scheme__` label via relabeling. If empty,
    Prometheus uses the default value `http`.
```


### Testing Instructions:
1. Deploy NooBaa system before the change on a new cluster (use `nb uninstall --cleanup -n test1` and ensure that the namespace was deleted, or you created a new namespace (see this guide - [link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
2. Build the image with the change and delete the operator pod - noobaa should be Ready.

- [ ] Doc added/updated
- [ ] Tests added
