### PR TITLE
SCC | Add SCC (`openshift.io/required-scc`) Annotations (CNPG new DB pods)

### DIFF
--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/cnpg"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
+	secv1 "github.com/openshift/api/security/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -165,6 +166,17 @@ func (r *Reconciler) reconcileDBCluster() error {
 		// Check if noobaa CR has a recovery configuration.
 		if r.NooBaa.Spec.DBSpec.DBRecovery == nil {
 			// No recovery configuration found, set bootstrap configuration to init a new DB
+
+			// This is a fresh installation
+			// Set openshift.io/required-scc annotation for new clusters only
+			// This annotation is set in InheritedMetadata so CNPG will propagate it to newly created pods
+			// We only set this during initial cluster creation (not recovery) to avoid CNPG trying to patch existing pods,
+			// which would fail because OpenShift doesn't allow changing the required-scc annotation on running pods
+			if r.CNPGCluster.Spec.InheritedMetadata.Annotations == nil {
+				r.CNPGCluster.Spec.InheritedMetadata.Annotations = map[string]string{}
+			}
+			r.CNPGCluster.Spec.InheritedMetadata.Annotations[secv1.RequiredSCCAnnotation] = "restricted-v2"
+
 			if r.CNPGCluster.Spec.Bootstrap == nil {
 				r.CNPGCluster.Spec.Bootstrap = &cnpgv1.BootstrapConfiguration{
 					InitDB: &cnpgv1.BootstrapInitDB{


### PR DESCRIPTION
### Describe the Problem
Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) Enforce least-privileged Security Context Constraint (SCC) across ODF pods.

### Explain the changes
1.  Add the `openshift.io/required-scc` with a value of `restricted-v2` to the DB pods of fresh installations (therefore is it implemented under `if r.CNPGCluster.UID == ""`).

### Issues: Fixed #2012
1. In the Jira ticket, it was decided that due to the issue, we will have the annotation of `openshift.io/required-scc` only in new NooBaa installations.

### Testing Instructions:
##### Local Cluster:
1. Build the images and install the NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
2. Check that you can see the annotation using the following examples:
- `kubectl get pod -n test1 noobaa-db-pg-cluster-1-initdb-4bd68 -o yaml | grep scc`
    openshift.io/required-scc: restricted-v2
- `kubectl get pod -n test1 noobaa-db-pg-cluster-1 -o yaml | grep scc`
    openshift.io/required-scc: restricted-v2

#### OCP Cluster:
Since it is on a fresh installation and not just replacing the image on an existing system, I couldn't test it.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved OpenShift compatibility for newly created database clusters by automatically applying the required security context configuration for restricted security policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->