### PR TITLE
[Backport 5.18] Fix IPv6 URL parsing

### DIFF
--- a/pkg/nb/router.go
+++ b/pkg/nb/router.go
@@ -3,6 +3,7 @@ package nb
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -172,13 +173,13 @@ func (r *APIRouterPortForward) GetAddress(api string) string {
 // GetAddress implements the router
 func (r *APIRouterPodPort) GetAddress(api string) string {
 	port := FindPortByName(r.ServiceMgmt, GetAPIPortName(api)).TargetPort.IntValue()
-	return fmt.Sprintf("wss://%s:%d/rpc/", r.PodIP, port)
+	return fmt.Sprintf("wss://%s/rpc/", net.JoinHostPort(r.PodIP, strconv.Itoa(port)))
 }
 
 // GetAddress implements the router
 func (r *APIRouterNodePort) GetAddress(api string) string {
 	port := FindPortByName(r.ServiceMgmt, GetAPIPortName(api)).NodePort
-	return fmt.Sprintf("wss://%s:%d/rpc/", r.NodeIP, port)
+	return util.GetFormattedEndpoint("wss", r.NodeIP, port)
 }
 
 // GetAddress implements the router

--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -8,6 +8,7 @@ import (
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -72,13 +73,13 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 				if pod.Status.HostIP != "" {
 					status.NodePorts = append(
 						status.NodePorts,
-						fmt.Sprintf("%s://%s:%d", proto, pod.Status.HostIP, servicePort.NodePort),
+						util.GetFormattedEndpoint(proto, pod.Status.HostIP, servicePort.NodePort),
 					)
 				}
 				if pod.Status.PodIP != "" {
 					status.PodPorts = append(
 						status.PodPorts,
-						fmt.Sprintf("%s://%s:%s", proto, pod.Status.PodIP, servicePort.TargetPort.String()),
+						util.GetFormattedEndpoint(proto, pod.Status.PodIP, servicePort.TargetPort.IntVal),
 					)
 				}
 			}
@@ -89,7 +90,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 	if srv.Spec.ClusterIP != "" {
 		status.InternalIP = append(
 			status.InternalIP,
-			fmt.Sprintf("%s://%s:%d", proto, srv.Spec.ClusterIP, servicePort.Port),
+			util.GetFormattedEndpoint(proto, srv.Spec.ClusterIP, servicePort.Port),
 		)
 		status.InternalDNS = append(
 			status.InternalDNS,
@@ -101,7 +102,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 	if route.Spec.Host != "" {
 		status.ExternalDNS = append(
 			status.ExternalDNS,
-			fmt.Sprintf("%s://%s:%d", proto, route.Spec.Host, servicePort.Port),
+			util.GetFormattedEndpoint(proto, route.Spec.Host, servicePort.Port),
 		)
 	}
 
@@ -111,7 +112,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 			if lb.IP != "" {
 				status.ExternalIP = append(
 					status.ExternalIP,
-					fmt.Sprintf("%s://%s:%d", proto, lb.IP, servicePort.Port),
+					util.GetFormattedEndpoint(proto, lb.IP, servicePort.Port),
 				)
 			}
 			if lb.Hostname != "" {
@@ -128,7 +129,7 @@ func (r *Reconciler) CheckServiceStatus(srv *corev1.Service, route *routev1.Rout
 		for _, ip := range srv.Spec.ExternalIPs {
 			status.ExternalIP = append(
 				status.ExternalIP,
-				fmt.Sprintf("%s://%s:%d", proto, ip, servicePort.Port),
+				util.GetFormattedEndpoint(proto, ip, servicePort.Port),
 			)
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -2281,4 +2282,10 @@ func HasNodeInclusionPolicyInPodTopologySpread() bool {
 		return false
 	}
 	return true
+}
+
+// GetFormattedEndpoint constructs a URL string of the form scheme://host:port,
+// using net.JoinHostPort to properly bracket IPv6 addresses.
+func GetFormattedEndpoint(scheme string, host string, port int32) string {
+	return fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(host, strconv.FormatInt(int64(port), 10)))
 }


### PR DESCRIPTION
(cherry picked from commit 64234766ee803efc7936570cbb57f1cbdf6413e5 - backport 5.19)

### Explain the changes
1. Fix IPv6 URL parsing by using net.JoinHostPort and GetFormattedEndpoint helper

### Issues: Fixed #xxx / Gap #xxx
1. [DFBUGS-8845](https://redhat.atlassian.net/browse/DFBUGS-8845)

### Testing Instructions:
1. Verify endpoint URLs with IPv6 addresses are correctly bracketed

- [ ] Doc added/updated
- [ ] Tests added