### PR TITLE
CLI | Backingstore Change the Wait Interval Back to 3 Seconds

### DIFF
--- a/pkg/backingstore/backingstore.go
+++ b/pkg/backingstore/backingstore.go
@@ -1108,7 +1108,7 @@ func WaitReady(backStore *nbv1.BackingStore) bool {
 	log := util.Logger()
 	klient := util.KubeClient()
 
-	interval := time.Duration(30)
+	interval := time.Duration(3)
 
 	err := wait.PollUntilContextCancel(ctx, interval*time.Second, true, func(ctx context.Context) (bool, error) {
 		err := klient.Get(util.Context(), util.ObjectKey(backStore), backStore)


### PR DESCRIPTION
### Describe the Problem
I noticed that the interval for backingstore creation was changed from 3 to 30 seconds (it is still 3 seconds in namespacestore), suggesting changing it back to what it was.
When I worked on another epic, using 30 seconds interval gave the feeling like something was stuck.

### Explain the changes
1. In the function `WaitReady` change the `time.Duration` from 30 to 3.

### Issues:
1. none

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create a new backingstore and notice the printing intervals on the left, for example: `nb backingstore create pv-pool bs-shira-01 -n test1 --num-volumes 1 --request-cpu 500m --limit-cpu 500m --request-memory 500Mi --limit-memory 500Mi --pv-size-gb 20 -n test1`
Partial output:
```
INFO[0129] ⏳ BackingStore "bs-shira-01" Phase is "Creating": BackingStorePhaseCreating noobaa operator started phase 3/3 - "Creating"
INFO[0132] ⏳ BackingStore "bs-shira-01" Phase is "Creating": BackingStorePhaseCreating noobaa operator started phase 3/3 - "Creating"
INFO[0135] ⏳ BackingStore "bs-shira-01" Phase is "Creating": BackingStorePhaseCreating noobaa operator started phase 3/3 - "Creating"
INFO[0138] ⏳ BackingStore "bs-shira-01" Phase is "Creating": BackingStorePhaseCreating noobaa operator started phase 3/3 - "Creating"
INFO[0141] ⏳ BackingStore "bs-shira-01" Phase is "Creating": BackingStorePhaseCreating noobaa operator started phase 3/3 - "Creating"
INFO[0144] ⏳ BackingStore "bs-shira-01" Phase is "Creating": BackingStorePhaseCreating noobaa operator started phase 3/3 - "Creating"
INFO[0147] ⏳ BackingStore "bs-shira-01" Phase is "Creating": BackingStorePhaseCreating noobaa operator started phase 3/3 - "Creating"
INFO[0150] ✅ BackingStore "bs-shira-01" Phase is Ready
INFO[0150]
INFO[0150]
INFO[0150] ✅ Exists: BackingStore "bs-shira-01"
INFO[0150] ✅ BackingStore "bs-shira-01" Phase is Ready
```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness monitoring by checking status updates more frequently.
  * Failures and readiness changes are now detected sooner during CLI wait operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->