### PR TITLE
Replace default-ibm-z profile with in-place CPU request adjustment on s390x

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1946,7 +1946,6 @@ spec:
                   Explicit per-component resource/count fields take precedence over the profile.
                 enum:
                 - default
-                - default-ibm-z
                 - mixed-workload
                 - small-objects
                 - dev-env

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -262,7 +262,7 @@ type NooBaaSpec struct {
 	// settings for the core, db and endpoint components.
 	// Explicit per-component resource/count fields take precedence over the profile.
 	// +optional
-	// +kubebuilder:validation:Enum=default;default-ibm-z;mixed-workload;small-objects;dev-env;mini-env
+	// +kubebuilder:validation:Enum=default;mixed-workload;small-objects;dev-env;mini-env
 	PerformanceProfile PerformanceProfileType `json:"performanceProfile,omitempty"`
 }
 
@@ -894,8 +894,6 @@ type PerformanceProfileType string
 const (
 	// PerformanceProfileDefault is the default profile
 	PerformanceProfileDefault PerformanceProfileType = "default"
-	// PerformanceProfileDefaultIBMZ is the default profile adjusted for IBM Z (s390x) with halved CPU requests
-	PerformanceProfileDefaultIBMZ PerformanceProfileType = "default-ibm-z"
 	// PerformanceProfileMixedWorkload is for mixed workload
 	PerformanceProfileMixedWorkload PerformanceProfileType = "mixed-workload"
 	// PerformanceProfileSmallObjects is for small objects workload

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1511,7 +1511,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "e359dfd8f3c4a8ef7ac5605b1c86ce6d939846435e13c8376cef2252bb9e95f4"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "88be0872b57677c437aeb656eac747cd13871d9b2733d41b0b2ec5b2d4ea7603"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -3461,7 +3461,6 @@ spec:
                   Explicit per-component resource/count fields take precedence over the profile.
                 enum:
                 - default
-                - default-ibm-z
                 - mixed-workload
                 - small-objects
                 - dev-env

--- a/pkg/system/performance_profiles.go
+++ b/pkg/system/performance_profiles.go
@@ -1,12 +1,19 @@
 package system
 
 import (
+	"runtime"
+
 	"github.com/sirupsen/logrus"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	ibmZCpuArch         = "s390x"
+	ibmZCpuAdjustFactor = 0.5
 )
 
 type performanceProfile struct {
@@ -41,18 +48,6 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 		dbResources:       profileResources("1", "1", "2Gi", "2Gi"),
 		endpointResources: profileResources("500m", "2", "1Gi", "3Gi"),
 		pvPoolResources:   profileResources("400m", "400m", "800Mi", "800Mi"),
-		endpointMinCount:  1,
-		endpointMaxCount:  2,
-		dbInstances:       2,
-		pvPoolNumVolumes:  3,
-	},
-	// for IBM Z, we adjust the CPU requests by a factor of 0.5 https://redhat.atlassian.net/browse/RHSTOR-9067
-	nbv1.PerformanceProfileDefaultIBMZ: {
-		coreResources:     profileResources("250m", "1", "1Gi", "4Gi"),
-		logResources:      profileResources("200m", "200m", "500Mi", "500Mi"),
-		dbResources:       profileResources("500m", "1", "2Gi", "2Gi"),
-		endpointResources: profileResources("250m", "2", "1Gi", "3Gi"),
-		pvPoolResources:   profileResources("200m", "400m", "800Mi", "800Mi"),
 		endpointMinCount:  1,
 		endpointMaxCount:  2,
 		dbInstances:       2,
@@ -104,6 +99,23 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 	},
 }
 
+// On IBM Z (s390x), halve CPU requests for all profile-managed components once at
+// startup, matching ocs-operator's IbmZCpuAdjustFactor.
+// See https://redhat.atlassian.net/browse/RHSTOR-9067
+func init() {
+	if runtime.GOARCH != ibmZCpuArch {
+		return
+	}
+	for name, profile := range performanceProfiles {
+		profile.coreResources = adjustCpuResourcesForIbmZ(profile.coreResources, ibmZCpuAdjustFactor)
+		profile.logResources = adjustCpuResourcesForIbmZ(profile.logResources, ibmZCpuAdjustFactor)
+		profile.dbResources = adjustCpuResourcesForIbmZ(profile.dbResources, ibmZCpuAdjustFactor)
+		profile.endpointResources = adjustCpuResourcesForIbmZ(profile.endpointResources, ibmZCpuAdjustFactor)
+		profile.pvPoolResources = adjustCpuResourcesForIbmZ(profile.pvPoolResources, ibmZCpuAdjustFactor)
+		performanceProfiles[name] = profile
+	}
+}
+
 func lookupProfile(nb *nbv1.NooBaa) performanceProfile {
 	profileType := nb.Spec.PerformanceProfile
 	if profile, ok := performanceProfiles[profileType]; ok {
@@ -141,6 +153,21 @@ func getEndpointResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {
 		return *nb.Spec.Endpoints.Resources
 	}
 	return lookupProfile(nb).endpointResources
+}
+
+// adjustCpuResourcesForIbmZ multiplies CPU requests by adjustFactor (limits are unchanged).
+func adjustCpuResourcesForIbmZ(rr corev1.ResourceRequirements, adjustFactor float64) corev1.ResourceRequirements {
+	rrCopy := rr.DeepCopy()
+	if rrCopy.Requests != nil {
+		if cpuRequest, exists := rrCopy.Requests[corev1.ResourceCPU]; exists {
+			rrCopy.Requests[corev1.ResourceCPU] = adjustCpu(cpuRequest, adjustFactor)
+		}
+	}
+	return *rrCopy
+}
+
+func adjustCpu(cpuQty resource.Quantity, adjustFactor float64) resource.Quantity {
+	return *resource.NewMilliQuantity(int64(float64(cpuQty.MilliValue())*adjustFactor), resource.DecimalSI)
 }
 
 func getDBInstances(nb *nbv1.NooBaa) int {

--- a/pkg/system/performance_profiles_test.go
+++ b/pkg/system/performance_profiles_test.go
@@ -613,15 +613,6 @@ func TestProfileResourcesValues(t *testing.T) {
 			pvPool:   [4]string{"400m", "400m", "800Mi", "800Mi"},
 		},
 		{
-			name:     "default-ibm-z",
-			profile:  nbv1.PerformanceProfileDefaultIBMZ,
-			core:     [4]string{"250m", "1", "1Gi", "4Gi"},
-			log:      [4]string{"200m", "200m", "500Mi", "500Mi"},
-			db:       [4]string{"500m", "1", "2Gi", "2Gi"},
-			endpoint: [4]string{"250m", "2", "1Gi", "3Gi"},
-			pvPool:   [4]string{"200m", "400m", "800Mi", "800Mi"},
-		},
-		{
 			name:     "mixed-workload",
 			profile:  nbv1.PerformanceProfileMixedWorkload,
 			core:     [4]string{"1", "2", "2Gi", "4Gi"},
@@ -680,5 +671,71 @@ func assertResourceQuantity(t *testing.T, resources corev1.ResourceRequirements,
 	}
 	if resources.Limits.Memory().Cmp(memLim) != 0 {
 		t.Errorf("memory limit = %s, want %s", resources.Limits.Memory().String(), memLim.String())
+	}
+}
+
+func TestAdjustCpuResourcesForIbmZ(t *testing.T) {
+	tests := []struct {
+		name       string
+		cpuReq     string
+		cpuLim     string
+		factor     float64
+		wantCPUReq string
+		wantCPULim string
+	}{
+		{
+			name:       "whole number cpu",
+			cpuReq:     "2",
+			cpuLim:     "4",
+			factor:     0.5,
+			wantCPUReq: "1",
+			wantCPULim: "4",
+		},
+		{
+			name:       "fractional cpu",
+			cpuReq:     "1.5",
+			cpuLim:     "2",
+			factor:     0.5,
+			wantCPUReq: "750m",
+			wantCPULim: "2",
+		},
+		{
+			name:       "even milli cpu",
+			cpuReq:     "500m",
+			cpuLim:     "1",
+			factor:     0.5,
+			wantCPUReq: "250m",
+			wantCPULim: "1",
+		},
+		{
+			name:       "odd milli cpu",
+			cpuReq:     "501m",
+			cpuLim:     "1",
+			factor:     0.5,
+			wantCPUReq: "250m", // int64 truncates 250.5
+			wantCPULim: "1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := profileResources(tt.cpuReq, tt.cpuLim, "1Gi", "4Gi")
+			got := adjustCpuResourcesForIbmZ(input, tt.factor)
+
+			wantCPUReq := resource.MustParse(tt.wantCPUReq)
+			wantCPULim := resource.MustParse(tt.wantCPULim)
+			if got.Requests.Cpu().Cmp(wantCPUReq) != 0 {
+				t.Errorf("cpu request = %s, want %s", got.Requests.Cpu().String(), wantCPUReq.String())
+			}
+			if got.Limits.Cpu().Cmp(wantCPULim) != 0 {
+				t.Errorf("cpu limit = %s, want %s", got.Limits.Cpu().String(), wantCPULim.String())
+			}
+			if got.Requests.Memory().Cmp(*input.Requests.Memory()) != 0 {
+				t.Errorf("memory request changed unexpectedly")
+			}
+			if got.Limits.Memory().Cmp(*input.Limits.Memory()) != 0 {
+				t.Errorf("memory limit changed unexpectedly")
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Describe the Problem
A dedicated `default-ibm-z` performance profile is not the right approach for IBM Z. By agreement, IBM Z should have all the same features as a normal ODF deployment, so NooBaa resource profiles should be usable on IBM Z as well. IBM Z's situation is unique in that its CPUs are very powerful, so having half as much CPU request compared to other architectures makes sense—rather than maintaining a separate profile.

### Explain the changes
1. Remove the `default-ibm-z` performance profile from the API, CRD, and profile map
2. On `runtime.GOARCH == s390x`, halve CPU requests (factor 0.5) for all profile-managed components—core, log, db, endpoint, and pvPool—once at startup in `init()`, matching ocs-operator / ocs-client-operator. Limits are unchanged; explicit resource overrides still take precedence
3. Add unit tests for `adjustCpuResourcesForIbmZ` (whole, fractional, even/odd milli CPU)

Follow Up to
https://github.com/red-hat-storage/ocs-operator/pull/4039

### Testing Instructions:
1. Unit: `go test ./pkg/system/ -run 'TestAdjustCpuResourcesForIbmZ|TestLookupProfile|TestGetCoreResources|TestGetDBResources|TestGetEndpointResources|TestGetLogResources|TestGetPVPoolResources'`
2. Confirm `performanceProfile: default-ibm-z` is no longer a valid enum value on the NooBaa CRD
3. On s390x, verify core/log/db/endpoint/pvPool CPU requests from any profile are halved; explicit resource overrides are unchanged

- [ ] Doc added/updated
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance profiles for mixed workloads, small objects, development environments, and minimal environments.
  * IBM Z systems now automatically apply optimized CPU request sizing across supported performance profiles.

* **Breaking Changes**
  * Removed the `default-ibm-z` performance profile option. Use the standard `default` profile on IBM Z systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->