### PR TITLE
Add operator set-log-level CLI command

### DIFF
--- a/doc/operator-log-level.md
+++ b/doc/operator-log-level.md
@@ -63,35 +63,22 @@ kubectl patch configmap noobaa-config -n <namespace> \
   -p '{"data":{"OPERATOR_LOG_LEVEL":"info"}}'
 ```
 
+Or use the CLI:
+
+```bash
+nb operator set-log-level debug -n <namespace>
+```
+
 The operator picks up the change on the next reconcile cycle (no restart needed).
 Core and endpoint pods are **not** affected.
 
 ### Example Output
 
-**Before the change** (`OPERATOR_LOG_LEVEL` = `info`, Update events logged at Info):
+```bash
+nb operator set-log-level debug -n test1
 
-```
-time="2025-10-10T13:20:54Z" level=info msg="Update event detected for noobaa (openshift-storage), queuing Reconcile"
-time="2025-10-10T13:20:54Z" level=info msg="Update event detected for noobaa-default-backing-store (openshift-storage), queuing Reconcile"
-```
+INFO[0000] ✅ Updated: ConfigMap "noobaa-config"
 
-**After the change** (`OPERATOR_LOG_LEVEL` = `info`, Update events demoted to Debug — hidden):
-
-```
-time="2025-10-10T13:20:54Z" level=info msg="Create event detected for noobaa (openshift-storage), queuing Reconcile"
-time="2025-10-10T13:20:54Z" level=info msg="Delete event detected for noobaa-default-backing-store (openshift-storage), queuing Reconcile"
-```
-
-Only Create and Delete events appear at Info level. The frequent Update/Generic
-events are now Debug-only and no longer visible unless `OPERATOR_LOG_LEVEL` is
-set to `debug`.
-
-**With `OPERATOR_LOG_LEVEL` = `debug`** (all events visible):
-
-```
-time="2025-10-10T13:20:54Z" level=info  msg="Create event detected for noobaa (openshift-storage), queuing Reconcile"
-time="2025-10-10T13:20:54Z" level=debug msg="Update event detected for noobaa (openshift-storage), queuing Reconcile"
-time="2025-10-10T13:20:54Z" level=debug msg="Update event detected for noobaa-default-backing-store (openshift-storage), queuing Reconcile"
-time="2025-10-10T13:20:57Z" level=info  msg="Delete event detected for noobaa-default-backing-store (openshift-storage), queuing Reconcile"
-time="2025-10-10T13:20:57Z" level=debug msg="Generic event detected for noobaa (openshift-storage), queuing Reconcile"
+Operator log level was set to "debug" successfully
+The operator picks up the change on the next reconcile. Core and endpoint pods are not restarted.
 ```

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -39,6 +39,7 @@ func Cmd() *cobra.Command {
 		CmdStatus(),
 		CmdYaml(),
 		CmdRun(),
+		CmdSetLogLevel(),
 	)
 	return cmd
 }
@@ -98,6 +99,50 @@ func CmdRun() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	return cmd
+}
+
+// CmdSetLogLevel returns a CLI command
+func CmdSetLogLevel() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-log-level <level>",
+		Short: "Sets the operator log level in noobaa-config. level can be 'warn', 'info', or 'debug'",
+		Run:   RunSetLogLevel,
+		Args:  cobra.ExactArgs(1),
+	}
+	return cmd
+}
+
+// RunSetLogLevel updates OPERATOR_LOG_LEVEL in the noobaa-config ConfigMap.
+func RunSetLogLevel(cmd *cobra.Command, args []string) {
+	log := util.Logger()
+	level := args[0]
+	switch level {
+	case "warn", "info", "debug":
+	default:
+		log.Fatalf(`invalid log-level argument %q. must be 'warn', 'info', or 'debug'. %s`, level, cmd.UsageString())
+	}
+
+	cm := util.KubeObject(bundle.File_deploy_internal_configmap_empty_yaml).(*corev1.ConfigMap)
+	cm.Namespace = options.Namespace
+	cm.Name = "noobaa-config"
+
+	_, _, err := util.KubeGet(cm)
+	if err != nil {
+		log.Fatalf(`❌ ConfigMap "noobaa-config" not found in namespace %q. Create a NooBaa system first.`, options.Namespace)
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data["OPERATOR_LOG_LEVEL"] = level
+
+	if !util.KubeUpdate(cm) {
+		log.Fatal(`❌ Failed to update ConfigMap "noobaa-config"`)
+	}
+
+	fmt.Println("")
+	fmt.Printf("Operator log level was set to %q successfully\n", level)
+	fmt.Println("The operator picks up the change on the next reconcile. Core and endpoint pods are not restarted.")
 }
 
 // RunUpgrade runs a CLI command


### PR DESCRIPTION
## Summary
- Add `nb operator set-log-level <warn|info|debug>` to update `OPERATOR_LOG_LEVEL` in `noobaa-config` at runtime
- Provide a CLI equivalent to `nb system set-debug-level` for operator logging after install
- Document the new command and its example output in `doc/operator-log-level.md`

## Test plan
- [ ] `nb operator set-log-level debug -n <namespace>` updates `OPERATOR_LOG_LEVEL` in `noobaa-config`
- [ ] `nb operator set-log-level warn -n <namespace>` reduces operator log noise
- [ ] Invalid level returns a clear CLI error
- [ ] Operator picks up the change on next reconcile without restarting core/endpoint pods
- [ ] `oc logs -n <namespace> -l noobaa-operator=deployment -f` shows expected verbosity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `operator set-log-level <level>` CLI subcommand supporting `warn`, `info`, and `debug`.
  * Persists the requested log level and confirms it will be applied on the next reconcile cycle without restarting core or endpoint pods.

* **Documentation**
  * Updated the operator log-level guide to include an “Or use the CLI” example and a simplified success output (including the `nb operator set-log-level debug -n <namespace>` command).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->