### PR TITLE
SCC | Add SCC (`openshift.io/required-scc`) Annotations (Job analyze-resource)

### DIFF
--- a/deploy/job_analyze_resource.yml
+++ b/deploy/job_analyze_resource.yml
@@ -11,6 +11,11 @@ spec:
   activeDeadlineSeconds: 60
   ttlSecondsAfterFinished: 10
   template:
+    metadata:
+      labels:
+        app: noobaa
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       volumes:
       - name: cloud-credentials

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5963,7 +5963,7 @@ const File_deploy_internal_text_system_status_readme_rejected_tmpl = `
 	NooBaa Operator Version: {{.OperatorVersion}}
 `
 
-const Sha256_deploy_job_analyze_resource_yml = "c80810baeda94fd9dd97a6c62241be5c582e08009bdbb1f2a13992c99d90ea33"
+const Sha256_deploy_job_analyze_resource_yml = "679a4e5b63548cab5a3efdc44b4d21ff5709c8f2f4e48438cba077c9c7a14785"
 
 const File_deploy_job_analyze_resource_yml = `apiVersion: batch/v1
 kind: Job
@@ -5978,6 +5978,11 @@ spec:
   activeDeadlineSeconds: 60
   ttlSecondsAfterFinished: 10
   template:
+    metadata:
+      labels:
+        app: noobaa
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       volumes:
       - name: cloud-credentials


### PR DESCRIPTION
### Describe the Problem
Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) Enforce least-privileged Security Context Constraint (SCC) across ODF pods.

### Explain the changes
1. Edit job YAML Manifests (added to the `spec.template.metadata`, so pods will inherit this):
- `annotations` with `openshift.io/required-scc: restricted-v2`.
- `labels` with `app: noobaa` (noticed it was missing).


### Issues: 
1. none

### Testing Instructions:
1. Tested on OCP cluster using the CLI: `nb diagnostics analyze backingstore noobaa-default-backing-store -n openshift-storage`
2. During the running pods, verified: `kubectl get pod -n $NS noobaa-analyze-resource-wthmr -o yaml | grep scc`

```
    openshift.io/required-scc: restricted-v2
    openshift.io/scc: restricted-v2
    security.openshift.io/validated-scc-subject-type: user
```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the resource analysis job to run with the required restricted security context.
  * Preserved the application label on the job’s pods for consistent identification and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->