### PR TITLE
add upgrade job to operator to replace upgrade in core

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -2198,6 +2198,10 @@ spec:
                   key rotate
                 format: date-time
                 type: string
+              lastSuccessfulUpgradeImage:
+                description: LastSuccessfulUpgradeImage is the image that most recently
+                  completed the core upgrade job
+                type: string
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed for this noobaa system.

--- a/deploy/internal/job-upgrade-core.yaml
+++ b/deploy/internal/job-upgrade-core.yaml
@@ -1,0 +1,74 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: noobaa-core-upgrade
+  labels:
+    app: noobaa
+spec:
+  completions: 1
+  parallelism: 1
+  # backoffLimit is set by setDesiredUpgradeJob() — see upgradeJobBackoffLimit in pkg/system/upgrade_reconciler.go
+  template:
+    metadata:
+      labels:
+        app: noobaa
+      annotations:
+        openshift.io/required-scc: noobaa-core
+    spec:
+      # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
+      serviceAccountName: noobaa-core
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 0
+      volumes:
+        - name: noobaa-server
+          secret:
+            secretName: noobaa-server
+            optional: true
+      containers:
+        - name: noobaa-core-upgrade
+          image: NOOBAA_CORE_IMAGE
+          command:
+            - /bin/bash
+            - -c
+            - "cd /root/node_modules/noobaa-core && node ./src/upgrade/upgrade_manager.js --upgrade_scripts_dir /root/node_modules/noobaa-core/src/upgrade/upgrade_scripts"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: UPGRADE_SCRIPTS_DIR
+              value: /root/node_modules/noobaa-core/src/upgrade/upgrade_scripts
+            - name: POSTGRES_HOST
+            - name: POSTGRES_HOST_RO
+            - name: POSTGRES_PORT
+            - name: POSTGRES_DBNAME
+            - name: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+            - name: POSTGRES_CONNECTION_STRING
+            - name: POSTGRES_SSL_REQUIRED
+            - name: POSTGRES_SSL_UNAUTHORIZED
+            - name: POSTGRES_HOST_PATH
+            - name: POSTGRES_USER_PATH
+            - name: POSTGRES_PASSWORD_PATH
+            - name: POSTGRES_DBNAME_PATH
+            - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
+            - name: DB_TYPE
+              value: postgres
+            - name: CONTAINER_PLATFORM
+              value: KUBERNETES
+            - name: NODE_EXTRA_CA_CERTS
+            - name: HTTP_PROXY
+            - name: HTTPS_PROXY
+            - name: NO_PROXY
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
+          volumeMounts:
+            - name: noobaa-server
+              mountPath: /etc/noobaa-server
+              readOnly: true
+      restartPolicy: Never

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -554,6 +554,10 @@ type NooBaaStatus struct {
 	// +optional
 	UpgradePhase UpgradePhase `json:"upgradePhase,omitempty"`
 
+	// LastSuccessfulUpgradeImage is the image that most recently completed the core upgrade job
+	// +optional
+	LastSuccessfulUpgradeImage string `json:"lastSuccessfulUpgradeImage,omitempty"`
+
 	// Upgrade reports the status of the ongoing postgres upgrade process
 	// +optional
 	PostgresUpdatePhase UpgradePhase `json:"postgresUpdatePhase,omitempty"`
@@ -736,8 +740,8 @@ type AccountsStatus struct {
 
 // ServicesStatus is the status info of the system's services
 type ServicesStatus struct {
-	ServiceMgmt    ServiceStatus `json:"serviceMgmt"`
-	ServiceS3      ServiceStatus `json:"serviceS3"`
+	ServiceMgmt ServiceStatus `json:"serviceMgmt"`
+	ServiceS3   ServiceStatus `json:"serviceS3"`
 	// +optional
 	ServiceSts     ServiceStatus `json:"serviceSts,omitempty"`
 	ServiceIam     ServiceStatus `json:"serviceIam,omitempty"`

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1511,7 +1511,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "e359dfd8f3c4a8ef7ac5605b1c86ce6d939846435e13c8376cef2252bb9e95f4"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "b0cd35ec708b34b39b1b104f9d62f36f1ee3fb93fea2e7e0c5a54ff98ce0f070"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -3713,6 +3713,10 @@ spec:
                   key rotate
                 format: date-time
                 type: string
+              lastSuccessfulUpgradeImage:
+                description: LastSuccessfulUpgradeImage is the image that most recently
+                  completed the core upgrade job
+                type: string
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed for this noobaa system.
@@ -4873,6 +4877,84 @@ metadata:
   annotations:
     service.beta.openshift.io/inject-cabundle: 'true'
 data: {}
+`
+
+const Sha256_deploy_internal_job_upgrade_core_yaml = "afc168042ec3d0bc22426a11f0e682344a17179ed04f7c48ab04d6db2ef55aff"
+
+const File_deploy_internal_job_upgrade_core_yaml = `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: noobaa-core-upgrade
+  labels:
+    app: noobaa
+spec:
+  completions: 1
+  parallelism: 1
+  # backoffLimit is set by setDesiredUpgradeJob() — see upgradeJobBackoffLimit in pkg/system/upgrade_reconciler.go
+  template:
+    metadata:
+      labels:
+        app: noobaa
+      annotations:
+        openshift.io/required-scc: noobaa-core
+    spec:
+      # Notice that changing the serviceAccountName would need to update existing AWS STS role trust policy for customers
+      serviceAccountName: noobaa-core
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 0
+      volumes:
+        - name: noobaa-server
+          secret:
+            secretName: noobaa-server
+            optional: true
+      containers:
+        - name: noobaa-core-upgrade
+          image: NOOBAA_CORE_IMAGE
+          command:
+            - /bin/bash
+            - -c
+            - "cd /root/node_modules/noobaa-core && node ./src/upgrade/upgrade_manager.js --upgrade_scripts_dir /root/node_modules/noobaa-core/src/upgrade/upgrade_scripts"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: UPGRADE_SCRIPTS_DIR
+              value: /root/node_modules/noobaa-core/src/upgrade/upgrade_scripts
+            - name: POSTGRES_HOST
+            - name: POSTGRES_HOST_RO
+            - name: POSTGRES_PORT
+            - name: POSTGRES_DBNAME
+            - name: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+            - name: POSTGRES_CONNECTION_STRING
+            - name: POSTGRES_SSL_REQUIRED
+            - name: POSTGRES_SSL_UNAUTHORIZED
+            - name: POSTGRES_HOST_PATH
+            - name: POSTGRES_USER_PATH
+            - name: POSTGRES_PASSWORD_PATH
+            - name: POSTGRES_DBNAME_PATH
+            - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
+            - name: DB_TYPE
+              value: postgres
+            - name: CONTAINER_PLATFORM
+              value: KUBERNETES
+            - name: NODE_EXTRA_CA_CERTS
+            - name: HTTP_PROXY
+            - name: HTTPS_PROXY
+            - name: NO_PROXY
+          envFrom:
+            - configMapRef:
+                name: noobaa-config
+          volumeMounts:
+            - name: noobaa-server
+              mountPath: /etc/noobaa-server
+              readOnly: true
+      restartPolicy: Never
 `
 
 const Sha256_deploy_internal_nsfs_pvc_cr_yaml = "6dd65ca7d324991b813f209ec6a8a6bcf6c2c9a9f45c519ad3fba51e25042f07"

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -203,23 +203,15 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 		return err
 	}
 
-	// before reconciling the core, check if the image was changed so an upgrade is needed.
-	// if upgrade is needed, stop the core and endpoints pods to allow the upgrade_manager in noobaa-core to run without interruptions
-	if util.KubeCheckQuiet(r.CoreApp) {
-		if r.NooBaa.Status.ActualImage != r.CoreApp.Spec.Template.Spec.Containers[0].Image {
-			numRunningPods, err := r.stopNoobaaPodsAndGetNumRunningPods()
-			if err != nil {
-				return fmt.Errorf("got error stopping noobaa-core and noobaa-endpoint pods. error: %v", err)
-			}
-			// wait for the endpoints to be stopped
-			if numRunningPods != 0 {
-				return fmt.Errorf("waiting for noobaa-core and noobaa-endpoint pods to be terminated before upgrade. %d pods are still running", numRunningPods)
-			}
-		}
+	// run core image upgrade job before reconciling core STS
+	if err := r.reconcileCoreImageUpgrade(); err != nil {
+		return err
 	}
 
-	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
-		return err
+	if !r.isCoreImageUpgradeNeeded() || r.isCoreUpgradeFinishedForActualImage() {
+		if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
+			return err
+		}
 	}
 
 	// reconcile noobaa-mgmt route only if routes are enabled
@@ -597,7 +589,11 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 		case "POSTGRES_HOST_PATH":
 			c.Env[j].Value = postgresSecretMountPath + "/host"
 		case "POSTGRES_CONNECTION_STRING_PATH":
-			c.Env[j].Value = postgresSecretMountPath + "/db_url"
+			if r.shouldReconcileCNPGCluster() {
+				c.Env[j].Value = postgresSecretMountPath + "/uri"
+			} else {
+				c.Env[j].Value = postgresSecretMountPath + "/db_url"
+			}
 
 		case "NODE_EXTRA_CA_CERTS":
 			c.Env[j].Value = r.ApplyCAsToPods
@@ -654,7 +650,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	podSpec.ServiceAccountName = "noobaa-core"
 	coreImageChanged := false
 
-	if r.CoreApp.Spec.Replicas != nil && *r.CoreApp.Spec.Replicas == 0 {
+	if r.CoreApp.Spec.Replicas != nil && *r.CoreApp.Spec.Replicas == 0 && !r.shouldBlockWorkloadRestore() {
 		// replicas can be set to 0 if the cluster went through data import to DB cluster
 		// restore back to 1 replica
 		oneReplica := int32(1)

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -73,6 +74,8 @@ type Reconciler struct {
 	NooBaa                    *nbv1.NooBaa
 	ServiceAccount            *corev1.ServiceAccount
 	CoreApp                   *appsv1.StatefulSet
+	UpgradeJob                *batchv1.Job
+	DefaultUpgradeJob         *corev1.PodSpec
 	CoreAppConfig             *corev1.ConfigMap
 	DefaultCoreApp            *corev1.PodSpec
 	PostgresDBConf            *corev1.ConfigMap
@@ -160,6 +163,7 @@ func NewReconciler(
 		NooBaa:                    util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml).(*nbv1.NooBaa),
 		ServiceAccount:            util.KubeObject(bundle.File_deploy_service_account_yaml).(*corev1.ServiceAccount),
 		CoreApp:                   util.KubeObject(bundle.File_deploy_internal_statefulset_core_yaml).(*appsv1.StatefulSet),
+		UpgradeJob:                util.KubeObject(bundle.File_deploy_internal_job_upgrade_core_yaml).(*batchv1.Job),
 		CoreAppConfig:             util.KubeObject(bundle.File_deploy_internal_configmap_empty_yaml).(*corev1.ConfigMap),
 		PostgresDBConf:            util.KubeObject(bundle.File_deploy_internal_configmap_postgres_db_yaml).(*corev1.ConfigMap),
 		NooBaaPostgresDB:          util.KubeObject(bundle.File_deploy_internal_statefulset_postgres_db_yaml).(*appsv1.StatefulSet),
@@ -216,6 +220,7 @@ func NewReconciler(
 	r.NooBaa.Namespace = r.Request.Namespace
 	r.ServiceAccount.Namespace = r.Request.Namespace
 	r.CoreApp.Namespace = r.Request.Namespace
+	r.UpgradeJob.Namespace = r.Request.Namespace
 	r.CoreAppConfig.Namespace = r.Request.Namespace
 	r.PostgresDBConf.Namespace = r.Request.Namespace
 	r.NooBaaPostgresDB.Namespace = r.Request.Namespace
@@ -269,6 +274,7 @@ func NewReconciler(
 	r.NooBaa.Name = r.Request.Name
 	r.ServiceAccount.Name = r.Request.Name
 	r.CoreApp.Name = r.Request.Name + "-core"
+	r.UpgradeJob.Name = r.Request.Name + "-core-upgrade"
 	r.CoreAppConfig.Name = "noobaa-config"
 	r.NooBaaPostgresDB.Name = r.Request.Name + "-db-pg"
 	r.ServiceMgmt.Name = r.Request.Name + "-mgmt"
@@ -348,6 +354,7 @@ func NewReconciler(
 	r.BucketLoggingVolumeMount = "/var/logs/bucket-logs"
 
 	r.DefaultCoreApp = r.CoreApp.Spec.Template.Spec.DeepCopy()
+	r.DefaultUpgradeJob = r.UpgradeJob.Spec.Template.Spec.DeepCopy()
 	r.DefaultDeploymentEndpoint = r.DeploymentEndpoint.Spec.Template.Spec.DeepCopy()
 	r.webIdentityTokenPath = util.WebIdentityTokenPath
 
@@ -777,11 +784,11 @@ func (r *Reconciler) stopNoobaaPodsAndGetNumRunningPods() (int, error) {
 		return -1, err
 	}
 	corePodsList := &corev1.PodList{}
-	if !util.KubeList(corePodsList, client.InNamespace(options.Namespace), client.MatchingLabels{"noobaa-core": "noobaa"}) {
+	if !util.KubeList(corePodsList, client.InNamespace(r.Request.Namespace), client.MatchingLabels{"noobaa-core": r.Request.Name}) {
 		return -1, fmt.Errorf("got error listing noobaa-core pods")
 	}
 	endpointPodsList := &corev1.PodList{}
-	if !util.KubeList(endpointPodsList, client.InNamespace(options.Namespace), client.MatchingLabels{"noobaa-s3": "noobaa"}) {
+	if !util.KubeList(endpointPodsList, client.InNamespace(r.Request.Namespace), client.MatchingLabels{"noobaa-s3": r.Request.Name}) {
 		return -1, fmt.Errorf("got error listing noobaa-endpoints pods")
 	}
 	return len(corePodsList.Items) + len(endpointPodsList.Items), nil

--- a/pkg/system/upgrade_reconciler.go
+++ b/pkg/system/upgrade_reconciler.go
@@ -1,0 +1,304 @@
+package system
+
+import (
+	"fmt"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const upgradeJobBackoffLimit = int32(4)
+
+func (r *Reconciler) getDeployedCoreImage() string {
+	for i := range r.CoreApp.Spec.Template.Spec.Containers {
+		if r.CoreApp.Spec.Template.Spec.Containers[i].Name == "core" {
+			return r.CoreApp.Spec.Template.Spec.Containers[i].Image
+		}
+	}
+	return ""
+}
+
+func (r *Reconciler) isCoreImageUpgradeNeeded() bool {
+	if !util.KubeCheckQuiet(r.CoreApp) {
+		return false
+	}
+	return r.NooBaa.Status.ActualImage != r.getDeployedCoreImage()
+}
+
+func (r *Reconciler) isCoreUpgradeInProgress() bool {
+	switch r.NooBaa.Status.UpgradePhase {
+	case nbv1.UpgradePhaseUpgrade, nbv1.UpgradePhaseFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *Reconciler) shouldBlockWorkloadRestore() bool {
+	return r.isCoreUpgradeInProgress()
+}
+
+func (r *Reconciler) isCoreUpgradeFinishedForActualImage() bool {
+	return r.NooBaa.Status.UpgradePhase == nbv1.UpgradePhaseFinished &&
+		r.NooBaa.Status.LastSuccessfulUpgradeImage != "" &&
+		r.NooBaa.Status.LastSuccessfulUpgradeImage == r.NooBaa.Status.ActualImage
+}
+
+func (r *Reconciler) reconcileCoreImageUpgrade() error {
+	if r.NooBaa.Status.UpgradePhase == nbv1.UpgradePhaseFailed {
+		if util.KubeCheckQuiet(r.UpgradeJob) {
+			return fmt.Errorf("core upgrade job failed; delete job %q to retry", r.UpgradeJob.Name)
+		}
+		r.NooBaa.Status.UpgradePhase = nbv1.UpgradePhaseUpgrade
+		if err := r.UpdateStatus(); err != nil {
+			return err
+		}
+	}
+
+	if !r.isCoreImageUpgradeNeeded() {
+		if r.NooBaa.Status.UpgradePhase != nbv1.UpgradePhaseNone && r.NooBaa.Status.UpgradePhase != "" {
+			if r.getDeployedCoreImage() == r.NooBaa.Status.ActualImage {
+				r.NooBaa.Status.UpgradePhase = nbv1.UpgradePhaseNone
+				if err := r.cleanupUpgradeJob(); err != nil {
+					return err
+				}
+				return r.UpdateStatus()
+			}
+		}
+		return nil
+	}
+
+	if r.isCoreUpgradeFinishedForActualImage() {
+		return nil
+	}
+
+	numRunningPods, err := r.stopNoobaaPodsAndGetNumRunningPods()
+	if err != nil {
+		return fmt.Errorf("got error stopping noobaa-core and noobaa-endpoint pods. error: %v", err)
+	}
+	if numRunningPods != 0 {
+		return fmt.Errorf("waiting for noobaa-core and noobaa-endpoint pods to be terminated before upgrade. %d pods are still running", numRunningPods)
+	}
+
+	if r.NooBaa.Status.UpgradePhase != nbv1.UpgradePhaseUpgrade {
+		r.NooBaa.Status.UpgradePhase = nbv1.UpgradePhaseUpgrade
+		if r.Recorder != nil {
+			r.Recorder.Eventf(r.NooBaa, nil, corev1.EventTypeNormal,
+				"CoreUpgradeStarted", "CoreUpgradeStarted",
+				"Starting core image upgrade to %q", r.NooBaa.Status.ActualImage)
+		}
+		if err := r.UpdateStatus(); err != nil {
+			return err
+		}
+	}
+
+	deleted, err := r.ensureUpgradeJobRecreate()
+	if err != nil {
+		return err
+	}
+	if deleted {
+		return fmt.Errorf("waiting for old core upgrade job to be deleted before recreating it")
+	}
+
+	if err := r.ReconcileObject(r.UpgradeJob, r.setDesiredUpgradeJob); err != nil {
+		return err
+	}
+
+	if err := r.Client.Get(r.Ctx, client.ObjectKeyFromObject(r.UpgradeJob), r.UpgradeJob); err != nil {
+		return err
+	}
+
+	if r.UpgradeJob.Status.Succeeded > 0 {
+		r.NooBaa.Status.UpgradePhase = nbv1.UpgradePhaseFinished
+		r.NooBaa.Status.LastSuccessfulUpgradeImage = r.NooBaa.Status.ActualImage
+		if r.Recorder != nil {
+			r.Recorder.Eventf(r.NooBaa, nil, corev1.EventTypeNormal,
+				"CoreUpgradeSucceeded", "CoreUpgradeSucceeded",
+				"Core image upgrade to %q completed successfully", r.NooBaa.Status.ActualImage)
+		}
+		if err := r.UpdateStatus(); err != nil {
+			return err
+		}
+		return r.cleanupUpgradeJob()
+	}
+
+	if r.isUpgradeJobFailed() {
+		r.NooBaa.Status.UpgradePhase = nbv1.UpgradePhaseFailed
+		if r.Recorder != nil {
+			r.Recorder.Eventf(r.NooBaa, nil, corev1.EventTypeWarning,
+				"CoreUpgradeFailed", "CoreUpgradeFailed",
+				"Core image upgrade to %q failed; delete job %q to retry",
+				r.NooBaa.Status.ActualImage, r.UpgradeJob.Name)
+		}
+		if err := r.UpdateStatus(); err != nil {
+			return err
+		}
+		return fmt.Errorf("core upgrade job failed; delete job %q to retry", r.UpgradeJob.Name)
+	}
+
+	return fmt.Errorf("waiting for core upgrade job to complete")
+}
+
+func (r *Reconciler) isUpgradeJobFailed() bool {
+	for _, c := range r.UpgradeJob.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return r.UpgradeJob.Status.Failed > upgradeJobBackoffLimit
+}
+
+func (r *Reconciler) ensureUpgradeJobRecreate() (bool, error) {
+	existing := &batchv1.Job{}
+	key := client.ObjectKeyFromObject(r.UpgradeJob)
+	err := r.Client.Get(r.Ctx, key, existing)
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if len(existing.Spec.Template.Spec.Containers) == 0 {
+		return false, nil
+	}
+	if existing.Spec.Template.Spec.Containers[0].Image == r.NooBaa.Status.ActualImage {
+		return false, nil
+	}
+	return true, r.deleteUpgradeJob(existing)
+}
+
+func (r *Reconciler) setDesiredUpgradeJob() error {
+	podSpec := &r.UpgradeJob.Spec.Template.Spec
+	defaultPodSpec := r.DefaultUpgradeJob
+	defaultContainer := defaultPodSpec.Containers[0]
+
+	podSpec.ServiceAccountName = "noobaa-core"
+	podSpec.RestartPolicy = corev1.RestartPolicyNever
+	podSpec.SecurityContext = defaultPodSpec.SecurityContext.DeepCopy()
+	backoffLimit := upgradeJobBackoffLimit
+	r.UpgradeJob.Spec.BackoffLimit = &backoffLimit
+
+	if r.NooBaa.Spec.ImagePullSecret == nil {
+		podSpec.ImagePullSecrets = []corev1.LocalObjectReference{}
+	} else {
+		podSpec.ImagePullSecrets = []corev1.LocalObjectReference{*r.NooBaa.Spec.ImagePullSecret}
+	}
+
+	podSpec.Volumes = defaultPodSpec.Volumes
+
+	c := &podSpec.Containers[0]
+	c.Command = append([]string(nil), defaultContainer.Command...)
+	c.EnvFrom = append([]corev1.EnvFromSource(nil), defaultContainer.EnvFrom...)
+	c.VolumeMounts = defaultContainer.VolumeMounts
+	c.SecurityContext = defaultContainer.SecurityContext.DeepCopy()
+	util.MergeEnvArrays(&c.Env, &defaultContainer.Env)
+	c.Image = r.NooBaa.Status.ActualImage
+	r.setDesiredCoreEnv(c)
+	r.setDesiredRootMasterKeyMounts(podSpec, c)
+
+	if r.shouldReconcileCNPGCluster() {
+		dbSecretVolumeMounts := []corev1.VolumeMount{{
+			Name:      r.CNPGCluster.Name,
+			MountPath: postgresSecretMountPath,
+			ReadOnly:  true,
+		}}
+		util.MergeVolumeMountList(&c.VolumeMounts, &dbSecretVolumeMounts)
+		dbSecretVolumes := []corev1.Volume{{
+			Name: r.CNPGCluster.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: r.getClusterSecretName(),
+				},
+			},
+		}}
+		util.MergeVolumeList(&podSpec.Volumes, &dbSecretVolumes)
+	} else if r.NooBaa.Spec.ExternalPgSecret != nil {
+		dbSecretVolumeMounts := []corev1.VolumeMount{{
+			Name:      r.NooBaa.Spec.ExternalPgSecret.Name,
+			MountPath: postgresSecretMountPath,
+			ReadOnly:  true,
+		}}
+		util.MergeVolumeMountList(&c.VolumeMounts, &dbSecretVolumeMounts)
+		externalPgVolumes := []corev1.Volume{{
+			Name: r.NooBaa.Spec.ExternalPgSecret.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: r.NooBaa.Spec.ExternalPgSecret.Name,
+				},
+			},
+		}}
+		util.MergeVolumeList(&podSpec.Volumes, &externalPgVolumes)
+	}
+
+	if util.KubeCheckQuiet(r.CaBundleConf) && len(r.CaBundleConf.Data) > 0 {
+		configMapVolumes := []corev1.Volume{{
+			Name: r.CaBundleConf.Name,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: r.CaBundleConf.Name,
+					},
+					Items: []corev1.KeyToPath{{
+						Key:  "ca-bundle.crt",
+						Path: "ca-bundle.crt",
+					}},
+				},
+			},
+		}}
+		util.MergeVolumeList(&podSpec.Volumes, &configMapVolumes)
+		configMapVolumeMounts := []corev1.VolumeMount{{
+			Name:      r.CaBundleConf.Name,
+			MountPath: "/etc/ocp-injected-ca-bundle",
+			ReadOnly:  true,
+		}}
+		util.MergeVolumeMountList(&c.VolumeMounts, &configMapVolumeMounts)
+	}
+
+	if r.ExternalPgSSLSecret != nil && util.KubeCheckQuiet(r.ExternalPgSSLSecret) {
+		secretVolumes := []corev1.Volume{{
+			Name: r.ExternalPgSSLSecret.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: r.ExternalPgSSLSecret.Name,
+				},
+			},
+		}}
+		util.MergeVolumeList(&podSpec.Volumes, &secretVolumes)
+		secretVolumeMounts := []corev1.VolumeMount{{
+			Name:      r.ExternalPgSSLSecret.Name,
+			MountPath: "/etc/external-db-secret",
+			ReadOnly:  true,
+		}}
+		util.MergeVolumeMountList(&c.VolumeMounts, &secretVolumeMounts)
+	}
+
+	util.ReflectEnvVariable(&c.Env, "HTTP_PROXY")
+	util.ReflectEnvVariable(&c.Env, "HTTPS_PROXY")
+	util.ReflectEnvVariable(&c.Env, "NO_PROXY")
+
+	return nil
+}
+
+func (r *Reconciler) cleanupUpgradeJob() error {
+	if r.UpgradeJob == nil || r.UpgradeJob.Name == "" {
+		return nil
+	}
+	if !util.KubeCheckQuiet(r.UpgradeJob) {
+		return nil
+	}
+	return r.deleteUpgradeJob(r.UpgradeJob)
+}
+
+func (r *Reconciler) deleteUpgradeJob(job *batchv1.Job) error {
+	propagationPolicy := metav1.DeletePropagationForeground
+	deleteOpts := client.DeleteOptions{PropagationPolicy: &propagationPolicy}
+	if err := r.Client.Delete(r.Ctx, job, &deleteOpts); err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/system/upgrade_reconciler_test.go
+++ b/pkg/system/upgrade_reconciler_test.go
@@ -1,0 +1,234 @@
+package system
+
+import (
+	"strings"
+	"testing"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestUpgradeReconciler(objs ...client.Object) *Reconciler {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = nbv1.SchemeBuilder.AddToScheme(scheme)
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := NewReconciler(types.NamespacedName{Namespace: "test-ns", Name: "noobaa"}, cl, scheme, nil)
+	r.NooBaa.Status.ActualImage = "noobaa/noobaa-core:new"
+	return r
+}
+
+func setCoreImage(r *Reconciler, image string) {
+	r.CoreApp.ObjectMeta = metav1.ObjectMeta{
+		Name:      r.CoreApp.Name,
+		Namespace: r.CoreApp.Namespace,
+		UID:       "core-uid",
+	}
+	r.CoreApp.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name:  "core",
+		Image: image,
+	}}
+}
+
+func TestShouldBlockWorkloadRestore(t *testing.T) {
+	tests := []struct {
+		name     string
+		phase    nbv1.UpgradePhase
+		oldImage string
+		want     bool
+	}{
+		{name: "no upgrade needed", phase: nbv1.UpgradePhaseNone, oldImage: "noobaa/noobaa-core:new", want: false},
+		{name: "upgrading", phase: nbv1.UpgradePhaseUpgrade, oldImage: "noobaa/noobaa-core:old", want: true},
+		{name: "failed", phase: nbv1.UpgradePhaseFailed, oldImage: "noobaa/noobaa-core:old", want: true},
+		{name: "done upgrade", phase: nbv1.UpgradePhaseFinished, oldImage: "noobaa/noobaa-core:old", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestUpgradeReconciler()
+			setCoreImage(r, tt.oldImage)
+			r.NooBaa.Status.UpgradePhase = tt.phase
+			if got := r.shouldBlockWorkloadRestore(); got != tt.want {
+				t.Fatalf("shouldBlockWorkloadRestore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultUpgradeJobCommandAndEnv(t *testing.T) {
+	const upgradeScriptsDir = "/root/node_modules/noobaa-core/src/upgrade/upgrade_scripts"
+
+	r := newTestUpgradeReconciler()
+	defaultContainer := r.DefaultUpgradeJob.Containers[0]
+	if len(defaultContainer.Command) == 0 {
+		t.Fatal("expected upgrade command in default upgrade job template")
+	}
+	cmd := strings.Join(defaultContainer.Command, " ")
+	if !strings.Contains(cmd, "upgrade_manager.js") {
+		t.Fatalf("upgrade command missing upgrade_manager.js: %q", cmd)
+	}
+	if !strings.Contains(cmd, "--upgrade_scripts_dir "+upgradeScriptsDir) {
+		t.Fatalf("upgrade command missing scripts dir: %q", cmd)
+	}
+
+	var upgradeScriptsDirEnv string
+	for _, env := range defaultContainer.Env {
+		if env.Name == "UPGRADE_SCRIPTS_DIR" {
+			upgradeScriptsDirEnv = env.Value
+			break
+		}
+	}
+	if upgradeScriptsDirEnv != upgradeScriptsDir {
+		t.Fatalf("UPGRADE_SCRIPTS_DIR = %q, want %q", upgradeScriptsDirEnv, upgradeScriptsDir)
+	}
+
+	if upgradeJobBackoffLimit != 4 {
+		t.Fatalf("upgradeJobBackoffLimit = %d, want 4", upgradeJobBackoffLimit)
+	}
+}
+
+func TestDefaultUpgradeJobCommandSurvivesUpgradeJobMutation(t *testing.T) {
+	r := newTestUpgradeReconciler()
+	if len(r.DefaultUpgradeJob.Containers) == 0 || len(r.DefaultUpgradeJob.Containers[0].Command) == 0 {
+		t.Fatal("expected default upgrade job template to include command")
+	}
+	if !strings.Contains(strings.Join(r.DefaultUpgradeJob.Containers[0].Command, " "), "upgrade_manager.js") {
+		t.Fatalf("default upgrade command missing upgrade_manager.js: %q",
+			strings.Join(r.DefaultUpgradeJob.Containers[0].Command, " "))
+	}
+
+	// ReconcileObject may clear command on the live Job; setDesiredUpgradeJob restores
+	// from DefaultUpgradeJob (DeepCopy from NewReconciler). Assert that source stays
+	// intact and the same copy used there restores the command, without calling
+	// setDesiredUpgradeJob (it uses global util.KubeCheckQuiet and needs kubeconfig).
+	r.UpgradeJob.Spec.Template.Spec.Containers[0].Command = nil
+	if len(r.DefaultUpgradeJob.Containers[0].Command) == 0 {
+		t.Fatal("mutating UpgradeJob command must not clear DefaultUpgradeJob template")
+	}
+
+	c := &r.UpgradeJob.Spec.Template.Spec.Containers[0]
+	defaultContainer := r.DefaultUpgradeJob.Containers[0]
+	c.Command = append([]string(nil), defaultContainer.Command...)
+	cmd := strings.Join(c.Command, " ")
+	if !strings.Contains(cmd, "upgrade_manager.js") {
+		t.Fatalf("restored upgrade command missing upgrade_manager.js: %q", cmd)
+	}
+}
+
+func TestShouldBlockWorkloadRestoreBlocksCoreReplicaRestore(t *testing.T) {
+	r := newTestUpgradeReconciler()
+	setCoreImage(r, "noobaa/noobaa-core:old")
+	r.NooBaa.Status.UpgradePhase = nbv1.UpgradePhaseUpgrade
+	if !r.shouldBlockWorkloadRestore() {
+		t.Fatal("expected workload restore to be blocked during upgrade")
+	}
+}
+
+func TestIsCoreUpgradeFinishedForActualImage(t *testing.T) {
+	tests := []struct {
+		name           string
+		phase          nbv1.UpgradePhase
+		actualImage    string
+		completedImage string
+		want           bool
+	}{
+		{
+			name:           "finished for current image",
+			phase:          nbv1.UpgradePhaseFinished,
+			actualImage:    "noobaa/noobaa-core:new",
+			completedImage: "noobaa/noobaa-core:new",
+			want:           true,
+		},
+		{
+			name:           "finished for previous image",
+			phase:          nbv1.UpgradePhaseFinished,
+			actualImage:    "noobaa/noobaa-core:newer",
+			completedImage: "noobaa/noobaa-core:new",
+			want:           false,
+		},
+		{
+			name:           "not finished phase",
+			phase:          nbv1.UpgradePhaseUpgrade,
+			actualImage:    "noobaa/noobaa-core:new",
+			completedImage: "noobaa/noobaa-core:new",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestUpgradeReconciler()
+			r.NooBaa.Status.UpgradePhase = tt.phase
+			r.NooBaa.Status.ActualImage = tt.actualImage
+			r.NooBaa.Status.LastSuccessfulUpgradeImage = tt.completedImage
+			if got := r.isCoreUpgradeFinishedForActualImage(); got != tt.want {
+				t.Fatalf("isCoreUpgradeFinishedForActualImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDeployedCoreImage(t *testing.T) {
+	r := newTestUpgradeReconciler()
+	setCoreImage(r, "noobaa/noobaa-core:deployed")
+	if got := r.getDeployedCoreImage(); got != "noobaa/noobaa-core:deployed" {
+		t.Fatalf("getDeployedCoreImage() = %q", got)
+	}
+}
+
+func TestIsUpgradeJobFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		failed int32
+		want   bool
+	}{
+		{name: "below backoffLimit", failed: upgradeJobBackoffLimit - 1, want: false},
+		{name: "equal to backoffLimit", failed: upgradeJobBackoffLimit, want: false},
+		{name: "above backoffLimit", failed: upgradeJobBackoffLimit + 1, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestUpgradeReconciler()
+			r.UpgradeJob.Status.Failed = tt.failed
+			if got := r.isUpgradeJobFailed(); got != tt.want {
+				t.Fatalf("isUpgradeJobFailed() with Failed=%d = %v, want %v", tt.failed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureUpgradeJobRecreateDeletesMismatchedImageAndRequeues(t *testing.T) {
+	r := newTestUpgradeReconciler()
+	r.UpgradeJob.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name:  "noobaa-core-upgrade",
+		Image: "noobaa/noobaa-core:old",
+	}}
+	r.NooBaa.Status.ActualImage = "noobaa/noobaa-core:new"
+	if err := r.Client.Create(r.Ctx, r.UpgradeJob.DeepCopy()); err != nil {
+		t.Fatalf("create stale upgrade job: %v", err)
+	}
+
+	deleted, err := r.ensureUpgradeJobRecreate()
+	if err != nil {
+		t.Fatalf("ensureUpgradeJobRecreate() error: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected ensureUpgradeJobRecreate() to delete mismatched job and request requeue")
+	}
+
+	err = r.Client.Get(r.Ctx, client.ObjectKeyFromObject(r.UpgradeJob), &batchv1.Job{})
+	if !k8serrors.IsNotFound(err) {
+		t.Fatalf("expected upgrade job to be deleted from the client, get err = %v", err)
+	}
+}


### PR DESCRIPTION
### Describe the Problem
Today the core upgrade runs from inside the `noobaa-core` pod itself.  This makes the upgrade flow harder for the operator to manage and makes failures/retries less clear. also it makes the upgrade depends on the core init process

### Explain the changes
1. Add a dedicated `noobaa-core-upgrade` Job that runs the upgrade before the `noobaa-core` pod is brought up with the new image.
2. Let the operator manage the upgrade flow: detect when an upgrade is needed, create the Job, wait for it to finish, and handle success or failure.
3. Scale down the core and endpoint pods before running the upgrade Job, and do not restore them until the upgrade completes successfully.
4. Pass the same database/configuration data the upgrade needs, including PostgreSQL/CNPG settings, secrets, CA bundles, and proxy env vars as core.
5. Add tests for the new upgrade flow and harden the upgrade Job security context.

### Issues: Fixed
https://redhat.atlassian.net/browse/RHSTOR-9433

### Gaps
1. remove upgrade from core_init.js in the core pod.
2. no deadline for the upgrade. we currently don't have measurements to how long it can take 

### Testing Instructions:
1. go test -mod=mod ./pkg/system/ -run Upgrade

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a one-time Kubernetes Job (`noobaa-core-upgrade`) to run core upgrade scripts in the core image.
  * Extended the NooBaa CRD/status with `status.lastSuccessfulUpgradeImage` to track the last completed upgrade image.
  * Improved upgrade-job wiring with database/CNPG handling and proxy-related environment variables.

* **Bug Fixes**
  * Reworked phase-based core image upgrade orchestration and related pod/restore coordination.
  * Adjusted environment configuration for DB connection paths and restore blocking behavior.

* **Tests**
  * Added/expanded unit tests for upgrade detection, job spec correctness, success/failure handling, and restore blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->