### PR TITLE
CI | Automatically label Backport PRs

### DIFF
--- a/.github/workflows/label-backport-prs.yml
+++ b/.github/workflows/label-backport-prs.yml
@@ -1,0 +1,41 @@
+name: Label backport PRs
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+jobs:
+  label_pr:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const issue_number = context.payload.pull_request.number;
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            const backport_label = 'Backport PR';
+            const matches = title.startsWith('[Backport');
+
+            if (matches && !labels.includes(backport_label)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                labels: [backport_label],
+              });
+              console.log(`Added "${backport_label}" to PR #${issue_number}`);
+            } else if (!matches && labels.includes(backport_label)) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                name: backport_label,
+              });
+              console.log(`Removed "${backport_label}" from PR #${issue_number}`);
+            } else {
+              console.log(`PR #${issue_number} labels already correct`);
+            }


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (ported from noobaa-core) that labels PRs whose title starts with `[Backport` with `Backport PR`
- Also removes the label if the title no longer matches

## Test plan
- [ ] Merge and open (or retitle) a PR whose title starts with `[Backport`
- [ ] Confirm the `Backport PR` label is applied automatically
- [ ] Edit the title to remove the `[Backport` prefix and confirm the label is removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated pull request labeling for backport changes.
  * Labels are now added or removed automatically based on the pull request title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->