### PR TITLE
Analyze Resource | Fix CA Changes (To Use Unsecured Agent)

### DIFF
--- a/deploy/job_analyze_resource.yml
+++ b/deploy/job_analyze_resource.yml
@@ -12,6 +12,7 @@ spec:
   ttlSecondsAfterFinished: 10
   template:
     spec:
+      automountServiceAccountToken: false
       volumes:
       - name: cloud-credentials
         secret:
@@ -30,7 +31,6 @@ spec:
           - name: HTTP_PROXY
           - name: HTTPS_PROXY
           - name: NO_PROXY
-          - name: NODE_EXTRA_CA_CERTS
         command: 
             - /bin/bash
             - -c

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5958,7 +5958,7 @@ const File_deploy_internal_text_system_status_readme_rejected_tmpl = `
 	NooBaa Operator Version: {{.OperatorVersion}}
 `
 
-const Sha256_deploy_job_analyze_resource_yml = "c80810baeda94fd9dd97a6c62241be5c582e08009bdbb1f2a13992c99d90ea33"
+const Sha256_deploy_job_analyze_resource_yml = "3292c193668e4325e9dd66c7777c1bda936e2d503971fbfa6261ad8ebe4ffa5f"
 
 const File_deploy_job_analyze_resource_yml = `apiVersion: batch/v1
 kind: Job
@@ -5974,6 +5974,7 @@ spec:
   ttlSecondsAfterFinished: 10
   template:
     spec:
+      automountServiceAccountToken: false
       volumes:
       - name: cloud-credentials
         secret:
@@ -5992,7 +5993,6 @@ spec:
           - name: HTTP_PROXY
           - name: HTTPS_PROXY
           - name: NO_PROXY
-          - name: NODE_EXTRA_CA_CERTS
         command: 
             - /bin/bash
             - -c

--- a/pkg/diagnostics/analyze.go
+++ b/pkg/diagnostics/analyze.go
@@ -225,7 +225,7 @@ func setNetworkEnvsInJob(analyzeResourceJob *batchv1.Job) {
 			coreApp.Name, coreApp.Namespace)
 	}
 
-	for _, networkEnvName := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "NODE_EXTRA_CA_CERTS"} {
+	for _, networkEnvName := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
 		networkEnvInCoreApp := util.GetEnvVariable(&coreApp.Spec.Template.Spec.Containers[0].Env, networkEnvName)
 		if networkEnvInCoreApp != nil && networkEnvInCoreApp.Value != "" {
 			networkEnvInJob := util.GetEnvVariable(&analyzeResourceJob.Spec.Template.Spec.Containers[0].Env, networkEnvName)


### PR DESCRIPTION
### Describe the Problem
While I worked on another feature, I noticed an error in the setup when using s3-compatible (OBM COS) with the changes that were made regarding the TLS (noobaa/noobaa-core#9395).

### Explain the changes
1. Add `automountServiceAccountToken: false` in the analyze resource job.
2. Clean up the env `NODE_EXTRA_CA_CERTS` as it is not used in noobaa-core anymore.

### Issues: 
1. Before the change, I noticed that in IBM COS, it had an error: `self-signed certificate in certificate chain`.
2. After the change, all the tests are passing. The explanation for this (using AI): 

> With `automountServiceAccountToken: false`:
> - `service-ca.crt` is not mounted → `INTERNAL_CA_CERTS` read fails → no CA loaded
> - No OCP CA bundle on this job either → `EXTERNAL_CA_CERTS` also missing
> - `https_agent.options.ca` is empty → `get_unsecured_agent` skips TLS verification for non-AWS endpoints
> That matches block-store agents, which also set `automountServiceAccountToken: false` and therefore never see `service-ca.crt`.

reference: 
https://github.com/noobaa/noobaa-core/blob/646bdc10b8565d4486becda601642eb7cb753ce0/src/util/http_utils.js#L39-L40

### Testing Instructions:
1. Use the Simple Jenkins Deploy with OCP deployed with ODF (includes NooBaa).
2. Use the CLI and run: `nb diagnostics analyze backingstore noobaa-default-backing-store -n openshift-storage` (expect all tests to pass).

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled automatic service account token mounting for resource analysis jobs to enhance security.

* **Chores**
  * Simplified environment variable handling by removing unnecessary certificate configuration while preserving proxy settings for resource analysis operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->