### PR TITLE
Add RBAC Permission For `events.k8s.io`

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -31,6 +31,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
   - pods/exec

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -6829,7 +6829,7 @@ spec:
         #     name: socket
 `
 
-const Sha256_deploy_role_yaml = "22c739e1b81a9d3c1b167b89c0e8e6757b2981b1434071aa4441332ec4c68d64"
+const Sha256_deploy_role_yaml = "074639a33687392f9d7d914133672af3f532d5f36bee61f9422f019f5aee394c"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -6863,6 +6863,14 @@ rules:
   - serviceaccounts
   verbs:
   - '*'
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
### Describe the Problem
While working on another epic, I noticed an error in the operator logs related to events. I've opened a PR to fix it.

### Explain the changes
1. Added RBAC (Role-Based Access Control) to `events.k8s.io` in `deploy/role.yaml`.

### Issues: Fixed [DFBUGS-8508](https://redhat.atlassian.net/browse/DFBUGS-8508)
1. Before the fix we could see in the logs of the operator errors such as:

```
E0719 04:50:13.675855       1 event_broadcaster.go:270] "Server rejected event (will not retry!)" err="events.events.k8s.io is forbidden: User \"system:serviceaccount:test1:noobaa\" cannot create resource \"events\" in API group \"events.k8s.io\" in the namespace \"test1\"" event="&Event{ObjectMeta:{noobaa-default-backing-store.18c397a5524b260a  test1    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},EventTime:2026-07-19 04:50:13.674888384 +0000 UTC m=+258.491744207,Series:nil,ReportingController:noobaa-operator,ReportingInstance:noobaa-operator-noobaa-operator-5cf84ffbc7-rwq28,Action:BackingStorePhaseReady,Reason:BackingStorePhaseReady,Regarding:{BackingStore test1 noobaa-default-backing-store 0df0a88e-8967-42e5-b587-53356ca3c062 noobaa.io/v1alpha1 743572 },Related:nil,Note:Backing store mode: OPTIMAL,Type:Normal,DeprecatedSource:{ },DeprecatedFirstTimestamp:0001-01-01 00:00:00 +0000 UTC,DeprecatedLastTimestamp:0001-01-01 00:00:00 +0000 UTC,DeprecatedCount:0,}"
```

2. To verify it, I run:
```
kubectl auth can-i create events.events.k8s.io \
  --namespace=test1 \
  --as=system:serviceaccount:test1:noobaa
```
(and saw `no`)
3. On the running cluster, I added the change in `deploy/role.yaml`: `kubectl apply -f deploy/role.yaml -n test1` (I saw `role.rbac.authorization.k8s.io/noobaa configured`).
4. Then verified it again:
```
kubectl auth can-i create events.events.k8s.io \
  --namespace=test1 \
  --as=system:serviceaccount:test1:noobaa
```
(and saw `yes`)
5. Then restart the operator with: `kubectl rollout restart deployment/noobaa-operator -n test1` (I saw `deployment.apps/noobaa-operator restarted`).
6. Checking the logs again - we didn't have the error anymore: `kubectl logs $(kubectl get pod -n test1 | grep operator | awk '{ print $1}') -n test1 | grep forbidden`

#### GAPs:
- We would need to edit the permissions that we have in `noobaa-core` and `noobaa-endpoint` as they contain irrelevant permissions, for example:
operator/blob/1ff9bcd0cd298313765592ceb2ae738321e572ed/deploy/role_core.yaml#L25
https://github.com/noobaa/noobaa-operator/blob/1ff9bcd0cd298313765592ceb2ae738321e572ed/deploy/role_endpoint.yaml#L25
(More details in the [comment](https://github.com/noobaa/noobaa-operator/pull/2034#issuecomment-5015306176))

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
Please notice that you musy run `make gen`, I used: `make gen ; make gen-api ; make`.
3. Wait a couple of minutes and check the logs of the operator pod to see that we don't have the error anymore, for example: `kubectl logs $(kubectl get pod -n test1 | grep operator | awk '{ print $1}') -n test1 | grep forbidden`

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes event reporting by enabling the application to create, update, and patch event records.
* **Chores**
  * Updated deployment RBAC permissions to ensure event activity works reliably after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->