### PR TITLE
core HA - add wire leader election to core pod

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ ARG NOOBAA_BIN_PATH=build/_output/bin/noobaa-operator
 # tar is needed for kubectl cp
 RUN microdnf -y install tar
 
-# install operator binary
+# install operator binary (includes Hidden leader-elect subcommand for core pods)
 COPY ${NOOBAA_BIN_PATH} ${OPERATOR}
 
 USER ${USER_UID}

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -27,6 +27,8 @@ spec:
       volumes:
         - name: logs
           emptyDir: {}
+        - name: shared-bin
+          emptyDir: {}
         - name: mgmt-secret
           secret:
             secretName: noobaa-mgmt-serving-cert
@@ -48,6 +50,20 @@ spec:
       securityContext:
         runAsUser: 10001
         runAsGroup: 0
+      initContainers:
+        - name: copy-leader-elect
+          image: NOOBAA_OPERATOR_IMAGE
+          command:
+            - cp
+            - /usr/local/bin/noobaa-operator
+            - /noobaa-shared/noobaa-operator
+          volumeMounts:
+            - name: shared-bin
+              mountPath: /noobaa-shared
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       containers:
         #----------------#
         # CORE CONTAINER #
@@ -60,9 +76,20 @@ spec:
             timeoutSeconds: 2
           image: NOOBAA_CORE_IMAGE
           terminationMessagePolicy: FallbackToLogsOnError
+          command:
+            - /noobaa-shared/noobaa-operator
+            - leader-elect
+            - --
+            - /bin/bash
+            - -ec
+            - |
+              exec /usr/local/bin/node /root/node_modules/noobaa-core/src/cmd/core_init.js
           volumeMounts:
             - name: logs
               mountPath: /log
+            - name: shared-bin
+              mountPath: /noobaa-shared
+              readOnly: true
             - name: mgmt-secret
               mountPath: /etc/mgmt-secret
               readOnly: true
@@ -119,6 +146,8 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_VERSION_AUTH_ENABLED
+            - name: NOOBAA_CORE_LEASE_NAME
+              value: ""
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_HOST_RO

--- a/deploy/role_core.yaml
+++ b/deploy/role_core.yaml
@@ -56,3 +56,11 @@ rules:
   - update
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5603,7 +5603,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "cc38a4b3cd26c43156962823645c43be26e39ed57a7205d6b390c7849c39651b"
+const Sha256_deploy_internal_statefulset_core_yaml = "1f60f4995b291944111536d9f70b2678ec75dd60f53c0340d2bf6adb5bdd1325"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5634,6 +5634,8 @@ spec:
       volumes:
         - name: logs
           emptyDir: {}
+        - name: shared-bin
+          emptyDir: {}
         - name: mgmt-secret
           secret:
             secretName: noobaa-mgmt-serving-cert
@@ -5655,6 +5657,20 @@ spec:
       securityContext:
         runAsUser: 10001
         runAsGroup: 0
+      initContainers:
+        - name: copy-leader-elect
+          image: NOOBAA_OPERATOR_IMAGE
+          command:
+            - cp
+            - /usr/local/bin/noobaa-operator
+            - /noobaa-shared/noobaa-operator
+          volumeMounts:
+            - name: shared-bin
+              mountPath: /noobaa-shared
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       containers:
         #----------------#
         # CORE CONTAINER #
@@ -5667,9 +5683,20 @@ spec:
             timeoutSeconds: 2
           image: NOOBAA_CORE_IMAGE
           terminationMessagePolicy: FallbackToLogsOnError
+          command:
+            - /noobaa-shared/noobaa-operator
+            - leader-elect
+            - --
+            - /bin/bash
+            - -ec
+            - |
+              exec /usr/local/bin/node /root/node_modules/noobaa-core/src/cmd/core_init.js
           volumeMounts:
             - name: logs
               mountPath: /log
+            - name: shared-bin
+              mountPath: /noobaa-shared
+              readOnly: true
             - name: mgmt-secret
               mountPath: /etc/mgmt-secret
               readOnly: true
@@ -5726,6 +5753,8 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_VERSION_AUTH_ENABLED
+            - name: NOOBAA_CORE_LEASE_NAME
+              value: ""
             - name: POSTGRES_HOST
               value: "noobaa-db-pg-0.noobaa-db-pg"
             - name: POSTGRES_HOST_RO
@@ -7142,7 +7171,7 @@ subjects:
   name: custom-metrics-prometheus-adapter
 `
 
-const Sha256_deploy_role_core_yaml = "92e0178504b6d3ff202db026efe38de5cac63d29751b5e488842aa5326f36156"
+const Sha256_deploy_role_core_yaml = "922820415ce947d0f60eb47b82e2032806839729db5f587c5eddd6be8d156433"
 
 const File_deploy_role_core_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7202,6 +7231,14 @@ rules:
   - update
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
 `
 
 const Sha256_deploy_role_db_yaml = "bc7eeca1125dfcdb491ab8eb69e3dcbce9f004a467b88489f85678b3c6872cce"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/crd"
 	"github.com/noobaa/noobaa-operator/v5/pkg/diagnostics"
 	"github.com/noobaa/noobaa-operator/v5/pkg/install"
+	"github.com/noobaa/noobaa-operator/v5/pkg/leaderelect"
 	"github.com/noobaa/noobaa-operator/v5/pkg/namespacestore"
 	"github.com/noobaa/noobaa-operator/v5/pkg/noobaaaccount"
 	"github.com/noobaa/noobaa-operator/v5/pkg/obc"
@@ -153,6 +154,7 @@ Load noobaa completion to bash:
 			crd.Cmd(),
 			olm.Cmd(),
 			bench.Cmd(),
+			leaderelect.Cmd(),
 		},
 	}}
 

--- a/pkg/leaderelect/leaderelect.go
+++ b/pkg/leaderelect/leaderelect.go
@@ -1,0 +1,455 @@
+// Package leaderelect implements a PID-1 leader-election exec wrapper.
+//
+// Exposed as a Hidden cobra subcommand of the noobaa-operator binary and
+// copied into the core pod from the operator image:
+//
+//	noobaa-operator leader-elect [flags] -- <command> [args...]
+//
+// The command is Hidden so it does not appear in public CLI help. The wrapper
+// acquires a namespaced Lease, spawns the given command in its own process
+// group while holding leadership, reaps orphaned children (PID 1), and on
+// SIGTERM/SIGINT or leadership loss stops the child group before releasing
+// the Lease (ReleaseOnCancel).
+package leaderelect
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const (
+	exitOK     = 0
+	exitConfig = 1
+	exitLost   = 2
+
+	envLeaseName    = "NOOBAA_CORE_LEASE_NAME"
+	envPodNamespace = "POD_NAMESPACE"
+	saNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+	defaultLeaseDuration = 20 * time.Second
+	defaultRenewDeadline = 10 * time.Second
+	defaultRetryPeriod   = 3 * time.Second
+	defaultShutdownGrace = 25 * time.Second
+	defaultLostGrace     = 8 * time.Second
+	// childSigkillWait is how long stopChild waits after SIGKILL for the child process group to exit before returning.
+	childSigkillWait = 5 * time.Second
+	// leaseReleaseMargin is extra time after child teardown for ReleaseOnCancel.
+	leaseReleaseMargin = 10 * time.Second
+)
+
+// RecommendedTerminationGracePeriod is the pod terminationGracePeriodSeconds
+// that leaves room for ShutdownGrace + SIGKILL wait + lease release on cancel.
+func RecommendedTerminationGracePeriod(shutdownGrace time.Duration) int64 {
+	if shutdownGrace <= 0 {
+		shutdownGrace = defaultShutdownGrace
+	}
+	return int64((shutdownGrace + childSigkillWait + leaseReleaseMargin) / time.Second)
+}
+
+// Config holds leader-elect wrapper settings.
+type Config struct {
+	LeaseName     string
+	LeaseDuration time.Duration
+	RenewDeadline time.Duration
+	RetryPeriod   time.Duration
+	ShutdownGrace time.Duration
+	LostGrace     time.Duration
+	Command       []string
+}
+
+// Cmd returns the leader-elect CLI command (Hidden — for in-pod use).
+func Cmd() *cobra.Command {
+	cfg := defaultConfig()
+	cmd := &cobra.Command{
+		Hidden:                true,
+		Use:                   "leader-elect -- <command> [args...]",
+		Short:                 "Acquire a Lease then exec a command (PID 1 leader-elect wrapper)",
+		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
+		Args:                  cobra.ArbitraryArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg.Command = args
+			if err := cfg.Validate(); err != nil {
+				fmt.Fprintf(os.Stderr, "leader-elect: %v\n", err)
+				os.Exit(exitConfig)
+			}
+			os.Exit(Run(cfg))
+		},
+	}
+	bindFlags(cmd, cfg)
+	return cmd
+}
+
+func defaultConfig() *Config {
+	return &Config{
+		LeaseName:     os.Getenv(envLeaseName),
+		LeaseDuration: defaultLeaseDuration,
+		RenewDeadline: defaultRenewDeadline,
+		RetryPeriod:   defaultRetryPeriod,
+		ShutdownGrace: defaultShutdownGrace,
+		LostGrace:     defaultLostGrace,
+	}
+}
+
+func bindFlags(cmd *cobra.Command, cfg *Config) {
+	cmd.Flags().StringVar(&cfg.LeaseName, "lease-name", cfg.LeaseName, "Lease object name (default: $NOOBAA_CORE_LEASE_NAME)")
+	cmd.Flags().DurationVar(&cfg.LeaseDuration, "lease-duration", cfg.LeaseDuration, "Lease duration")
+	cmd.Flags().DurationVar(&cfg.RenewDeadline, "renew-deadline", cfg.RenewDeadline, "Leadership renew deadline")
+	cmd.Flags().DurationVar(&cfg.RetryPeriod, "retry-period", cfg.RetryPeriod, "Leadership retry period")
+	cmd.Flags().DurationVar(&cfg.ShutdownGrace, "shutdown-grace", cfg.ShutdownGrace, "Time to wait for child exit after SIGTERM/SIGINT before SIGKILL")
+	cmd.Flags().DurationVar(&cfg.LostGrace, "lost-grace", cfg.LostGrace, "Time to wait for child exit after leadership loss before SIGKILL")
+}
+
+// ParseArgs parses leader-elect flags and the wrapped command (args after flags/--).
+// It does not run the election or spawn processes.
+func ParseArgs(args []string) (*Config, error) {
+	cfg := defaultConfig()
+	cmd := &cobra.Command{
+		Use:           "leader-elect",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Args:          cobra.ArbitraryArgs,
+		Run: func(_ *cobra.Command, a []string) {
+			cfg.Command = a
+		},
+	}
+	bindFlags(cmd, cfg)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// Validate checks required fields and the lost-grace invariant.
+func (c *Config) Validate() error {
+	if c == nil {
+		return fmt.Errorf("nil config")
+	}
+	if c.LeaseName == "" {
+		return fmt.Errorf("--lease-name is required (or set $%s)", envLeaseName)
+	}
+	if len(c.Command) == 0 {
+		return fmt.Errorf("command is required after --")
+	}
+	maxLost := c.LeaseDuration - c.RenewDeadline
+	if maxLost <= 0 {
+		return fmt.Errorf("lease-duration (%v) must be greater than renew-deadline (%v)", c.LeaseDuration, c.RenewDeadline)
+	}
+	if c.LostGrace >= maxLost {
+		return fmt.Errorf("--lost-grace (%v) must be < lease-duration - renew-deadline (%v)", c.LostGrace, maxLost)
+	}
+	return nil
+}
+
+// Run acquires the Lease, runs the command while leading, and returns a process exit code.
+func Run(cfg *Config) int {
+	log := util.Logger()
+
+	namespace := resolveNamespace()
+	identity := leaderIdentity()
+
+	clientset, err := kubernetes.NewForConfig(util.KubeConfig())
+	if err != nil {
+		log.Errorf("leader-elect: create clientset: %v", err)
+		return exitConfig
+	}
+
+	lock, err := resourcelock.New(
+		resourcelock.LeasesResourceLock,
+		namespace,
+		cfg.LeaseName,
+		clientset.CoreV1(),
+		clientset.CoordinationV1(),
+		resourcelock.ResourceLockConfig{Identity: identity},
+	)
+	if err != nil {
+		log.Errorf("leader-elect: create lock: %v", err)
+		return exitConfig
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := &runner{
+		cfg:    cfg,
+		cancel: cancel,
+		log:    log,
+	}
+
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		sig := <-sigCh
+		r.log.Infof("leader-elect: received %v, stopping child then releasing lease", sig)
+		r.stopChild(cfg.ShutdownGrace)
+		r.forceExit(exitOK)
+		cancel()
+	}()
+
+	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   cfg.LeaseDuration,
+		RenewDeadline:   cfg.RenewDeadline,
+		RetryPeriod:     cfg.RetryPeriod,
+		ReleaseOnCancel: true,
+		Name:            cfg.LeaseName,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leadCtx context.Context) {
+				r.onStartedLeading(leadCtx)
+			},
+			OnStoppedLeading: func() {
+				r.log.Infof("leader-elect: stopped leading (identity %s)", identity)
+			},
+		},
+	})
+	if err != nil {
+		log.Errorf("leader-elect: create elector: %v", err)
+		return exitConfig
+	}
+
+	log.Infof("leader-elect: waiting for lease %s/%s as %s", namespace, cfg.LeaseName, identity)
+	le.Run(ctx)
+
+	return r.getExit()
+}
+
+func resolveNamespace() string {
+	if ns := os.Getenv(envPodNamespace); ns != "" {
+		return ns
+	}
+	data, err := os.ReadFile(saNamespaceFile)
+	if err == nil {
+		if ns := strings.TrimSpace(string(data)); ns != "" {
+			return ns
+		}
+	}
+	return options.Namespace
+}
+
+func leaderIdentity() string {
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		hostname = "unknown"
+	}
+	return hostname + "_" + string(uuid.NewUUID())
+}
+
+type logger interface {
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+type runner struct {
+	cfg    *Config
+	cancel context.CancelFunc
+	log    logger
+
+	mu            sync.Mutex
+	childPID      int
+	childExited   chan struct{} // closed once the main child is reaped
+	childCode     int
+	exitCode      int
+	exitSet       bool
+	termRequested bool
+}
+
+func (r *runner) setExit(code int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.exitSet {
+		r.exitCode = code
+		r.exitSet = true
+	}
+}
+
+func (r *runner) forceExit(code int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.exitCode = code
+	r.exitSet = true
+}
+
+func (r *runner) getExit() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.exitSet {
+		// Cancelled before leading (e.g. SIGTERM while waiting for lease).
+		return exitOK
+	}
+	return r.exitCode
+}
+
+func (r *runner) onStartedLeading(leadCtx context.Context) {
+	r.log.Infof("leader-elect: acquired lease, starting %v", r.cfg.Command)
+
+	cmd := exec.Command(r.cfg.Command[0], r.cfg.Command[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		r.log.Errorf("leader-elect: spawn: %v", err)
+		r.setExit(exitConfig)
+		r.cancel()
+		return
+	}
+
+	childPID := cmd.Process.Pid
+	childDone := make(chan struct{})
+
+	r.mu.Lock()
+	r.childPID = childPID
+	r.childExited = childDone
+	// SIGTERM may have arrived before Start() while childPID was 0; stopChild
+	// returned without signaling. Re-check under the same lock as the publish.
+	alreadyTerm := r.termRequested
+	r.mu.Unlock()
+
+	// Single Wait4(-1) loop: observes the main child and reaps orphans (PID 1).
+	go r.waitAndReap(childPID, childDone)
+
+	if alreadyTerm {
+		r.stopChild(r.cfg.ShutdownGrace)
+		return
+	}
+
+	select {
+	case <-childDone:
+		r.mu.Lock()
+		termRequested := r.termRequested
+		r.mu.Unlock()
+		if termRequested {
+			// SIGTERM/lost path owns the wrapper exit code.
+			return
+		}
+		code := r.getChildCode()
+		r.log.Infof("leader-elect: child exited with code %d", code)
+		r.setExit(code)
+		r.cancel() // release lease after child is down
+	case <-leadCtx.Done():
+		r.mu.Lock()
+		termRequested := r.termRequested
+		r.mu.Unlock()
+		if termRequested {
+			// SIGTERM path owns teardown; wait for child then return.
+			select {
+			case <-childDone:
+			case <-time.After(r.cfg.ShutdownGrace + childSigkillWait):
+			}
+			return
+		}
+		r.log.Errorf("leader-elect: leadership lost, stopping child")
+		r.stopChild(r.cfg.LostGrace)
+		r.forceExit(exitLost)
+		select {
+		case <-childDone:
+		case <-time.After(r.cfg.LostGrace + childSigkillWait):
+		}
+	}
+}
+
+func (r *runner) getChildCode() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.childCode
+}
+
+// waitAndReap blocks on Wait4(-1), records the main child's exit code once, and
+// continues reaping any orphaned grandchildren until no children remain.
+func (r *runner) waitAndReap(childPID int, done chan struct{}) {
+	childReported := false
+	for {
+		var status syscall.WaitStatus
+		wpid, err := syscall.Wait4(-1, &status, 0, nil)
+		if err == syscall.EINTR {
+			continue
+		}
+		if err != nil {
+			// ECHILD: no children left.
+			if !childReported {
+				r.mu.Lock()
+				r.childCode = exitConfig
+				r.mu.Unlock()
+				close(done)
+			}
+			return
+		}
+		if wpid == childPID && !childReported {
+			childReported = true
+			r.mu.Lock()
+			r.childCode = waitStatusExitCode(status)
+			r.mu.Unlock()
+			close(done)
+		}
+	}
+}
+
+func waitStatusExitCode(status syscall.WaitStatus) int {
+	if status.Exited() {
+		return status.ExitStatus()
+	}
+	if status.Signaled() {
+		return 128 + int(status.Signal())
+	}
+	return exitConfig
+}
+
+func (r *runner) stopChild(grace time.Duration) {
+	r.mu.Lock()
+	r.termRequested = true
+	pid := r.childPID
+	done := r.childExited
+	r.mu.Unlock()
+
+	if pid <= 0 {
+		return
+	}
+
+	// Signal the whole process group (Setpgid makes pgid == child pid).
+	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+		r.log.Errorf("leader-elect: kill pgid %d SIGTERM: %v", pid, err)
+	}
+
+	if done == nil {
+		return
+	}
+
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return
+	case <-timer.C:
+		r.log.Infof("leader-elect: grace %v elapsed, SIGKILL process group %d", grace, pid)
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+			r.log.Errorf("leader-elect: kill pgid %d SIGKILL: %v", pid, err)
+		}
+		select {
+		case <-done:
+		case <-time.After(childSigkillWait):
+		}
+	}
+}

--- a/pkg/leaderelect/leaderelect_test.go
+++ b/pkg/leaderelect/leaderelect_test.go
@@ -1,0 +1,239 @@
+package leaderelect
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseArgs(t *testing.T) {
+	// Clear env so default lease-name does not leak across cases.
+	t.Setenv(envLeaseName, "")
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantLease    string
+		wantCmd      []string
+		wantLost     time.Duration
+		wantShutdown time.Duration
+		wantErr      string
+	}{
+		{
+			name:         "double-dash splits command",
+			args:         []string{"--lease-name=foo", "--", "/usr/local/bin/node", "core_init.js"},
+			wantLease:    "foo",
+			wantCmd:      []string{"/usr/local/bin/node", "core_init.js"},
+			wantLost:     defaultLostGrace,
+			wantShutdown: defaultShutdownGrace,
+		},
+		{
+			name:      "command without double-dash",
+			args:      []string{"--lease-name=bar", "sleep", "100"},
+			wantLease: "bar",
+			wantCmd:   []string{"sleep", "100"},
+		},
+		{
+			name:         "custom grace flags",
+			args:         []string{"--lease-name=x", "--lost-grace=5s", "--shutdown-grace=15s", "--", "echo", "hi"},
+			wantLease:    "x",
+			wantCmd:      []string{"echo", "hi"},
+			wantLost:     5 * time.Second,
+			wantShutdown: 15 * time.Second,
+		},
+		{
+			name:      "lease-duration and renew-deadline",
+			args:      []string{"--lease-name=x", "--lease-duration=30s", "--renew-deadline=12s", "--retry-period=4s", "--", "true"},
+			wantLease: "x",
+			wantCmd:   []string{"true"},
+		},
+		{
+			name:    "missing lease-name",
+			args:    []string{"--", "sleep", "1"},
+			wantErr: "--lease-name is required",
+		},
+		{
+			name:    "missing command",
+			args:    []string{"--lease-name=foo"},
+			wantErr: "command is required after --",
+		},
+		{
+			name:    "lost-grace equal to lease-duration minus renew-deadline",
+			args:    []string{"--lease-name=foo", "--lease-duration=20s", "--renew-deadline=10s", "--lost-grace=10s", "--", "sleep", "1"},
+			wantErr: "--lost-grace",
+		},
+		{
+			name:    "lost-grace greater than lease-duration minus renew-deadline",
+			args:    []string{"--lease-name=foo", "--lease-duration=20s", "--renew-deadline=10s", "--lost-grace=15s", "--", "sleep", "1"},
+			wantErr: "--lost-grace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ParseArgs(tt.args)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.LeaseName != tt.wantLease {
+				t.Errorf("LeaseName = %q, want %q", cfg.LeaseName, tt.wantLease)
+			}
+			if !reflect.DeepEqual(cfg.Command, tt.wantCmd) {
+				t.Errorf("Command = %#v, want %#v", cfg.Command, tt.wantCmd)
+			}
+			if tt.wantLost != 0 && cfg.LostGrace != tt.wantLost {
+				t.Errorf("LostGrace = %v, want %v", cfg.LostGrace, tt.wantLost)
+			}
+			if tt.wantShutdown != 0 && cfg.ShutdownGrace != tt.wantShutdown {
+				t.Errorf("ShutdownGrace = %v, want %v", cfg.ShutdownGrace, tt.wantShutdown)
+			}
+			if tt.name == "lease-duration and renew-deadline" {
+				if cfg.LeaseDuration != 30*time.Second {
+					t.Errorf("LeaseDuration = %v, want 30s", cfg.LeaseDuration)
+				}
+				if cfg.RenewDeadline != 12*time.Second {
+					t.Errorf("RenewDeadline = %v, want 12s", cfg.RenewDeadline)
+				}
+				if cfg.RetryPeriod != 4*time.Second {
+					t.Errorf("RetryPeriod = %v, want 4s", cfg.RetryPeriod)
+				}
+			}
+		})
+	}
+}
+
+func TestParseArgsLeaseNameFromEnv(t *testing.T) {
+	t.Setenv(envLeaseName, "from-env-lease")
+	cfg, err := ParseArgs([]string{"--", "true"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LeaseName != "from-env-lease" {
+		t.Fatalf("LeaseName = %q, want from-env-lease", cfg.LeaseName)
+	}
+}
+
+func TestValidateGraceInvariant(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "defaults ok",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: defaultLeaseDuration,
+				RenewDeadline: defaultRenewDeadline,
+				LostGrace:     defaultLostGrace,
+				Command:       []string{"sleep"},
+			},
+		},
+		{
+			name: "lost-grace just under max",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: 20 * time.Second,
+				RenewDeadline: 10 * time.Second,
+				LostGrace:     9 * time.Second,
+				Command:       []string{"sleep"},
+			},
+		},
+		{
+			name: "lost-grace equal rejected",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: 20 * time.Second,
+				RenewDeadline: 10 * time.Second,
+				LostGrace:     10 * time.Second,
+				Command:       []string{"sleep"},
+			},
+			wantErr: "--lost-grace",
+		},
+		{
+			name: "lost-grace above max rejected",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: 20 * time.Second,
+				RenewDeadline: 10 * time.Second,
+				LostGrace:     11 * time.Second,
+				Command:       []string{"sleep"},
+			},
+			wantErr: "--lost-grace",
+		},
+		{
+			name: "lease-duration not greater than renew-deadline",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: 10 * time.Second,
+				RenewDeadline: 10 * time.Second,
+				LostGrace:     1 * time.Second,
+				Command:       []string{"sleep"},
+			},
+			wantErr: "lease-duration",
+		},
+		{
+			name: "missing lease name",
+			cfg: Config{
+				LeaseDuration: defaultLeaseDuration,
+				RenewDeadline: defaultRenewDeadline,
+				LostGrace:     defaultLostGrace,
+				Command:       []string{"sleep"},
+			},
+			wantErr: "--lease-name is required",
+		},
+		{
+			name: "missing command",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: defaultLeaseDuration,
+				RenewDeadline: defaultRenewDeadline,
+				LostGrace:     defaultLostGrace,
+			},
+			wantErr: "command is required after --",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRecommendedTerminationGracePeriod(t *testing.T) {
+	t.Parallel()
+	// defaultShutdownGrace(25s) + childSigkillWait(5s) + leaseReleaseMargin(10s)
+	if got, want := RecommendedTerminationGracePeriod(0), int64(40); got != want {
+		t.Fatalf("RecommendedTerminationGracePeriod(0) = %d, want %d", got, want)
+	}
+	if got, want := RecommendedTerminationGracePeriod(30*time.Second), int64(45); got != want {
+		t.Fatalf("RecommendedTerminationGracePeriod(30s) = %d, want %d", got, want)
+	}
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,7 +30,7 @@ const (
 	// ContainerImageRepo is the repo of the default image url
 	ContainerImageRepo = "noobaa-core"
 	// ContainerImageTag is the tag of the default image url
-	ContainerImageTag = "master-20260603"
+	ContainerImageTag = "master-20260726"
 	// ContainerImageSemverLowerBound is the lower bound for supported image versions
 	ContainerImageSemverLowerBound = "5.0.0"
 	// ContainerImageSemverUpperBound is the upper bound for supported image versions

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libopenstorage/secrets"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/bundle"
+	"github.com/noobaa/noobaa-operator/v5/pkg/leaderelect"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util/kms"
@@ -618,6 +619,9 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			} else {
 				c.Env[j].Value = falseStr
 			}
+
+		case "NOOBAA_CORE_LEASE_NAME":
+			c.Env[j].Value = r.Request.Name + "-core-leader"
 		}
 	}
 
@@ -646,9 +650,9 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	r.CoreApp.Spec.ServiceName = r.ServiceMgmt.Name
 
 	podSpec := &r.CoreApp.Spec.Template.Spec
-	// set the termination grace period for noobaa-core pod.
-	// For now we set it to 1 second. A better approach should be to implement a graceful shutdown for the noobaa-core pod when SIGTERM is received.
-	terminationGracePeriodSeconds := int64(1)
+	// ShutdownGrace (25s) + SIGKILL wait (5s) + lease-release margin (10s).
+	// Keep in sync with leaderelect.RecommendedTerminationGracePeriod.
+	terminationGracePeriodSeconds := leaderelect.RecommendedTerminationGracePeriod(0)
 	podSpec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 	podSpec.ServiceAccountName = "noobaa-core"
 	coreImageChanged := false
@@ -663,13 +667,39 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	// adding the missing Volumes from default podSpec
 	podSpec.Volumes = r.DefaultCoreApp.Volumes
 
+	// Upsert owned init containers from the default YAML so upgrades pick up
+	// copy-leader-elect without wiping webhook-injected or other foreign inits
+	// (KubeCheck loads the live STS over CoreApp).
+	operatorImage := GetRunningOperatorImage()
+	for i := range r.DefaultCoreApp.InitContainers {
+		desired := *r.DefaultCoreApp.InitContainers[i].DeepCopy()
+		if desired.Name == "copy-leader-elect" {
+			desired.Image = operatorImage
+		}
+		found := false
+		for j := range podSpec.InitContainers {
+			if podSpec.InitContainers[j].Name == desired.Name {
+				podSpec.InitContainers[j] = desired
+				found = true
+				break
+			}
+		}
+		if !found {
+			podSpec.InitContainers = append(podSpec.InitContainers, desired)
+		}
+	}
+
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]
 
-		// adding the missing VolumeMounts from default container
-		c.VolumeMounts = r.DefaultCoreApp.Containers[i].VolumeMounts
-		// adding the missing Env variable from default container
-		util.MergeEnvArrays(&c.Env, &r.DefaultCoreApp.Containers[i].Env)
+		if i < len(r.DefaultCoreApp.Containers) {
+			// adding the missing VolumeMounts from default container
+			c.VolumeMounts = r.DefaultCoreApp.Containers[i].VolumeMounts
+			// adding the missing Env variable from default container
+			util.MergeEnvArrays(&c.Env, &r.DefaultCoreApp.Containers[i].Env)
+			// Sync Command so upgrades converge on the leader-elect wrap
+			c.Command = append([]string(nil), r.DefaultCoreApp.Containers[i].Command...)
+		}
 		r.setDesiredCoreEnv(c)
 
 		switch c.Name {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -823,15 +823,20 @@ func CheckNooBaaDBImages(cmd *cobra.Command, sys *nbv1.NooBaa, args []string) st
 	return runningImage
 }
 
-// CheckOperatorImage runs a CLI command
-func CheckOperatorImage(cmd *cobra.Command, args []string) string {
-	runningImage := ""
+// GetRunningOperatorImage returns the image of the running operator Deployment,
+// falling back to options.OperatorImage when the Deployment is missing.
+func GetRunningOperatorImage() string {
 	deployment := util.KubeObject(bundle.File_deploy_operator_yaml).(*appsv1.Deployment)
 	deployment.Namespace = options.Namespace
-	if util.KubeCheckQuiet(deployment) {
-		runningImage = deployment.Spec.Template.Spec.Containers[0].Image
+	if util.KubeCheckQuiet(deployment) && len(deployment.Spec.Template.Spec.Containers) > 0 {
+		return deployment.Spec.Template.Spec.Containers[0].Image
 	}
-	return runningImage
+	return options.OperatorImage
+}
+
+// CheckOperatorImage runs a CLI command
+func CheckOperatorImage(cmd *cobra.Command, args []string) string {
+	return GetRunningOperatorImage()
 }
 
 // RunSystemVersionsStatus runs a CLI command


### PR DESCRIPTION
### Describe the Problem
Today the NooBaa core pod runs as a single active instance. If it fails or is rescheduled, there is no built-in way for a standby core pod to take over cleanly. We need active-passive high availability so only one core pod serves at a time, with automatic failover when the leader is lost.

### Explain the changes
change noobaa core init command to run kubernetes leader elect module before calling core_init
1. add kubernetes leader elect pkg
2. create a new init script `leaderelect.go` to acquire the lease before starting the core pod and then renew it
3. 

### Issues:
1.part of https://redhat.atlassian.net/browse/RHSTOR-7491

### GAPs
1. currently still uses 1 core pod. scaling to 2 and enabling and disabled referred to next PR

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes Lease–based leader election for core pods.
  * Exposed an advanced `leader-elect` CLI subcommand for configuring election behavior.
* **Improvements**
  * Core pod startup now uses a shared leader-election binary and updates core lease naming.
  * Expanded RBAC to allow Lease operations.
  * Improved core reconciliation convergence for commands, environment, and init containers.
  * Updated the default operator image tag.
* **Tests**
  * Added unit tests for `leader-elect` argument parsing, validation, and grace/termination calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->