### PR TITLE
Deep Archive | Add archive boolean to create_namespace_resource params

### DIFF
--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -62,9 +62,9 @@ type Reconciler struct {
 	Secret         *corev1.Secret
 	ServiceAccount *corev1.ServiceAccount
 
-	SystemInfo              *nb.SystemInfo
-	ExternalConnectionInfo  *nb.ExternalConnectionInfo
-	NamespaceResourceinfo   *nb.NamespaceResourceInfo
+	SystemInfo             *nb.SystemInfo
+	ExternalConnectionInfo *nb.ExternalConnectionInfo
+	NamespaceResourceinfo  *nb.NamespaceResourceInfo
 
 	AddExternalConnectionParams    *nb.AddExternalConnectionParams
 	CreateNamespaceResourceParams  *nb.CreateNamespaceResourceParams
@@ -547,6 +547,7 @@ func (r *Reconciler) ReadSystemInfo() error {
 			Namespace: options.Namespace,
 		},
 		AccessMode: accessMode,
+		Archive:    r.NamespaceStore.Spec.Archive,
 	}
 
 	return nil
@@ -876,6 +877,10 @@ func (r *Reconciler) ReconcileNamespaceStore() error {
 	if r.CreateNamespaceResourceParams != nil {
 		err := r.NBClient.CreateNamespaceResourceAPI(*r.CreateNamespaceResourceParams)
 		if err != nil {
+			if rpcErr, ok := err.(*nb.RPCError); ok && rpcErr.RPCCode == string(nb.ExternalConnectionInvalidArchiveTarget) {
+				return util.NewPersistentError(rpcErr.RPCCode,
+					fmt.Sprintf("NamespaceStore %q invalid archive target %q", r.NamespaceStore.Name, r.CreateNamespaceResourceParams.TargetBucket))
+			}
 			return err
 		}
 	}

--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -506,6 +506,7 @@ type CreateNamespaceResourceParams struct {
 	AccessMode     APIAccessModeType   `json:"access_mode"`
 	NSFSConfig     *NSFSConfig         `json:"nsfs_config,omitempty"`
 	NamespaceStore *NamespaceStoreInfo `json:"namespace_store,omitempty"`
+	Archive        bool                `json:"archive,omitempty"`
 }
 
 // APIAccessModeType is the type of all the optional access modes
@@ -688,6 +689,8 @@ const (
 	ExternalConnectionTimeSkew ExternalConnectionStatus = "TIME_SKEW"
 	// ExternalConnectionUnknownFailure enum
 	ExternalConnectionUnknownFailure ExternalConnectionStatus = "UNKNOWN_FAILURE"
+	// ExternalConnectionInvalidArchiveTarget enum
+	ExternalConnectionInvalidArchiveTarget ExternalConnectionStatus = "INVALID_ARCHIVE_TARGET"
 )
 
 // ExternalConnectionInfo is a struct for reply with connection info


### PR DESCRIPTION
### Describe the Problem

### Explain the changes
1. Added archive (boolean) param to create_namespace_resource for setting it in the db. it'll also validate that the endpoint is DBS3 - currently the only check we can do is if headBucket returns 'Glacier' on `x-noobaa-supported-storage-class` header.
2. Failing on persistent error if create_namespce_resource failed with INVALID_ARCHIVE_TARGET error.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
Manual - 
1. install noobaa
2. create an archive namespacestore on top of the same noobaa (which is not an archive endpoint)
```
nb namespacestore create s3-compatible nss1 --access-key=<access-key>--secret-key=<secret-key> --endpoint=https://<endpoint-pod-ip>:6443/ --target-bucket=first.bucket --archive
INFO[0000] ✅ Exists: NooBaa "noobaa"
INFO[0000] ✅ Created: NamespaceStore "nss1"
INFO[0000] ✅ Created: Secret "namespace-store-s3-compatible-nss1"
INFO[0000]
INFO[0000] NOTE:
INFO[0000]   - This command has finished applying changes to the cluster.
INFO[0000]   - From now on, it only loops and reads the status, to monitor the operator work.
INFO[0000]   - You may Ctrl-C at any time to stop the loop and watch it manually.
INFO[0000]
INFO[0000] NamespaceStore Wait Ready:
INFO[0000] ⏳ NamespaceStore "nss1" Phase is "": waiting...
ERRO[0003] ❌ NamespaceStore "nss1" Phase is "Rejected": INVALID_ARCHIVE_TARGET NamespaceStore "nss1" invalid external connection "INVALID_ARCHIVE_TARGET" 
```
- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the archive target bucket when validating external connection settings in archive mode.

* **Bug Fixes**
  * Applies the namespace store’s archive setting when creating namespace resources.
  * Enhances error reporting for invalid archive target bucket values with a dedicated “invalid target” status and clearer messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->