### PR TITLE
Reduce CPU request for noobaa-operator pod

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -87,7 +87,7 @@ spec:
               cpu: "250m"
               memory: "512Mi"
             requests:
-              cpu: "100m"
+              cpu: "10m"
               memory: "256Mi"
           env:
             - name: OPERATOR_NAME

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -6742,7 +6742,7 @@ spec:
   sourceNamespace: default
 `
 
-const Sha256_deploy_operator_yaml = "e32d15db85c924ccda2f0d4ea6b3351ab35735866646126205bd7cd3a53732f0"
+const Sha256_deploy_operator_yaml = "f07a5e8c1750d485746a48e94faf1c7c9d9bd4f5622377a1d27b990387e7815f"
 
 const File_deploy_operator_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -6833,7 +6833,7 @@ spec:
               cpu: "250m"
               memory: "512Mi"
             requests:
-              cpu: "100m"
+              cpu: "10m"
               memory: "256Mi"
           env:
             - name: OPERATOR_NAME


### PR DESCRIPTION
## Summary
- Lower `noobaa-operator` CPU request from `100m` to `10m` (limit stays `250m`)

## Why this value was high
The `100m` CPU request was not based on measured need. It was added in [#1639](https://github.com/noobaa/noobaa-operator/pull/1639) as part of a broader epic to set requests/limits on each pod. NooBaa had been running fine without any CPU request before that; `100m` was a general approximation reused across operators at the time.

## Why lowering the request is safe
Operator pods are not CPU-intensive by design. They spend most of their lifetime idle and only wake to reconcile resources or respond to cluster events. During those brief bursts of activity they can still use CPU as needed — this change reduces only the **request**, not the **limit**.

This work comes from the IBM Z CPU adjust epic (reducing unnecessary CPU requests on operator-related pods), where testing showed these operator pods requesting more CPU than needed.

## Consistency with other operators
We have already reduced CPU requests for related operators to `10m`:

- **ocs-operator**: `50m` → `10m` — [red-hat-storage/ocs-operator#4061](https://github.com/red-hat-storage/ocs-operator/pull/4061)
- **odf-operator**: `200m` → `10m` — [red-hat-storage/odf-operator#886](https://github.com/red-hat-storage/odf-operator/pull/886)
- **rook-ceph-operator**: reduced to `10m` — [red-hat-storage/rook#1249](https://github.com/red-hat-storage/rook/pull/1249)
- **csi**, **csi-addons**, **ocs-client-operator**, and **odf-external-snapshotter** are already at `10m`

This change brings noobaa-operator in line with that standard.

## Note on CNPG
`cnpg-controller-manager` is intentionally left at the upstream `100m` CPU request. Unlike noobaa-operator, CNPG orchestrates Postgres failover/switchover (requeueing every ~1s while failover is in progress) and serves admission webhooks. Its upstream manifests and common deployments keep `cpu: 100m`, and lowering that request needs more testing under node CPU pressure.

Ref: https://redhat.atlassian.net/browse/RHSTOR-9516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced the NooBaa operator’s default CPU request to lower baseline resource consumption.

* **Compatibility**
  * Removed the `default-ibm-z` option from the `performanceProfile` configuration choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->