### PR TITLE
IAM | Fix Port Number Printed in `noobaa status` Command (`iam-https`)

### DIFF
--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -12,6 +12,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -88,10 +89,15 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 					)
 				}
 				if pod.Status.PodIP != "" {
-					status.PodPorts = append(
-						status.PodPorts,
-						util.GetFormattedEndpoint(proto, pod.Status.PodIP, servicePort.TargetPort.IntVal),
-					)
+					portNumber, ok := podTargetPortNumber(&pod, servicePort.TargetPort)
+					if ok {
+						status.PodPorts = append(
+							status.PodPorts,
+							util.GetFormattedEndpoint(proto, pod.Status.PodIP, portNumber),
+						)
+					} else {
+						log.Warnf("Could not resolve target port %q for pod %s", servicePort.TargetPort.String(), pod.Name)
+					}
 				}
 			}
 		}
@@ -174,4 +180,19 @@ func (r *Reconciler) InitNBClient() error {
 	// even when auth_token is empty.
 	_, err := r.NBClient.ReadAuthAPI()
 	return err
+}
+
+// podTargetPortNumber resolves a service targetPort to the numeric container port on a pod.
+func podTargetPortNumber(pod *corev1.Pod, targetPort intstr.IntOrString) (int32, bool) {
+	if targetPort.Type == intstr.Int {
+		return targetPort.IntVal, true
+	}
+	for i := range pod.Spec.Containers {
+		for _, port := range pod.Spec.Containers[i].Ports {
+			if port.Name == targetPort.StrVal {
+				return port.ContainerPort, true
+			}
+		}
+	}
+	return 0, false
 }

--- a/pkg/system/phase3_connecting_test.go
+++ b/pkg/system/phase3_connecting_test.go
@@ -1,0 +1,82 @@
+package system
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestPodTargetPortNumber(t *testing.T) {
+	tests := []struct {
+		name       string
+		pod        corev1.Pod
+		targetPort intstr.IntOrString
+		expected   int32
+		expectedOK bool
+	}{
+		{
+			name:       "numeric targetPort",
+			pod:        corev1.Pod{},
+			targetPort: intstr.FromInt32(6443),
+			expected:   6443,
+			expectedOK: true,
+		},
+		{
+			name: "named port on main container",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{{
+							Name:          "iam-https",
+							ContainerPort: 13443,
+						}},
+					}},
+				},
+			},
+			targetPort: intstr.FromString("iam-https"),
+			expected:   13443,
+			expectedOK: true,
+		},
+		{
+			name: "named port not found",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{{
+							Name:          "s3-https",
+							ContainerPort: 6443,
+						}},
+					}},
+				},
+			},
+			targetPort: intstr.FromString("iam-https"),
+			expectedOK: false,
+		},
+		{
+			name: "named port on second container",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Ports: []corev1.ContainerPort{{Name: "s3-https", ContainerPort: 6443}}},
+						{Ports: []corev1.ContainerPort{{Name: "iam-https", ContainerPort: 13443}}},
+					},
+				},
+			},
+			targetPort: intstr.FromString("iam-https"),
+			expected:   13443,
+			expectedOK: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := podTargetPortNumber(&tt.pod, tt.targetPort)
+			if ok != tt.expectedOK {
+				t.Errorf("podTargetPortNumber() ok = %v, expected %v", ok, tt.expectedOK)
+			}
+			if got != tt.expected {
+				t.Errorf("podTargetPortNumber() = %d, expected %d", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Describe the Problem
Currently, when using `noobaa status` command, it prints services and additional information, in the IAM service, in `NodePorts` value, the port that was printed is `iam-https` instead of the actual number. 

### Explain the changes
1. Add a helper function, in case the target port is not a number, to loop and find the port number.
2. Add unit tests (AI generated) for the new helper function.

### Issues:
1. Before the fix (using local cluster):
See the `PodPorts    : [https://10.42.0.47/:iam-https]` instead of a port number we see a string `iam-https`.

```
#-----------------#
#- IAM Addresses -#
#-----------------#

ExternalDNS : []
ExternalIP  : []
NodePorts   : [https://192.168.5.15:32558/]
InternalDNS : [[https://iam.test1.svc:443](https://iam.test1.svc/)]
InternalIP  : [[https://10.43.134.118:443](https://10.43.134.118/)]
PodPorts    : [https://10.42.0.47/:iam-https]
```

2. After PR #2013 was merged, it showed it as 0: 
See the `PodPorts    : [https://10.42.0.81:0/]`)
```
#-----------------#
#- IAM Addresses -#
#-----------------#

ExternalDNS : []
ExternalIP  : []
NodePorts   : [https://192.168.5.15:30523/]
InternalDNS : [[https://iam.test1.svc:443](https://iam.test1.svc/)]
InternalIP  : [[https://10.43.241.66:443](https://10.43.241.66/)]
PodPorts    : [https://10.42.0.81:0/]
```

#3. After the fix:

```
#-----------------#
#- IAM Addresses -#
#-----------------#

ExternalDNS : []
ExternalIP  : []
NodePorts   : [https://192.168.5.15:32558/]
InternalDNS : [[https://iam.test1.svc:443](https://iam.test1.svc/)]
InternalIP  : [[https://10.43.134.118:443](https://10.43.134.118/)]
PodPorts    : [https://10.42.0.47:13443/]
```

### Testing Instructions:
#### Unit Test:
Please run: `go test ./pkg/system/ -run TestPodTargetPortNumber -v`

#### Manul Test
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Run the command: `nb status -n <namespace>` and verify the port number in `PodPorts` in the IAM addresses section.

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Kubernetes service endpoint resolution when `targetPort` is set to a named port, ensuring pod container ports map correctly.
  * Added warning behavior when a named target port can’t be resolved, preventing incorrect endpoint entries.
* **Tests**
  * Added unit tests covering numeric `targetPort` mapping, named target-port resolution, and behavior when the named port is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->