### PR TITLE
[Backport to 5.20] revert to cnpg 1.29.1 and patch cnpg cluster role

### DIFF
--- a/pkg/cnpg/cnpg.go
+++ b/pkg/cnpg/cnpg.go
@@ -251,6 +251,18 @@ func LoadCnpgResources() (*CnpgResources, error) {
 	return cnpgRes, nil
 }
 
+// cnpgExtraRules returns additional RBAC rules required by the CNPG controller
+// binary that are not present in the embedded operator manifest YAML.
+func cnpgExtraRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"discovery.k8s.io"},
+			Resources: []string{"endpointslices"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+}
+
 // modifyCnpgRbac modifies the RBAC resources for CloudNativePG operator
 func modifyCnpgRbac(cnpgRes *CnpgResources) {
 
@@ -266,8 +278,9 @@ func modifyCnpgRbac(cnpgRes *CnpgResources) {
 			Name:      cnpgManagerRoleName,
 			Namespace: options.Namespace,
 		},
-		// we copy the rules from the cluster role
-		Rules: cnpgRes.CnpgManagerClusterRole.Rules,
+		// we copy the rules from the cluster role and add any extra rules
+		// that the CNPG controller needs but are not in the embedded manifest
+		Rules: append(cnpgRes.CnpgManagerClusterRole.Rules, cnpgExtraRules()...),
 	}
 
 	// add role binding for the role

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -177,7 +177,7 @@ var PrometheusNamespace = ""
 var AWSSTSARN = ""
 
 // CnpgVersion is the version of cloudnative-pg operator to use
-var CnpgVersion = "1.27.0"
+var CnpgVersion = "1.29.1"
 
 // CnpgImage is the container image url of cloudnative-pg operator
 var CnpgImage = "quay.io/noobaa/cloudnative-pg-noobaa:v1.25.0"


### PR DESCRIPTION
(cherry picked from commit c220cec723f7e7bb243f8f09ce82cd9ef50dd3a5) (cherry picked from commit 5d5df923beccbb72251925ab0e13d20d3bb87d07)

### Describe the Problem
- cnpg 1.29.2 require go 1.26.4 which is not supported d/s. reverting back to 1.29.1
- patching missing rules in the cnpg cluster role on noobaa-operator side.
- changed CnpgVersion to 1.29.1

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added
