### PR TITLE
Fix IPv6 URL parsing

### DIFF
--- a/pkg/bench/warp.go
+++ b/pkg/bench/warp.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -466,7 +468,7 @@ func prepareWarpHostList(endpointType EndpointType, https bool) string {
 	}
 
 	return strings.Join(util.Map(ips, func(ip string) string {
-		return fmt.Sprintf("%s:%d", ip, port)
+		return net.JoinHostPort(ip, strconv.FormatInt(int64(port), 10))
 	}), ",")
 }
 

--- a/pkg/nb/router.go
+++ b/pkg/nb/router.go
@@ -3,6 +3,7 @@ package nb
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -172,13 +173,13 @@ func (r *APIRouterPortForward) GetAddress(api string) string {
 // GetAddress implements the router
 func (r *APIRouterPodPort) GetAddress(api string) string {
 	port := FindPortByName(r.ServiceMgmt, GetAPIPortName(api)).TargetPort.IntValue()
-	return fmt.Sprintf("wss://%s:%d/rpc/", r.PodIP, port)
+	return fmt.Sprintf("wss://%s/rpc/", net.JoinHostPort(r.PodIP, strconv.Itoa(port)))
 }
 
 // GetAddress implements the router
 func (r *APIRouterNodePort) GetAddress(api string) string {
 	port := FindPortByName(r.ServiceMgmt, GetAPIPortName(api)).NodePort
-	return fmt.Sprintf("wss://%s:%d/rpc/", r.NodeIP, port)
+	return util.GetFormattedEndpoint("wss", r.NodeIP, port)
 }
 
 // GetAddress implements the router

--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -8,6 +8,7 @@ import (
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -83,13 +84,13 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 				if pod.Status.HostIP != "" {
 					status.NodePorts = append(
 						status.NodePorts,
-						fmt.Sprintf("%s://%s:%d", proto, pod.Status.HostIP, servicePort.NodePort),
+						util.GetFormattedEndpoint(proto, pod.Status.HostIP, servicePort.NodePort),
 					)
 				}
 				if pod.Status.PodIP != "" {
 					status.PodPorts = append(
 						status.PodPorts,
-						fmt.Sprintf("%s://%s:%s", proto, pod.Status.PodIP, servicePort.TargetPort.String()),
+						util.GetFormattedEndpoint(proto, pod.Status.PodIP, servicePort.TargetPort.IntVal),
 					)
 				}
 			}
@@ -100,7 +101,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 	if srv.Spec.ClusterIP != "" {
 		status.InternalIP = append(
 			status.InternalIP,
-			fmt.Sprintf("%s://%s:%d", proto, srv.Spec.ClusterIP, servicePort.Port),
+			util.GetFormattedEndpoint(proto, srv.Spec.ClusterIP, servicePort.Port),
 		)
 		status.InternalDNS = append(
 			status.InternalDNS,
@@ -112,7 +113,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 	if route.Spec.Host != "" {
 		status.ExternalDNS = append(
 			status.ExternalDNS,
-			fmt.Sprintf("%s://%s:%d", proto, route.Spec.Host, servicePort.Port),
+			util.GetFormattedEndpoint(proto, route.Spec.Host, servicePort.Port),
 		)
 	}
 
@@ -122,7 +123,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 			if lb.IP != "" {
 				status.ExternalIP = append(
 					status.ExternalIP,
-					fmt.Sprintf("%s://%s:%d", proto, lb.IP, servicePort.Port),
+					util.GetFormattedEndpoint(proto, lb.IP, servicePort.Port),
 				)
 			}
 			if lb.Hostname != "" {
@@ -139,7 +140,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 		for _, ip := range srv.Spec.ExternalIPs {
 			status.ExternalIP = append(
 				status.ExternalIP,
-				fmt.Sprintf("%s://%s:%d", proto, ip, servicePort.Port),
+				util.GetFormattedEndpoint(proto, ip, servicePort.Port),
 			)
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -2876,6 +2877,12 @@ func OnSignal(cb func(), signals ...os.Signal) {
 	<-signalChan
 
 	cb()
+}
+
+// GetFormattedEndpoint constructs a URL string of the form scheme://host:port,
+// using net.JoinHostPort to properly bracket IPv6 addresses.
+func GetFormattedEndpoint(scheme string, host string, port int32) string {
+	return fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(host, strconv.FormatInt(int64(port), 10)))
 }
 
 // secretDataString returns a secret data value by key from StringData or Data.


### PR DESCRIPTION
### Describe the Problem
QE found the issue -
```
time="2026-07-08T09:00:33Z" level=info msg="SetPhase: temporary error during phase \"Connecting\"" backingstore=openshift-storage/noobaa-default-backing-store
time="2026-07-08T09:00:33Z" level=warning msg="⏳ Temporary Error: Connect(): Failed to parse mgmt url \"https://fd13:6d20:29dc:1::8c:0\". got error: parse \"https://fd13:6d20:29dc:1::8c:0\": invalid port \":6d20:29dc:1::8c:0\" after host" backingstore=openshift-storage/noobaa-default-backing-store
```

IMO, this issue gets triggered especially in ipv6 single-stack clusters.

### Explain the changes
This PR changes the URL parsing by using the `net` package's parsing instead of manually stitching host and port.

### Issues: Fixed #xxx / Gap #xxx
https://redhat.atlassian.net/browse/DFBUGS-7824?focusedCommentId=17486166

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint URL construction by consistently combining host and port values to prevent malformed addresses, with correct handling for IPv6 and other special host formats.
  * Standardized WebSocket and service status endpoint generation for more consistent connectivity checks across routing and benchmarking.

* **New Features**
  * Added a shared endpoint formatting helper to centralize `scheme://host:port` URL creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->