### PR TITLE
fix: ensure NooBaaAccount credentials Secret exists before Ready

### DIFF
--- a/pkg/nb/types.go
+++ b/pkg/nb/types.go
@@ -44,6 +44,7 @@ type AccountInfo struct {
 	NextPasswordChange int64          `json:"next_password_change"`
 	DefaultResource    string         `json:"default_resource"`
 	AccessKeys         []S3AccessKeys `json:"access_keys"`
+	ARN                string         `json:"arn,omitempty"`
 	AllowedIPs         []struct {
 		Start string `json:"start"`
 		End   string `json:"end"`

--- a/pkg/noobaaaccount/reconciler.go
+++ b/pkg/noobaaaccount/reconciler.go
@@ -261,7 +261,8 @@ func (r *Reconciler) ReconcilePhaseConfiguring() error {
 		}
 	}
 
-	return nil
+	// Ensure credentials Secret exists before Ready
+	return r.ensureNoobaaAccountSecret()
 }
 
 // ReconcileDeletion handles the deletion of a noobaa account using the noobaa api
@@ -355,23 +356,50 @@ func (r *Reconciler) CreateNooBaaAccount() error {
 			return err
 		}
 		accessKeys = readAccountReply.AccessKeys[0]
+		if accountInfo.ARN == "" {
+			accountInfo.ARN = readAccountReply.ARN
+		}
 	} else {
 		accessKeys = accountInfo.AccessKeys[0]
 	}
-	r.Secret.StringData = map[string]string{}
-	r.Secret.StringData["AWS_ACCESS_KEY_ID"] = string(accessKeys.AccessKey)
-	r.Secret.StringData["AWS_SECRET_ACCESS_KEY"] = string(accessKeys.SecretKey)
-	r.Secret.StringData["ARN"] = string(accountInfo.ARN)
 
-	r.Own(r.Secret)
-	err = r.Client.Create(r.Ctx, r.Secret)
-	if err != nil {
-		r.Logger.Errorf("got error on NooBaaAccount creation. error: %v", err)
+	if err := r.createNoobaaAccountSecret(accessKeys, accountInfo.ARN); err != nil {
 		return err
 	}
 
 	log.Infof("✅ Successfully created account %q", r.NooBaaAccount.Name)
 	return nil
+}
+
+// createNoobaaAccountSecret creates the credentials Secret for the NooBaaAccount
+func (r *Reconciler) createNoobaaAccountSecret(accessKeys nb.S3AccessKeys, arn string) error {
+	r.Secret.StringData = map[string]string{
+		"AWS_ACCESS_KEY_ID":     string(accessKeys.AccessKey),
+		"AWS_SECRET_ACCESS_KEY": string(accessKeys.SecretKey),
+		"ARN":                   arn,
+	}
+	r.Own(r.Secret)
+	if !util.KubeCreateSkipExisting(r.Secret) {
+		return fmt.Errorf("Failed to create NoobaaAccount secret %q", r.Secret.Name)
+	}
+	return nil
+}
+
+// ensureNoobaaAccountSecret ensures the credentials Secret exists for the NooBaaAccount
+func (r *Reconciler) ensureNoobaaAccountSecret() error {
+	if util.KubeCheck(r.Secret) {
+		return nil
+	}
+
+	r.Logger.Warnf("⏳ Secret %q is missing, recreating from account credentials", r.Secret.Name)
+	accountInfo, err := r.NBClient.ReadAccountAPI(nb.ReadAccountParams{Email: r.NooBaaAccount.Name})
+	if err != nil {
+		return err
+	}
+	if len(accountInfo.AccessKeys) == 0 {
+		return fmt.Errorf("NooBaaAccount %q has no access keys", r.NooBaaAccount.Name)
+	}
+	return r.createNoobaaAccountSecret(accountInfo.AccessKeys[0], accountInfo.ARN)
 }
 
 // UpdateNooBaaAccount update an existing noobaa account


### PR DESCRIPTION
### Describe the Problem
NooBaaAccount can reach `phase: Ready` after a flaky `create_account` RPC even when the credentials Secret was never created, so later Secret reads fail.

### Explain the changes
1. After create/update, ensure the account credentials Secret exists (`ensureNoobaaAccountSecret` → KubeCheck, recreate via `ReadAccountAPI` if missing) before Ready.
2. Share Secret creation in `createNoobaaAccountSecret` using `KubeCreateSkipExisting`, and always pass the account ARN (including on restore) so recreated Secrets match the original contract.

Before changes:
NooBaaAccount can reach/stay phase: Ready even when the credentials Secret was never created (e.g. flaky create_account RPC). Later Secret reads fail; nb account status can show Ready with ❌ Not Found for the Secret.
<img width="548" height="325" alt="Screenshot From 2026-07-30 13-31-51" src="https://github.com/user-attachments/assets/3ba0992c-7806-4cf0-bf55-6a9747d5c704" />


After changes:
On reconcile, the operator ensures noobaa-account-<name> exists before Ready; if missing, it recreates the Secret from account credentials (or requeues on failure). 

**Note:** Secret delete alone does not trigger reconcile until the account is reconciled again (e.g. spec change).

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed: https://redhat.atlassian.net/browse/DFBUGS-8859
2.  Related PR: https://github.com/noobaa/noobaa-core/pull/9904

### Testing Instructions:
1. Create a `NooBaaAccount` with `default_resource` set; wait until Ready and confirm Secret `noobaa-account-<name>` exists.
3. Delete that Secret, then patch the account (e.g. `force_md5_etag`) to force reconcile.
`$ kubectl patch noobaaaccount aayush --type=merge   -p '{"spec":{"force_md5_etag":true}}'`
4. Confirm the Secret is recreated and the account stays/returns Ready (nb account status shows connection info).

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NooBaa account setup reliability by ensuring the credentials Secret is created before configuration completes.
  * Added recovery for missing credentials Secrets by retrieving account details and recreating the Secret when valid access keys are available.
  * Preserved the account ARN to support reliable credentials Secret management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->