### PR TITLE
[Direct into 5.16] Bumping deps to avoid CVE (26/07/2026)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/noobaa/noobaa-operator/v5
 
-go 1.23.0
+go 1.23.10
 
 replace (
 	// TODO: remove this replace once https://github.com/libopenstorage/secrets/pull/83 is merged


### PR DESCRIPTION
### Explain the Changes
1. [Direct into 5.16] Bumping deps to avoid CVE (26/07/2026)