### PR TITLE
allow rwo in mcg only, use pvc_access_mode_rwo

### DIFF
--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -849,6 +849,10 @@ const (
 
 	// AlertmanagerHostOverride is Annotation name for overriding the alertmanager host, in the format https://<alertmanager-host>:<port>
 	AlertmanagerHostOverride = "noobaa.io/alertmanager_host_override"
+
+	// PVCAccessModeRWO is a boolean Annotation name for overriding the NooBaa PVC access mode.
+	// If set to true, the PVC access mode will be set to ReadWriteOnce.
+	PVCAccessModeRWO = "noobaa.io/pvc_access_mode_rwo"
 )
 
 // DBTypes is a string enum type for specify the types of DB that are supported.

--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -270,7 +270,7 @@ func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {
 
 	// update db volume resources
 	// update the storage configuration
-	err := setDesiredStorageConf(&r.CNPGCluster.Spec.StorageConfiguration, dbSpec)
+	err := setDesiredStorageConf(&r.CNPGCluster.Spec.StorageConfiguration, dbSpec, r.NooBaa.Annotations)
 	if err != nil {
 		r.cnpgLogError("got error getting desired storage configuration for cnpg cluster. error: %v", err)
 		return err
@@ -771,14 +771,15 @@ func getDesiredDbImage(dbSpec *nbv1.NooBaaDBSpec) string {
 	return desiredDbImage
 }
 
-func setDesiredStorageConf(storageConfiguration *cnpgv1.StorageConfiguration, dbSpec *nbv1.NooBaaDBSpec) error {
+func setDesiredStorageConf(storageConfiguration *cnpgv1.StorageConfiguration, dbSpec *nbv1.NooBaaDBSpec, annotations map[string]string) error {
 	if storageConfiguration == nil {
 		return fmt.Errorf("storage configuration is nil")
 	}
 	if storageConfiguration.PersistentVolumeClaimTemplate == nil {
 		storageConfiguration.PersistentVolumeClaimTemplate = &corev1.PersistentVolumeClaimSpec{}
 	}
-	storageConfiguration.PersistentVolumeClaimTemplate.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod}
+	accessMode := getDesiredDBPVCAccessMode(annotations)
+	storageConfiguration.PersistentVolumeClaimTemplate.AccessModes = []corev1.PersistentVolumeAccessMode{accessMode}
 	if dbSpec.DBStorageClass != nil {
 		storageConfiguration.StorageClass = dbSpec.DBStorageClass
 	} else {
@@ -810,6 +811,16 @@ func setDesiredStorageConf(storageConfiguration *cnpgv1.StorageConfiguration, db
 	storageConfiguration.Size = desiredSize
 
 	return nil
+}
+
+// getDesiredDBPVCAccessMode returns the DB PVC access mode from the NooBaa CR annotation.
+// Default is ReadWriteOncePod. Set noobaa.io/pvc_access_mode_rwo=true to use ReadWriteOnce
+// when the CSI driver lacks RWOP support.
+func getDesiredDBPVCAccessMode(annotations map[string]string) corev1.PersistentVolumeAccessMode {
+	if annotations != nil && annotations[nbv1.PVCAccessModeRWO] == "true" {
+		return corev1.ReadWriteOnce
+	}
+	return corev1.ReadWriteOncePod
 }
 
 func isClusterReady(cluster *cnpgv1.Cluster) bool {

--- a/pkg/system/db_reconciler_test.go
+++ b/pkg/system/db_reconciler_test.go
@@ -2,6 +2,10 @@ package system
 
 import (
 	"testing"
+
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestFormatBytesKB(t *testing.T) {
@@ -255,4 +259,79 @@ func assertParam(t *testing.T, params map[string]string, key, expected string) {
 	if got != expected {
 		t.Errorf("param %q = %q, want %q", key, got, expected)
 	}
+}
+
+func TestGetDesiredDBPVCAccessMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        corev1.PersistentVolumeAccessMode
+	}{
+		{
+			name:        "nil annotations defaults to RWOP",
+			annotations: nil,
+			want:        corev1.ReadWriteOncePod,
+		},
+		{
+			name:        "missing annotation defaults to RWOP",
+			annotations: map[string]string{},
+			want:        corev1.ReadWriteOncePod,
+		},
+		{
+			name:        "annotation true sets RWO",
+			annotations: map[string]string{nbv1.PVCAccessModeRWO: "true"},
+			want:        corev1.ReadWriteOnce,
+		},
+		{
+			name:        "annotation false keeps RWOP",
+			annotations: map[string]string{nbv1.PVCAccessModeRWO: "false"},
+			want:        corev1.ReadWriteOncePod,
+		},
+		{
+			name:        "annotation other value keeps RWOP",
+			annotations: map[string]string{nbv1.PVCAccessModeRWO: "yes"},
+			want:        corev1.ReadWriteOncePod,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDesiredDBPVCAccessMode(tt.annotations)
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetDesiredStorageConfAccessMode(t *testing.T) {
+	storageClass := "lab-rwo-only"
+	dbSpec := &nbv1.NooBaaDBSpec{
+		DBStorageClass: &storageClass,
+	}
+
+	t.Run("defaults to RWOP", func(t *testing.T) {
+		storageConfiguration := &cnpgv1.StorageConfiguration{}
+		if err := setDesiredStorageConf(storageConfiguration, dbSpec, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		modes := storageConfiguration.PersistentVolumeClaimTemplate.AccessModes
+		if len(modes) != 1 || modes[0] != corev1.ReadWriteOncePod {
+			t.Fatalf("got access modes %v, want [%s]", modes, corev1.ReadWriteOncePod)
+		}
+	})
+
+	t.Run("annotation true sets RWO", func(t *testing.T) {
+		storageConfiguration := &cnpgv1.StorageConfiguration{}
+		annotations := map[string]string{nbv1.PVCAccessModeRWO: "true"}
+		if err := setDesiredStorageConf(storageConfiguration, dbSpec, annotations); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		modes := storageConfiguration.PersistentVolumeClaimTemplate.AccessModes
+		if len(modes) != 1 || modes[0] != corev1.ReadWriteOnce {
+			t.Fatalf("got access modes %v, want [%s]", modes, corev1.ReadWriteOnce)
+		}
+		if storageConfiguration.StorageClass == nil || *storageConfiguration.StorageClass != storageClass {
+			t.Fatalf("got storage class %v, want %q", storageConfiguration.StorageClass, storageClass)
+		}
+	})
 }


### PR DESCRIPTION
### Describe the Problem

[DFBUGS-8863](https://redhat.atlassian.net/browse/DFBUGS-8863)

MCG-only (ODF 4.19+) hardcodes NooBaa DB PVC access mode to ReadWriteOncePod. CSI drivers without RWOP support (e.g. HPE) fail PVC provisioning and NooBaa never becomes Ready.

### Explain the changes
1. Add boolean NooBaa CR annotation noobaa.io/pvc_access_mode_rwo (true → RWO; missing/other → RWOP).
2. CNPG path (setDesiredStorageConf) reads the annotation and sets DB PVC access mode accordingly.
3. Add unit tests for the annotation and storage conf wiring.

### Issues: Fixed #xxx / Gap #xxx
1. DFBUGS-8863 — Allow RWO via NooBaa CR annotation when storage lacks RWOP (MCG-only).

### Testing Instructions:
1. Unit: go test -mod=mod ./pkg/system/ -run 'TestGetDesiredDBPVCAccessMode|TestSetDesiredStorageConfAccessMode' -count=1 -v
2. Cluster: MCG-only on non-RWOP storage (or lab deny policy) → annotate as below → confirm CNPG accessModes=["ReadWriteOnce"], DB PVCs Bound RWO, NooBaa Ready:
`oc -n openshift-storage annotate noobaa noobaa \
  noobaa.io/pvc_access_mode_rwo=true --overwrite`

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an annotation to control the database PVC access mode.
  * When the annotation value is exactly `"true"`, the PVC access mode is set to **ReadWriteOnce**; otherwise it defaults to **ReadWriteOncePod**.

* **Bug Fixes**
  * Improved database storage configuration so the selected access mode (and the configured storage class) is applied correctly.

* **Tests**
  * Added unit tests covering default behavior and annotation-driven access-mode selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->