### PR TITLE
Include log processor resources in performance profiles

### DIFF
--- a/pkg/system/performance_profiles.go
+++ b/pkg/system/performance_profiles.go
@@ -11,7 +11,7 @@ import (
 
 type performanceProfile struct {
 	coreResources     corev1.ResourceRequirements
-	logResources      *corev1.ResourceRequirements
+	logResources      corev1.ResourceRequirements
 	dbResources       corev1.ResourceRequirements
 	endpointResources corev1.ResourceRequirements
 	pvPoolResources   corev1.ResourceRequirements
@@ -37,6 +37,7 @@ func profileResources(cpuReq, cpuLim, memReq, memLim string) corev1.ResourceRequ
 var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 	nbv1.PerformanceProfileDefault: {
 		coreResources:     profileResources("500m", "1", "1Gi", "4Gi"),
+		logResources:      profileResources("200m", "200m", "500Mi", "500Mi"),
 		dbResources:       profileResources("1", "1", "2Gi", "2Gi"),
 		endpointResources: profileResources("500m", "2", "1Gi", "3Gi"),
 		pvPoolResources:   profileResources("400m", "400m", "800Mi", "800Mi"),
@@ -48,6 +49,7 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 	// for IBM Z, we adjust the CPU requests by a factor of 0.5 https://redhat.atlassian.net/browse/RHSTOR-9067
 	nbv1.PerformanceProfileDefaultIBMZ: {
 		coreResources:     profileResources("250m", "1", "1Gi", "4Gi"),
+		logResources:      profileResources("200m", "200m", "500Mi", "500Mi"),
 		dbResources:       profileResources("500m", "1", "2Gi", "2Gi"),
 		endpointResources: profileResources("250m", "2", "1Gi", "3Gi"),
 		pvPoolResources:   profileResources("200m", "400m", "800Mi", "800Mi"),
@@ -58,6 +60,7 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 	},
 	nbv1.PerformanceProfileMixedWorkload: {
 		coreResources:     profileResources("1", "2", "2Gi", "4Gi"),
+		logResources:      profileResources("200m", "200m", "500Mi", "500Mi"),
 		dbResources:       profileResources("4", "4", "8Gi", "8Gi"),
 		endpointResources: profileResources("2", "4", "2Gi", "4Gi"),
 		pvPoolResources:   profileResources("1", "1", "2Gi", "2Gi"),
@@ -68,6 +71,7 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 	},
 	nbv1.PerformanceProfileSmallObjects: {
 		coreResources:     profileResources("1", "2", "2Gi", "6Gi"),
+		logResources:      profileResources("200m", "200m", "500Mi", "500Mi"),
 		dbResources:       profileResources("6", "6", "16Gi", "16Gi"),
 		endpointResources: profileResources("2", "4", "2Gi", "4Gi"),
 		pvPoolResources:   profileResources("1", "1", "2Gi", "2Gi"),
@@ -78,6 +82,7 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 	},
 	nbv1.PerformanceProfileDevEnv: {
 		coreResources:     profileResources("500m", "500m", "1Gi", "1Gi"),
+		logResources:      profileResources("200m", "200m", "500Mi", "500Mi"),
 		dbResources:       profileResources("1", "1", "2Gi", "2Gi"),
 		endpointResources: profileResources("500m", "500m", "500Mi", "500Mi"),
 		pvPoolResources:   profileResources("500m", "500m", "500Mi", "500Mi"),
@@ -87,17 +92,8 @@ var performanceProfiles = map[nbv1.PerformanceProfileType]performanceProfile{
 		pvPoolNumVolumes:  1,
 	},
 	nbv1.PerformanceProfileMiniEnv: {
-		coreResources: profileResources("100m", "100m", "1Gi", "1Gi"),
-		logResources: &corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("50m"),
-				corev1.ResourceMemory: resource.MustParse("200Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("50m"),
-				corev1.ResourceMemory: resource.MustParse("200Mi"),
-			},
-		},
+		coreResources:     profileResources("100m", "100m", "1Gi", "1Gi"),
+		logResources:      profileResources("50m", "50m", "200Mi", "200Mi"),
 		dbResources:       profileResources("100m", "100m", "500Mi", "500Mi"),
 		endpointResources: profileResources("100m", "100m", "500Mi", "500Mi"),
 		pvPoolResources:   profileResources("100m", "100m", "400Mi", "400Mi"),
@@ -126,9 +122,9 @@ func getCoreResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {
 	return lookupProfile(nb).coreResources
 }
 
-func getLogResources(nb *nbv1.NooBaa) *corev1.ResourceRequirements {
+func getLogResources(nb *nbv1.NooBaa) corev1.ResourceRequirements {
 	if nb.Spec.LogResources != nil {
-		return nb.Spec.LogResources
+		return *nb.Spec.LogResources
 	}
 	return lookupProfile(nb).logResources
 }

--- a/pkg/system/performance_profiles_test.go
+++ b/pkg/system/performance_profiles_test.go
@@ -109,6 +109,52 @@ func TestGetCoreResources(t *testing.T) {
 	}
 }
 
+func TestGetLogResources(t *testing.T) {
+	explicit := profileResources("300m", "300m", "300Mi", "300Mi")
+
+	tests := []struct {
+		name     string
+		nb       *nbv1.NooBaa
+		expected corev1.ResourceRequirements
+	}{
+		{
+			name: "default profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileDefault,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileDefault].logResources,
+		},
+		{
+			name: "mini-env profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileMiniEnv,
+				},
+			},
+			expected: performanceProfiles[nbv1.PerformanceProfileMiniEnv].logResources,
+		},
+		{
+			name: "explicit log resources override profile",
+			nb: &nbv1.NooBaa{
+				Spec: nbv1.NooBaaSpec{
+					PerformanceProfile: nbv1.PerformanceProfileDefault,
+					LogResources:       &explicit,
+				},
+			},
+			expected: explicit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getLogResources(tt.nb)
+			assertResourceRequirements(t, got, tt.expected)
+		})
+	}
+}
+
 func TestGetDBResources(t *testing.T) {
 	explicitCNPG := profileResources("5", "5", "5Gi", "5Gi")
 
@@ -503,6 +549,7 @@ func TestGetResourcesPrecedencePerComponent(t *testing.T) {
 func assertPerformanceProfile(t *testing.T, got, want performanceProfile) {
 	t.Helper()
 	assertResourceRequirements(t, got.coreResources, want.coreResources)
+	assertResourceRequirements(t, got.logResources, want.logResources)
 	assertResourceRequirements(t, got.dbResources, want.dbResources)
 	assertResourceRequirements(t, got.endpointResources, want.endpointResources)
 	assertResourceRequirements(t, got.pvPoolResources, want.pvPoolResources)
@@ -551,6 +598,7 @@ func TestProfileResourcesValues(t *testing.T) {
 		name     string
 		profile  nbv1.PerformanceProfileType
 		core     [4]string
+		log      [4]string
 		db       [4]string
 		endpoint [4]string
 		pvPool   [4]string
@@ -559,6 +607,7 @@ func TestProfileResourcesValues(t *testing.T) {
 			name:     "default",
 			profile:  nbv1.PerformanceProfileDefault,
 			core:     [4]string{"500m", "1", "1Gi", "4Gi"},
+			log:      [4]string{"200m", "200m", "500Mi", "500Mi"},
 			db:       [4]string{"1", "1", "2Gi", "2Gi"},
 			endpoint: [4]string{"500m", "2", "1Gi", "3Gi"},
 			pvPool:   [4]string{"400m", "400m", "800Mi", "800Mi"},
@@ -567,6 +616,7 @@ func TestProfileResourcesValues(t *testing.T) {
 			name:     "default-ibm-z",
 			profile:  nbv1.PerformanceProfileDefaultIBMZ,
 			core:     [4]string{"250m", "1", "1Gi", "4Gi"},
+			log:      [4]string{"200m", "200m", "500Mi", "500Mi"},
 			db:       [4]string{"500m", "1", "2Gi", "2Gi"},
 			endpoint: [4]string{"250m", "2", "1Gi", "3Gi"},
 			pvPool:   [4]string{"200m", "400m", "800Mi", "800Mi"},
@@ -575,6 +625,7 @@ func TestProfileResourcesValues(t *testing.T) {
 			name:     "mixed-workload",
 			profile:  nbv1.PerformanceProfileMixedWorkload,
 			core:     [4]string{"1", "2", "2Gi", "4Gi"},
+			log:      [4]string{"200m", "200m", "500Mi", "500Mi"},
 			db:       [4]string{"4", "4", "8Gi", "8Gi"},
 			endpoint: [4]string{"2", "4", "2Gi", "4Gi"},
 			pvPool:   [4]string{"1", "1", "2Gi", "2Gi"},
@@ -583,9 +634,19 @@ func TestProfileResourcesValues(t *testing.T) {
 			name:     "small-objects",
 			profile:  nbv1.PerformanceProfileSmallObjects,
 			core:     [4]string{"1", "2", "2Gi", "6Gi"},
+			log:      [4]string{"200m", "200m", "500Mi", "500Mi"},
 			db:       [4]string{"6", "6", "16Gi", "16Gi"},
 			endpoint: [4]string{"2", "4", "2Gi", "4Gi"},
 			pvPool:   [4]string{"1", "1", "2Gi", "2Gi"},
+		},
+		{
+			name:     "mini-env",
+			profile:  nbv1.PerformanceProfileMiniEnv,
+			core:     [4]string{"100m", "100m", "1Gi", "1Gi"},
+			log:      [4]string{"50m", "50m", "200Mi", "200Mi"},
+			db:       [4]string{"100m", "100m", "500Mi", "500Mi"},
+			endpoint: [4]string{"100m", "100m", "500Mi", "500Mi"},
+			pvPool:   [4]string{"100m", "100m", "400Mi", "400Mi"},
 		},
 	}
 
@@ -593,6 +654,7 @@ func TestProfileResourcesValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			profile := performanceProfiles[tt.profile]
 			assertResourceQuantity(t, profile.coreResources, tt.core)
+			assertResourceQuantity(t, profile.logResources, tt.log)
 			assertResourceQuantity(t, profile.dbResources, tt.db)
 			assertResourceQuantity(t, profile.endpointResources, tt.endpoint)
 			assertResourceQuantity(t, profile.pvPoolResources, tt.pvPool)

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -27,7 +27,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -784,22 +783,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 				c.Image = r.NooBaa.Status.ActualImage
 			}
 
-			if logResources := getLogResources(r.NooBaa); logResources != nil {
-				c.Resources = *logResources
-			} else {
-				var reqCPU, reqMem resource.Quantity
-				reqCPU, _ = resource.ParseQuantity("200m")
-				reqMem, _ = resource.ParseQuantity("500Mi")
-
-				logResourceList := corev1.ResourceList{
-					corev1.ResourceCPU:    reqCPU,
-					corev1.ResourceMemory: reqMem,
-				}
-				c.Resources = corev1.ResourceRequirements{
-					Requests: logResourceList,
-					Limits:   logResourceList,
-				}
-			}
+			c.Resources = getLogResources(r.NooBaa)
 			// we want to check that the cm exists and also that it has data in it
 			if util.KubeCheckQuiet(r.CaBundleConf) && len(r.CaBundleConf.Data) > 0 {
 				configMapVolumeMounts := []corev1.VolumeMount{{


### PR DESCRIPTION
### Describe the Problem
The `noobaa-log-processor` container resources were only set via the performance profile for `mini-env`. All other profiles fell back to a hardcoded 200m/500Mi in `phase2_creating.go`, while core, db, endpoint, and pv-pool already live in the profiles. That split makes resource defaults harder to maintain and inconsistent with the profile model.

### Explain the changes
1. Add `logResources` to every performance profile (`default`, `default-ibm-z`, `mixed-workload`, `small-objects`, `dev-env`, `mini-env`)
2. Drive log-processor resources from the profile (or `spec.logResources` override) and remove the hardcoded fallback
3. Add/extend unit tests for log resources in profiles and `getLogResources`

This consolidates resource requirements in a single place for better consistency, handling, and maintenance.

### Issues: Fixed #xxx / Gap #xxx
1. N/A

### Testing Instructions:
1. Unit: `go test ./pkg/system/ -run 'TestGetLogResources|TestProfileResourcesValues|TestLookupProfile'`
2. Create/reconcile a NooBaa with `performanceProfile: default` and confirm `noobaa-log-processor` gets 200m/500Mi from the profile
3. With `performanceProfile: mini-env`, confirm log processor gets 50m/200Mi
4. Set `spec.logResources` and confirm it overrides the profile

- [ ] Doc added/updated
- [x] Tests added

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and standardized log-processor resource configuration across all supported performance profiles.
  * Explicit log-resource configuration now reliably overrides the selected profile’s defaults.
  * Ensured profile defaults are applied consistently when no explicit log resources are set.

* **Tests**
  * Added new test coverage for profile-based vs explicitly configured log resources.
  * Expanded existing performance profile assertions to include log-resource expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->