### PR TITLE
SCC | Add SCC (`openshift.io/required-scc`) Annotations (cnpg-controller-manager)

### DIFF
--- a/pkg/cnpg/cnpg.go
+++ b/pkg/cnpg/cnpg.go
@@ -14,6 +14,7 @@ import (
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	cnpgReleases "github.com/cloudnative-pg/cloudnative-pg/releases"
+	secv1 "github.com/openshift/api/security/v1"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -385,6 +386,10 @@ func modifyResources(cnpgRes *CnpgResources) {
 	depl.Spec.Template.Spec.Containers[0].Image = options.CnpgImage
 	// add app:noobaa label to the deployments pod
 	depl.Spec.Template.Labels["app"] = "noobaa"
+	if depl.Spec.Template.Annotations == nil {
+		depl.Spec.Template.Annotations = make(map[string]string)
+	}
+	depl.Spec.Template.Annotations[secv1.RequiredSCCAnnotation] = "restricted-v2"
 	// add WATCH_NAMESPACE env variable to the deployment to restrict the operator to current namespace
 	depl.Spec.Template.Spec.Containers[0].Env = append(depl.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name: "WATCH_NAMESPACE",


### PR DESCRIPTION
### Describe the Problem
Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) Enforce least-privileged Security Context Constraint (SCC) across ODF pods.

### Explain the changes
1. Edit `modifyResources` so we will have the `openshift.io/required-scc` annotation with `restricted-v2` (as it is used today).

### Issues:
1. none

### Testing Instructions:
#### Local cluster
1. Build the images and install the NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
2. `kubectl get pod -n test1 cnpg-controller-manager-67fcdc8888-j8vmr -o yaml | grep scc` (output: `openshift.io/required-scc: restricted-v2`).

#### OCP Cluster
Instructions are in the [comment](https://github.com/noobaa/noobaa-operator/pull/2040#issuecomment-5057572986) below.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Updated CNPG operator workloads to automatically set the required OpenShift Security Context Constraints (SCC) to `restricted-v2`.
  * Improved reliability by ensuring pod template annotations are initialized before applying the security annotation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->