### PR TITLE
Add PV pool resources to perf profiles + ibm z profile

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1946,6 +1946,7 @@ spec:
                   Explicit per-component resource/count fields take precedence over the profile.
                 enum:
                 - default
+                - default-ibm-z
                 - mixed-workload
                 - small-objects
                 - dev-env

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -262,7 +262,7 @@ type NooBaaSpec struct {
 	// settings for the core, db and endpoint components.
 	// Explicit per-component resource/count fields take precedence over the profile.
 	// +optional
-	// +kubebuilder:validation:Enum=default;mixed-workload;small-objects;dev-env;mini-env
+	// +kubebuilder:validation:Enum=default;default-ibm-z;mixed-workload;small-objects;dev-env;mini-env
 	PerformanceProfile PerformanceProfileType `json:"performanceProfile,omitempty"`
 }
 
@@ -890,6 +890,8 @@ type PerformanceProfileType string
 const (
 	// PerformanceProfileDefault is the default profile
 	PerformanceProfileDefault PerformanceProfileType = "default"
+	// PerformanceProfileDefaultIBMZ is the default profile adjusted for IBM Z (s390x) with halved CPU requests
+	PerformanceProfileDefaultIBMZ PerformanceProfileType = "default-ibm-z"
 	// PerformanceProfileMixedWorkload is for mixed workload
 	PerformanceProfileMixedWorkload PerformanceProfileType = "mixed-workload"
 	// PerformanceProfileSmallObjects is for small objects workload

--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -299,28 +299,13 @@ func CmdCreateGoogleCloudStorageSTS() *cobra.Command {
 	return cmd
 }
 
-// Minimum backing store pv pool resources
 const (
-	// CPU, in cores. (500m = .5 cores)
-	minCPUString string = "100m"
-	// Memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	minMemoryString string = "400Mi"
-
-	// Test ENV minimal resources
-	testEnvMinCPUString    string = "50m"
-	testEnvMinMemoryString string = "200Mi"
-
-	// Dev ENV minimal resources
-	devEnvMinCPUString    string = "500m"
-	devEnvMinMemoryString string = "500Mi"
-
 	// Default volume size for pv-pool backing store
 	defaultVolumeSize = int64(20 * 1024 * 1024 * 1024) // 20Gi=20*1024^3
 )
 
 // CmdCreatePVPool returns a CLI command
 func CmdCreatePVPool() *cobra.Command {
-	minCPUStringByEnv, minMemoryStringByEnv := getMinimalResourcesByEnv()
 	cmd := &cobra.Command{
 		Use:   "pv-pool <backing-store-name>",
 		Short: "Create pv-pool backing store",
@@ -335,20 +320,20 @@ func CmdCreatePVPool() *cobra.Command {
 		`PV size of each volume in the store`,
 	)
 	cmd.Flags().String(
-		"request-cpu", minCPUStringByEnv,
-		"Request cpu for an agent pod",
+		"request-cpu", "",
+		"Request cpu for an agent pod (default: determined by performance profile)",
 	)
 	cmd.Flags().String(
-		"request-memory", minMemoryStringByEnv,
-		"Request memory for an agent pod",
+		"request-memory", "",
+		"Request memory for an agent pod (default: determined by performance profile)",
 	)
 	cmd.Flags().String(
-		"limit-cpu", minCPUStringByEnv,
-		"Limit cpu for an agent pod",
+		"limit-cpu", "",
+		"Limit cpu for an agent pod (default: determined by performance profile)",
 	)
 	cmd.Flags().String(
-		"limit-memory", minMemoryStringByEnv,
-		"Limit memory for an agent pod",
+		"limit-memory", "",
+		"Limit memory for an agent pod (default: determined by performance profile)",
 	)
 	cmd.Flags().String(
 		"storage-class", "",
@@ -446,6 +431,21 @@ func createCommon(cmd *cobra.Command, args []string, storeType nbv1.StoreType, p
 	}
 
 	populate(backStore, secret)
+
+	if storeType == nbv1.StoreTypePVPool && backStore.Spec.PVPool != nil {
+		profileDefaults := system.GetPVPoolResources(sys)
+		effective := corev1.ResourceRequirements{
+			Requests: profileDefaults.Requests.DeepCopy(),
+			Limits:   profileDefaults.Limits.DeepCopy(),
+		}
+		if vr := backStore.Spec.PVPool.VolumeResources; vr != nil {
+			applyResourceOverrides(&effective, vr)
+		}
+		if err := validateResourceRequestsVsLimits(effective); err != nil {
+			log.Fatalf(`❌ PV pool resource conflict (against profile defaults): %v`, err)
+		}
+	}
+
 	if secretName != "" {
 		if !util.KubeCheck(secret) {
 			log.Fatalf(`❌ Could not find the suggested secret: name %q namespace %q`, secret.Name, secret.Namespace)
@@ -878,50 +878,63 @@ func RunCreatePVPool(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		var requestCPUQuantity, requestMemoryQuantity, limitCPUQuantity, limitMemoryQuantity resource.Quantity
-		var err error
-		requestCPUQuantity, err = resource.ParseQuantity(requestCPU)
-		if err != nil {
-			log.Fatalf(`❌ Could not parse request cpu %q`,
-				requestCPU)
+		volumeRequests := corev1.ResourceList{
+			corev1.ResourceStorage: *resource.NewQuantity(int64(pvSizeGB)*1024*1024*1024, resource.BinarySI),
 		}
-		requestMemoryQuantity, err = resource.ParseQuantity(requestMemory)
-		if err != nil {
-			log.Fatalf(`❌ Could not parse request Memory %q`,
-				requestMemory)
+		volumeLimits := corev1.ResourceList{}
+
+		if requestCPU != "" {
+			qty, err := resource.ParseQuantity(requestCPU)
+			if err != nil {
+				log.Fatalf(`❌ Could not parse request cpu %q`, requestCPU)
+			}
+			volumeRequests[corev1.ResourceCPU] = qty
 		}
-		limitCPUQuantity, err = resource.ParseQuantity(limitCPU)
-		if err != nil {
-			log.Fatalf(`❌ Could not parse limit cpu %q`,
-				limitCPU)
+		if requestMemory != "" {
+			qty, err := resource.ParseQuantity(requestMemory)
+			if err != nil {
+				log.Fatalf(`❌ Could not parse request memory %q`, requestMemory)
+			}
+			volumeRequests[corev1.ResourceMemory] = qty
 		}
-		limitMemoryQuantity, err = resource.ParseQuantity(limitMemory)
-		if err != nil {
-			log.Fatalf(`❌ Could not parse limit Memory %q`,
-				limitMemory)
+		if limitCPU != "" {
+			qty, err := resource.ParseQuantity(limitCPU)
+			if err != nil {
+				log.Fatalf(`❌ Could not parse limit cpu %q`, limitCPU)
+			}
+			volumeLimits[corev1.ResourceCPU] = qty
 		}
-		if requestCPUQuantity.Cmp(limitCPUQuantity) > 0 {
-			log.Fatalf(`❌ Request CPU %v is larger than limit CPU %v`,
-				requestCPUQuantity.String(), limitCPUQuantity.String())
+		if limitMemory != "" {
+			qty, err := resource.ParseQuantity(limitMemory)
+			if err != nil {
+				log.Fatalf(`❌ Could not parse limit memory %q`, limitMemory)
+			}
+			volumeLimits[corev1.ResourceMemory] = qty
 		}
-		if requestMemoryQuantity.Cmp(limitMemoryQuantity) > 0 {
-			log.Fatalf(`❌ Request memory %v is larger than limit memory %v`,
-				requestMemoryQuantity.String(), limitMemoryQuantity.String())
+
+		if reqCPU, hasReqCPU := volumeRequests[corev1.ResourceCPU]; hasReqCPU {
+			if limCPU, hasLimCPU := volumeLimits[corev1.ResourceCPU]; hasLimCPU {
+				if reqCPU.Cmp(limCPU) > 0 {
+					log.Fatalf(`❌ Request CPU %v is larger than limit CPU %v`,
+						reqCPU.String(), limCPU.String())
+				}
+			}
+		}
+		if reqMem, hasReqMem := volumeRequests[corev1.ResourceMemory]; hasReqMem {
+			if limMem, hasLimMem := volumeLimits[corev1.ResourceMemory]; hasLimMem {
+				if reqMem.Cmp(limMem) > 0 {
+					log.Fatalf(`❌ Request memory %v is larger than limit memory %v`,
+						reqMem.String(), limMem.String())
+				}
+			}
 		}
 
 		backStore.Spec.PVPool = &nbv1.PVPoolSpec{
 			StorageClass: storageClass,
 			NumVolumes:   int(numVolumes),
 			VolumeResources: &corev1.VolumeResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: *resource.NewQuantity(int64(pvSizeGB)*1024*1024*1024, resource.BinarySI),
-					corev1.ResourceCPU:     requestCPUQuantity,
-					corev1.ResourceMemory:  requestMemoryQuantity,
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    limitCPUQuantity,
-					corev1.ResourceMemory: limitMemoryQuantity,
-				},
+				Requests: volumeRequests,
+				Limits:   volumeLimits,
 			},
 			Secret: corev1.SecretReference{
 				Name:      secret.Name,

--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -1384,31 +1384,36 @@ func (r *Reconciler) updatePodTemplate() error {
 }
 
 func (r *Reconciler) updatePodResourcesTemplate(c *corev1.Container) error {
-	minCPUStringByEnv, minMemoryStringByEnv := getMinimalResourcesByEnv()
-	minimalCPU := resource.MustParse(minCPUStringByEnv)
-	minimalMemory := resource.MustParse(minMemoryStringByEnv)
-	var src, dst *corev1.ResourceList
-	pvPool := r.BackingStore.Spec.PVPool
+	profileDefaults := system.GetPVPoolResources(r.NooBaa)
 
-	// Request
-	dst = &c.Resources.Requests
-	if pvPool != nil && pvPool.VolumeResources != nil {
-		src = &pvPool.VolumeResources.Requests
-	}
-	if err := r.reconcileResources(src, dst, minimalCPU, minimalMemory); err != nil {
-		return err
+	c.Resources.Requests = profileDefaults.Requests.DeepCopy()
+	c.Resources.Limits = profileDefaults.Limits.DeepCopy()
+
+	if pvPool := r.BackingStore.Spec.PVPool; pvPool != nil && pvPool.VolumeResources != nil {
+		applyResourceOverrides(&c.Resources, pvPool.VolumeResources)
 	}
 
-	// Limits
-	src = nil
-	if pvPool != nil && pvPool.VolumeResources != nil {
-		src = &pvPool.VolumeResources.Limits
-	}
-	dst = &c.Resources.Limits
-	if err := r.reconcileResources(src, dst, minimalCPU, minimalMemory); err != nil {
-		return err
+	if err := validateResourceRequestsVsLimits(c.Resources); err != nil {
+		return util.NewPersistentError("InvalidResources",
+			fmt.Sprintf("BackingStore %q has invalid resources: %v", r.BackingStore.Name, err))
 	}
 
+	r.Logger.Infof("BackingStore %q PV pool resources — requests cpu:%v mem:%v, limits cpu:%v mem:%v",
+		r.BackingStore.Name,
+		c.Resources.Requests.Cpu(), c.Resources.Requests.Memory(),
+		c.Resources.Limits.Cpu(), c.Resources.Limits.Memory())
+	return nil
+}
+
+// validateResourceRequestsVsLimits checks that for each resource, request does not exceed limit.
+func validateResourceRequestsVsLimits(res corev1.ResourceRequirements) error {
+	for _, rName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		req, hasReq := res.Requests[rName]
+		lim, hasLim := res.Limits[rName]
+		if hasReq && hasLim && req.Cmp(lim) > 0 {
+			return fmt.Errorf("request %s (%s) exceeds limit (%s)", rName, req.String(), lim.String())
+		}
+	}
 	return nil
 }
 
@@ -1440,46 +1445,20 @@ func (r *Reconciler) deletePvPool() error {
 	return nil
 }
 
-func (r *Reconciler) reconcileResources(src, dst *corev1.ResourceList, minCPU, minMem resource.Quantity) error {
-	log := r.Logger
-	cpu := minCPU
-	mem := minMem
-
-	if src != nil {
-		if qty, ok := (*src)[corev1.ResourceCPU]; ok {
-			if qty.Cmp(minCPU) < 0 {
-				return util.NewPersistentError("MinRequestCpu",
-					fmt.Sprintf("NooBaa BackingStore %v is in rejected phase due to small cpu request %v, min is %v", r.BackingStore.Name, qty.String(), minCPU.String()))
-			}
-			cpu = qty
+// applyResourceOverrides overrides CPU and memory in dst with values from src
+// when present. Used to apply user-specified PVPool.VolumeResources over profile defaults.
+func applyResourceOverrides(dst *corev1.ResourceRequirements, src *corev1.VolumeResourceRequirements) {
+	overrideList := func(dstList *corev1.ResourceList, srcList corev1.ResourceList) {
+		if srcList == nil {
+			return
 		}
-		if qty, ok := (*src)[corev1.ResourceMemory]; ok {
-			if qty.Cmp(minMem) < 0 {
-				return util.NewPersistentError("MinRequestCpu",
-					fmt.Sprintf("NooBaa BackingStore %v is in rejected phase due to small memory request %v, min is %v", r.BackingStore.Name, qty.String(), minMem.String()))
-			}
-			mem = qty
+		if qty, ok := srcList[corev1.ResourceCPU]; ok {
+			(*dstList)[corev1.ResourceCPU] = qty
+		}
+		if qty, ok := srcList[corev1.ResourceMemory]; ok {
+			(*dstList)[corev1.ResourceMemory] = qty
 		}
 	}
-	log.Infof("BackingStore %q was created with resurce cpu:%v mem:%v.", r.BackingStore.Name, cpu, mem)
-
-	(*dst)[corev1.ResourceCPU] = cpu
-	(*dst)[corev1.ResourceMemory] = mem
-	return nil
-}
-
-// getMinimalResourcesByEnv returns the minimal CPU / memory resources by env
-// of backingstore of type pv-pool
-func getMinimalResourcesByEnv() (string, string) {
-	minCPUStringByEnv := minCPUString
-	minMemoryStringByEnv := minMemoryString
-	if util.IsTestEnv() {
-		minCPUStringByEnv = testEnvMinCPUString
-		minMemoryStringByEnv = testEnvMinMemoryString
-	}
-	if util.IsDevEnv() {
-		minCPUStringByEnv = devEnvMinCPUString
-		minMemoryStringByEnv = devEnvMinMemoryString
-	}
-	return minCPUStringByEnv, minMemoryStringByEnv
+	overrideList(&dst.Requests, src.Requests)
+	overrideList(&dst.Limits, src.Limits)
 }

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1511,7 +1511,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "88be0872b57677c437aeb656eac747cd13871d9b2733d41b0b2ec5b2d4ea7603"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "e359dfd8f3c4a8ef7ac5605b1c86ce6d939846435e13c8376cef2252bb9e95f4"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -3461,6 +3461,7 @@ spec:
                   Explicit per-component resource/count fields take precedence over the profile.
                 enum:
                 - default
+                - default-ibm-z
                 - mixed-workload
                 - small-objects
                 - dev-env

--- a/pkg/system/performance_profiles.go
+++ b/pkg/system/performance_profiles.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -13,6 +14,7 @@ type performanceProfile struct {
 	logResources      *corev1.ResourceRequirements
 	dbResources       corev1.ResourceRequirements
 	endpointResources corev1.ResourceRequirements
+	pvPoolResources   corev1.ResourceRequirements
 	endpointMinCount  int32
 	endpointMaxCount  int32
 	dbInstances       int
@@ -37,6 +39,18 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 		coreResources:     profileResources("500m", "1", "1Gi", "4Gi"),
 		dbResources:       profileResources("1", "1", "2Gi", "2Gi"),
 		endpointResources: profileResources("500m", "2", "1Gi", "3Gi"),
+		pvPoolResources:   profileResources("400m", "400m", "800Mi", "800Mi"),
+		endpointMinCount:  1,
+		endpointMaxCount:  2,
+		dbInstances:       2,
+		pvPoolNumVolumes:  3,
+	},
+	// for IBM Z, we adjust the CPU requests by a factor of 0.5 https://redhat.atlassian.net/browse/RHSTOR-9067
+	nbv1.PerformanceProfileDefaultIBMZ: {
+		coreResources:     profileResources("250m", "1", "1Gi", "4Gi"),
+		dbResources:       profileResources("500m", "1", "2Gi", "2Gi"),
+		endpointResources: profileResources("250m", "2", "1Gi", "3Gi"),
+		pvPoolResources:   profileResources("200m", "400m", "800Mi", "800Mi"),
 		endpointMinCount:  1,
 		endpointMaxCount:  2,
 		dbInstances:       2,
@@ -46,6 +60,7 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 		coreResources:     profileResources("1", "2", "2Gi", "4Gi"),
 		dbResources:       profileResources("4", "4", "8Gi", "8Gi"),
 		endpointResources: profileResources("2", "4", "2Gi", "4Gi"),
+		pvPoolResources:   profileResources("1", "1", "2Gi", "2Gi"),
 		endpointMinCount:  2,
 		endpointMaxCount:  4,
 		dbInstances:       2,
@@ -55,6 +70,7 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 		coreResources:     profileResources("1", "2", "2Gi", "6Gi"),
 		dbResources:       profileResources("6", "6", "16Gi", "16Gi"),
 		endpointResources: profileResources("2", "4", "2Gi", "4Gi"),
+		pvPoolResources:   profileResources("1", "1", "2Gi", "2Gi"),
 		endpointMinCount:  2,
 		endpointMaxCount:  4,
 		dbInstances:       2,
@@ -64,6 +80,7 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 		coreResources:     profileResources("500m", "500m", "1Gi", "1Gi"),
 		dbResources:       profileResources("1", "1", "2Gi", "2Gi"),
 		endpointResources: profileResources("500m", "500m", "500Mi", "500Mi"),
+		pvPoolResources:   profileResources("500m", "500m", "500Mi", "500Mi"),
 		endpointMinCount:  1,
 		endpointMaxCount:  1,
 		dbInstances:       1,
@@ -83,6 +100,7 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 		},
 		dbResources:       profileResources("100m", "100m", "500Mi", "500Mi"),
 		endpointResources: profileResources("100m", "100m", "500Mi", "500Mi"),
+		pvPoolResources:   profileResources("100m", "100m", "400Mi", "400Mi"),
 		endpointMinCount:  1,
 		endpointMaxCount:  1,
 		dbInstances:       1,
@@ -169,4 +187,14 @@ func getEndpointMinMax(nb *nbv1.NooBaa) (int32, int32) {
 		}
 	}
 	return minCount, maxCount
+}
+
+// GetPVPoolResources returns the default CPU/memory resources for PV pool
+// backingstore pods based on the performance profile.
+// In test env, returns minimal resources regardless of the profile.
+func GetPVPoolResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {
+	if util.IsTestEnv() {
+		return profileResources("50m", "50m", "200Mi", "200Mi")
+	}
+	return lookupProfile(nb).pvPoolResources
 }

--- a/pkg/system/performance_profiles_test.go
+++ b/pkg/system/performance_profiles_test.go
@@ -233,6 +233,49 @@ func TestGetEndpointResources(t *testing.T) {
 	}
 }
 
+func TestGetPVPoolResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		nb       *nbv1.NooBaa
+		expected corev1.ResourceRequirements
+	}{
+		{
+			name: "default profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileDefault,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileDefault].pvPoolResources,
+		},
+		{
+			name: "mixed-workload profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMixedWorkload,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileMixedWorkload].pvPoolResources,
+		},
+		{
+			name: "mini profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMiniEnv,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileMiniEnv].pvPoolResources,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPVPoolResources(tt.nb)
+			assertResourceRequirements(t, got, tt.expected)
+		})
+	}
+}
+
 func TestGetDBInstances(t *testing.T) {
 	explicitInstances := 5
 
@@ -462,6 +505,7 @@ func assertPerformanceProfile(t *testing.T, got, want performanceProfile) {
 	assertResourceRequirements(t, got.coreResources, want.coreResources)
 	assertResourceRequirements(t, got.dbResources, want.dbResources)
 	assertResourceRequirements(t, got.endpointResources, want.endpointResources)
+	assertResourceRequirements(t, got.pvPoolResources, want.pvPoolResources)
 	if got.endpointMinCount != want.endpointMinCount {
 		t.Errorf("endpointMinCount = %d, want %d", got.endpointMinCount, want.endpointMinCount)
 	}
@@ -504,32 +548,44 @@ func assertResourceList(t *testing.T, got, want corev1.ResourceList, listName st
 
 func TestProfileResourcesValues(t *testing.T) {
 	tests := []struct {
-		name    string
-		profile nbv1.PerformanceProfileType
-		core    [4]string
-		db      [4]string
+		name     string
+		profile  nbv1.PerformanceProfileType
+		core     [4]string
+		db       [4]string
 		endpoint [4]string
+		pvPool   [4]string
 	}{
 		{
-			name:    "default",
-			profile: nbv1.PerformanceProfileDefault,
-			core:    [4]string{"500m", "1", "1Gi", "4Gi"},
-			db:      [4]string{"1", "1", "2Gi", "2Gi"},
+			name:     "default",
+			profile:  nbv1.PerformanceProfileDefault,
+			core:     [4]string{"500m", "1", "1Gi", "4Gi"},
+			db:       [4]string{"1", "1", "2Gi", "2Gi"},
 			endpoint: [4]string{"500m", "2", "1Gi", "3Gi"},
+			pvPool:   [4]string{"400m", "400m", "800Mi", "800Mi"},
 		},
 		{
-			name:    "mixed-workload",
-			profile: nbv1.PerformanceProfileMixedWorkload,
-			core:    [4]string{"1", "2", "2Gi", "4Gi"},
-			db:      [4]string{"4", "4", "8Gi", "8Gi"},
-			endpoint: [4]string{"2", "4", "2Gi", "4Gi"},
+			name:     "default-ibm-z",
+			profile:  nbv1.PerformanceProfileDefaultIBMZ,
+			core:     [4]string{"250m", "1", "1Gi", "4Gi"},
+			db:       [4]string{"500m", "1", "2Gi", "2Gi"},
+			endpoint: [4]string{"250m", "2", "1Gi", "3Gi"},
+			pvPool:   [4]string{"200m", "400m", "800Mi", "800Mi"},
 		},
 		{
-			name:    "small-objects",
-			profile: nbv1.PerformanceProfileSmallObjects,
-			core:    [4]string{"1", "2", "2Gi", "6Gi"},
-			db:      [4]string{"6", "6", "16Gi", "16Gi"},
+			name:     "mixed-workload",
+			profile:  nbv1.PerformanceProfileMixedWorkload,
+			core:     [4]string{"1", "2", "2Gi", "4Gi"},
+			db:       [4]string{"4", "4", "8Gi", "8Gi"},
 			endpoint: [4]string{"2", "4", "2Gi", "4Gi"},
+			pvPool:   [4]string{"1", "1", "2Gi", "2Gi"},
+		},
+		{
+			name:     "small-objects",
+			profile:  nbv1.PerformanceProfileSmallObjects,
+			core:     [4]string{"1", "2", "2Gi", "6Gi"},
+			db:       [4]string{"6", "6", "16Gi", "16Gi"},
+			endpoint: [4]string{"2", "4", "2Gi", "4Gi"},
+			pvPool:   [4]string{"1", "1", "2Gi", "2Gi"},
 		},
 	}
 
@@ -539,6 +595,7 @@ func TestProfileResourcesValues(t *testing.T) {
 			assertResourceQuantity(t, profile.coreResources, tt.core)
 			assertResourceQuantity(t, profile.dbResources, tt.db)
 			assertResourceQuantity(t, profile.endpointResources, tt.endpoint)
+			assertResourceQuantity(t, profile.pvPoolResources, tt.pvPool)
 		})
 	}
 }

--- a/pkg/validations/backingstore_validations.go
+++ b/pkg/validations/backingstore_validations.go
@@ -7,6 +7,7 @@ import (
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -42,6 +43,9 @@ func ValidateBackingStore(bs nbv1.BackingStore) error {
 			return err
 		}
 		if err := ValidateMinVolumeCount(bs); err != nil {
+			return err
+		}
+		if err := ValidatePvpoolResources(bs); err != nil {
 			return err
 		}
 	case nbv1.StoreTypeS3Compatible:
@@ -257,6 +261,40 @@ func ValidateMinVolumeCount(bs nbv1.BackingStore) error {
 	if bs.Spec.PVPool.NumVolumes <= 0 {
 		return util.ValidationError{
 			Msg: "Unsupported volume count, the minimum supported volume count is 1",
+		}
+	}
+	return nil
+}
+
+// ValidatePvpoolResources validates the CPU and memory resources in PVPool VolumeResources.
+// It checks that resource values are valid (non-negative) and that requests do not exceed limits.
+func ValidatePvpoolResources(bs nbv1.BackingStore) error {
+	if bs.Spec.PVPool == nil || bs.Spec.PVPool.VolumeResources == nil {
+		return nil
+	}
+	vr := bs.Spec.PVPool.VolumeResources
+
+	for _, rName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if qty, ok := vr.Requests[rName]; ok {
+			if qty.Cmp(resource.MustParse("0")) < 0 {
+				return util.ValidationError{
+					Msg: fmt.Sprintf("Invalid PV pool resource: request %s must not be negative", rName),
+				}
+			}
+		}
+		if qty, ok := vr.Limits[rName]; ok {
+			if qty.Cmp(resource.MustParse("0")) < 0 {
+				return util.ValidationError{
+					Msg: fmt.Sprintf("Invalid PV pool resource: limit %s must not be negative", rName),
+				}
+			}
+		}
+		req, hasReq := vr.Requests[rName]
+		lim, hasLim := vr.Limits[rName]
+		if hasReq && hasLim && req.Cmp(lim) > 0 {
+			return util.ValidationError{
+				Msg: fmt.Sprintf("Invalid PV pool resource: request %s (%s) exceeds limit (%s)", rName, req.String(), lim.String()),
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
### Describe the Problem
PV pool backingstore agent pods used hardcoded minimum CPU/memory values
that varied only by environment variables (TEST_ENV, DEV_ENV). These
values were enforced with a PersistentError that rejected backingstores
if resources fell below the minimum, and were not tied to the
performance profile system used by all other NooBaa components.

Additionally, the CLI validation for CPU/memory requests vs. limits was
insufficient — if a user provided only a request flag without a
corresponding limit flag, CLI validation passed but the reconciler would
apply the request against profile defaults with lower limits, creating
invalid Kubernetes resources (request > limit).

### Explain the Changes
1. Added `pvPoolResources` field to the `performanceProfile` struct with
   per-profile CPU/memory values (requests=limits):
   default (400m/800Mi), default-ibm-z (200m req, 400m lim / 800Mi),
   mixed-workload and small-objects (1/2Gi), dev-env (500m/500Mi),
   mini-env (100m/400Mi).
2. Added new `PerformanceProfileDefaultIBMZ` (`"default-ibm-z"`) profile
   with the same values as the default profile but CPU **requests** halved
   (0.5x factor) to accommodate IBM Z (s390x) environments.
3. Added exported `GetPVPoolResources()` function that returns profile-based
   defaults, with a test-env override (50m/200Mi).
4. Refactored `updatePodResourcesTemplate` in the backingstore reconciler to
   use profile defaults instead of env-based minimums, and replaced
   `reconcileResources` (which returned PersistentError on under-minimum
   values) with `applyResourceOverrides` that selectively merges
   user-specified VolumeResources over profile defaults.
5. Added `validateResourceRequestsVsLimits` in the reconciler to catch
   request > limit after merging user overrides with profile defaults.
6. Removed hardcoded `minCPUString`/`minMemoryString` constants and
   `getMinimalResourcesByEnv()` function.
7. Updated CLI `CmdCreatePVPool` flags to default to empty (profile-determined)
   instead of hardcoded values; CPU/memory are only set in VolumeResources
   when explicitly provided by the user. CLI-level request vs. limit
   validation only runs when both values are explicitly provided.
8. Added `ValidatePvpoolResources` admission validation in
   `backingstore_validations.go` that checks for non-negative resource
   values and request <= limit for CPU and memory, wired into
   `ValidateBackingStore` for `StoreTypePVPool`.
9. Added `TestGetPVPoolResources` covering all profiles and fallback, updated
   `TestProfileResourcesValues` and `assertPerformanceProfile` to validate
   pvPool resources including the new `default-ibm-z` profile.

### Issues: Fixed #xxx / Gap #xxx
1.

### Testing Instructions:
1. Run `go test ./pkg/system/...` — all profile tests pass including new
   `TestGetPVPoolResources` and `default-ibm-z` profile values.
2. Run `go test ./pkg/validations/...` — all validation tests pass.
3. Run `go build ./...` — clean build with no errors.
4. Deploy with different performance profiles and verify PV pool agent pods
   get the expected CPU/memory from the profile.
5. Deploy with `performanceProfile: default-ibm-z` and verify CPU requests
   are halved compared to the default profile while limits remain unchanged.
6. Create a PV pool backingstore via CLI without `--request-cpu`/`--request-memory`
   flags and verify it uses profile defaults.
7. Create a PV pool backingstore via CLI with explicit resource flags and verify
   the user values override the profile defaults.
8. Create a PV pool backingstore with `--request-cpu` exceeding the profile's
   default limit (without `--limit-cpu`) and verify the reconciler rejects it
   with a PersistentError.

- [ ] Doc added/updated
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `default-ibm-z` performance profile option.
  - PV pool CPU and memory resources now come from the selected performance profile.
  - PV pool CPU/memory requests and limits support overrides when explicitly configured.

- **Bug Fixes**
  - Improved PV pool validation to reject negative CPU/memory requests or limits.
  - Enforced CPU/memory request-vs-limit correctness (request must not exceed limit when both are set).

- **Tests**
  - Added/updated unit tests to cover PV pool resource computation and new profile expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->