### PR TITLE
Fix: stop PV-pool agent recreate loop on toleration superset match

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -1240,7 +1240,8 @@ func (r *Reconciler) needUpdate(pod *corev1.Pod) bool {
 	podTolerations := pod.Spec.Tolerations
 	noobaaTolerations := r.NooBaa.Spec.Tolerations
 	for _, noobaaToleration := range noobaaTolerations {
-		if !util.Contains(podTolerations, noobaaToleration) {
+		if !util.ContainsAny(podTolerations, noobaaToleration, util.IsTolerationSuperset) {
+			r.Logger.Warnf("Change in Tolerations detected: missing/uncovered (%+v) pod(%+v)", noobaaToleration, podTolerations)
 			return true
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2002,6 +2002,39 @@ func ContainsAny[T any](arr []T, item T, eq func(T, T) bool) bool {
 	return false
 }
 
+// IsTolerationSuperset returns true if ss tolerates a superset of t
+func IsTolerationSuperset(ss, t corev1.Toleration) bool {
+	if ss == t {
+		return true
+	}
+	// Empty key + Exists means match all keys and values.
+	if t.Key != ss.Key &&
+		(ss.Key != "" || ss.Operator != corev1.TolerationOpExists) {
+		return false
+	}
+	// Empty effect means match all effects.
+	if t.Effect != ss.Effect && ss.Effect != "" {
+		return false
+	}
+	// For NoExecute, ss must not expire sooner than t.
+	if ss.Effect == corev1.TaintEffectNoExecute {
+		if ss.TolerationSeconds != nil {
+			if t.TolerationSeconds == nil ||
+				*t.TolerationSeconds > *ss.TolerationSeconds {
+				return false
+			}
+		}
+	}
+	switch ss.Operator {
+	case corev1.TolerationOpEqual, "": // Empty operator means Equal (Kubernetes default)
+		return (t.Operator == corev1.TolerationOpEqual || t.Operator == "") && t.Value == ss.Value
+	case corev1.TolerationOpExists: // Exists covers Equal for the same key
+		return true
+	default:
+		return false
+	}
+}
+
 // GetEnvVariable is looking for env variable called name in env and return a pointer to the variable
 func GetEnvVariable(env *[]corev1.EnvVar, name string) *corev1.EnvVar {
 	for i := range *env {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -772,3 +772,166 @@ func TestValidateGCPWIFParams(t *testing.T) {
 		})
 	}
 }
+
+// TestIsTolerationSuperset tests the IsTolerationSuperset function
+func TestIsTolerationSuperset(t *testing.T) {
+	sec60 := int64(60)
+	sec30 := int64(30)
+
+	equal := corev1.Toleration{
+		Key:      "k",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "v",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	emptyOp := corev1.Toleration{
+		Key:    "k",
+		Value:  "v",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+	exists := corev1.Toleration{
+		Operator: corev1.TolerationOpExists,
+	}
+	keyExists := corev1.Toleration{
+		Key:      "k",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	other := corev1.Toleration{
+		Key:      "other",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "v",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	noExecute60 := corev1.Toleration{
+		Key:               "k",
+		Operator:          corev1.TolerationOpExists,
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: &sec60,
+	}
+	noExecute30 := corev1.Toleration{
+		Key:               "k",
+		Operator:          corev1.TolerationOpExists,
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: &sec30,
+	}
+	noExecuteForever := corev1.Toleration{
+		Key:      "k",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoExecute,
+	}
+
+	tests := []struct {
+		name     string
+		ss       corev1.Toleration
+		target   corev1.Toleration
+		expected bool
+	}{
+		{
+			name:     "identical",
+			ss:       equal,
+			target:   equal,
+			expected: true,
+		},
+		{
+			name:     "bare Exists covers Equal",
+			ss:       exists,
+			target:   equal,
+			expected: true,
+		},
+		{
+			name:     "Equal does not cover bare Exists",
+			ss:       equal,
+			target:   exists,
+			expected: false,
+		},
+		{
+			name:     "key Exists covers Equal",
+			ss:       keyExists,
+			target:   equal,
+			expected: true,
+		},
+		{
+			name:     "unrelated key",
+			ss:       other,
+			target:   equal,
+			expected: false,
+		},
+		{
+			name:     "empty ss operator means Equal",
+			ss:       emptyOp,
+			target:   equal,
+			expected: true,
+		},
+		{
+			name:     "empty target operator means Equal",
+			ss:       equal,
+			target:   emptyOp,
+			expected: true,
+		},
+		{
+			name:     "both empty operators match",
+			ss:       emptyOp,
+			target:   emptyOp,
+			expected: true,
+		},
+		{
+			name: "effect mismatch",
+			ss: corev1.Toleration{
+				Key:      "k",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "v",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			target: corev1.Toleration{
+				Key:      "k",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "v",
+				Effect:   corev1.TaintEffectNoExecute,
+			},
+			expected: false,
+		},
+		{
+			name:     "NoExecute with shorter seconds does not cover forever",
+			ss:       noExecute60,
+			target:   noExecuteForever,
+			expected: false,
+		},
+		{
+			name:     "NoExecute with shorter seconds does not cover longer seconds",
+			ss:       noExecute30,
+			target:   noExecute60,
+			expected: false,
+		},
+		{
+			name:     "NoExecute covers equal or shorter seconds",
+			ss:       noExecute60,
+			target:   noExecute30,
+			expected: true,
+		},
+		{
+			name: "unknown operator",
+			ss: corev1.Toleration{
+				Key:      "k",
+				Operator: "Unknown",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			target: corev1.Toleration{
+				Key:      "k",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "v",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := IsTolerationSuperset(tc.ss, tc.target)
+			if actual != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Describe the Problem
PV-pool BackingStore agent pods can loop create/delete when namespace `defaultTolerations` (via `PodTolerationRestriction`) leave the live pod with broader tolerations than `NooBaa.spec.tolerations`.

`needUpdate()` required an exact match instead of treating a pod toleration as sufficient when it is a superset of the CR entry (Kubernetes merge semantics), so it kept deleting agents that already covered the intended tolerations. That merge applies only to newly created pods; existing pods are unchanged until recreated.

Merge/superset behavior (in kubernetes/OpenShift): [kubernetes/pkg/util/tolerations/tolerations.go at master · kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/blob/master/pkg/util/tolerations/tolerations.go)

### Explain the changes
1. Compare CR tolerations against the live pod with Kubernetes-style superset coverage (`IsTolerationSuperset + ContainsAny`) instead of exact match, so a broader pod toleration (e.g. bare Exists) counts as covering the CR entries.
2. Log a warning when a CR toleration is still missing/uncovered before deleting the agent pod.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed: https://redhat.atlassian.net/browse/DFBUGS-8843

### Testing Instructions:
**Prereq:** OpenShift, or Kubernetes with PodTolerationRestriction enabled.

1) NS default toleration (bare Exists)
```
kubectl annotate ns default \
  scheduler.alpha.kubernetes.io/defaultTolerations='[{"operator":"Exists"}]' \
  --overwrite
```

2) Specific toleration on NooBaa CR
```
kubectl patch noobaa noobaa -n default --type=merge -p '{
  "spec": {
    "tolerations": [{
      "key": "node.ocs.openshift.io/storage",
      "operator": "Equal",
      "value": "true",
      "effect": "NoSchedule"
    }]
  }
}'
```

3) Confirm mismatch: CR specific vs pod Exists
```
kubectl get noobaa noobaa -n default -o jsonpath='{.spec.tolerations}{"\n"}'
kubectl get pods -n default -l pool=noobaa-default-backing-store \
  -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.tolerations}{"\n"}{end}'
```

4) Watch ~60s (or more) — with fix: AGE grows, no recreate loop; BackingStore Ready
```
kubectl get pods -n default -l pool=noobaa-default-backing-store -w
kubectl get backingstore noobaa-default-backing-store -n default

```

5) Cleanup:
`kubectl annotate ns default scheduler.alpha.kubernetes.io/defaultTolerations-`

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes pod update detection by treating existing pod tolerations as a “coverage” superset of the required spec, instead of requiring exact toleration matches.
  * Enhanced update behavior and messaging when required toleration coverage is missing or insufficient.

* **Tests**
  * Added unit tests for toleration superset evaluation, including operator/value/effect rules and `NoExecute` toleration seconds comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->