### PR TITLE
coreHA | sperate leaderelect function to windows / unix

### DIFF
--- a/pkg/leaderelect/leaderelect.go
+++ b/pkg/leaderelect/leaderelect.go
@@ -163,6 +163,11 @@ func (c *Config) Validate() error {
 
 // Run acquires the Lease, runs the command while leading, and returns a process exit code.
 func Run(cfg *Config) int {
+	if err := checkPlatform(); err != nil {
+		fmt.Fprintf(os.Stderr, "leader-elect: %v\n", err)
+		return exitConfig
+	}
+
 	log := util.Logger()
 
 	namespace := resolveNamespace()
@@ -308,7 +313,7 @@ func (r *runner) onStartedLeading(leadCtx context.Context) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureChildProc(cmd)
 
 	if err := cmd.Start(); err != nil {
 		r.log.Errorf("leader-elect: spawn: %v", err)
@@ -375,81 +380,4 @@ func (r *runner) getChildCode() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.childCode
-}
-
-// waitAndReap blocks on Wait4(-1), records the main child's exit code once, and
-// continues reaping any orphaned grandchildren until no children remain.
-func (r *runner) waitAndReap(childPID int, done chan struct{}) {
-	childReported := false
-	for {
-		var status syscall.WaitStatus
-		wpid, err := syscall.Wait4(-1, &status, 0, nil)
-		if err == syscall.EINTR {
-			continue
-		}
-		if err != nil {
-			// ECHILD: no children left.
-			if !childReported {
-				r.mu.Lock()
-				r.childCode = exitConfig
-				r.mu.Unlock()
-				close(done)
-			}
-			return
-		}
-		if wpid == childPID && !childReported {
-			childReported = true
-			r.mu.Lock()
-			r.childCode = waitStatusExitCode(status)
-			r.mu.Unlock()
-			close(done)
-		}
-	}
-}
-
-func waitStatusExitCode(status syscall.WaitStatus) int {
-	if status.Exited() {
-		return status.ExitStatus()
-	}
-	if status.Signaled() {
-		return 128 + int(status.Signal())
-	}
-	return exitConfig
-}
-
-func (r *runner) stopChild(grace time.Duration) {
-	r.mu.Lock()
-	r.termRequested = true
-	pid := r.childPID
-	done := r.childExited
-	r.mu.Unlock()
-
-	if pid <= 0 {
-		return
-	}
-
-	// Signal the whole process group (Setpgid makes pgid == child pid).
-	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
-		r.log.Errorf("leader-elect: kill pgid %d SIGTERM: %v", pid, err)
-	}
-
-	if done == nil {
-		return
-	}
-
-	timer := time.NewTimer(grace)
-	defer timer.Stop()
-	select {
-	case <-done:
-		return
-	case <-timer.C:
-		r.log.Infof("leader-elect: grace %v elapsed, SIGKILL process group %d", grace, pid)
-		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
-			r.log.Errorf("leader-elect: kill pgid %d SIGKILL: %v", pid, err)
-		}
-		select {
-		case <-done:
-		case <-time.After(childSigkillWait):
-		}
-	}
 }

--- a/pkg/leaderelect/leaderelect_unix.go
+++ b/pkg/leaderelect/leaderelect_unix.go
@@ -1,0 +1,92 @@
+//go:build unix
+
+package leaderelect
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func checkPlatform() error { return nil }
+
+func configureChildProc(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// waitAndReap blocks on Wait4(-1), records the main child's exit code once, and
+// continues reaping any orphaned grandchildren until no children remain.
+func (r *runner) waitAndReap(childPID int, done chan struct{}) {
+	childReported := false
+	for {
+		var status syscall.WaitStatus
+		wpid, err := syscall.Wait4(-1, &status, 0, nil)
+		if err == syscall.EINTR {
+			continue
+		}
+		if err != nil {
+			// ECHILD: no children left.
+			if !childReported {
+				r.mu.Lock()
+				r.childCode = exitConfig
+				r.mu.Unlock()
+				close(done)
+			}
+			return
+		}
+		if wpid == childPID && !childReported {
+			childReported = true
+			r.mu.Lock()
+			r.childCode = waitStatusExitCode(status)
+			r.mu.Unlock()
+			close(done)
+		}
+	}
+}
+
+func waitStatusExitCode(status syscall.WaitStatus) int {
+	if status.Exited() {
+		return status.ExitStatus()
+	}
+	if status.Signaled() {
+		return 128 + int(status.Signal())
+	}
+	return exitConfig
+}
+
+func (r *runner) stopChild(grace time.Duration) {
+	r.mu.Lock()
+	r.termRequested = true
+	pid := r.childPID
+	done := r.childExited
+	r.mu.Unlock()
+
+	if pid <= 0 {
+		return
+	}
+
+	// Signal the whole process group (Setpgid makes pgid == child pid).
+	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+		r.log.Errorf("leader-elect: kill pgid %d SIGTERM: %v", pid, err)
+	}
+
+	if done == nil {
+		return
+	}
+
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return
+	case <-timer.C:
+		r.log.Infof("leader-elect: grace %v elapsed, SIGKILL process group %d", grace, pid)
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+			r.log.Errorf("leader-elect: kill pgid %d SIGKILL: %v", pid, err)
+		}
+		select {
+		case <-done:
+		case <-time.After(childSigkillWait):
+		}
+	}
+}

--- a/pkg/leaderelect/leaderelect_windows.go
+++ b/pkg/leaderelect/leaderelect_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package leaderelect
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+func checkPlatform() error {
+	return fmt.Errorf("not supported on Windows (Linux PID-1 wrapper only)")
+}
+
+// configureChildProc is a no-op on Windows (no process groups / Setpgid).
+func configureChildProc(cmd *exec.Cmd) {}
+
+// waitAndReap cannot use Wait4 on Windows. Leader-elect is a Linux PID-1
+// wrapper; this stub only exists so the operator CLI still cross-compiles.
+func (r *runner) waitAndReap(childPID int, done chan struct{}) {
+	r.mu.Lock()
+	r.childCode = exitConfig
+	r.mu.Unlock()
+	close(done)
+}
+
+// stopChild cannot signal process groups on Windows.
+func (r *runner) stopChild(grace time.Duration) {
+	r.mu.Lock()
+	r.termRequested = true
+	r.mu.Unlock()
+}


### PR DESCRIPTION
### Describe the Problem
leaderelect module runs as part of the operator CLI. on windows specific functions don't compile and build fails

### Explain the changes
1. create two files one for windows and one for unix. each with his own implementations.
2. unix functions are the same
3. since code should only be ran from noobaa core which is strictly a unix environment. and should not be used by the user. put stub methods in the windows file. so binary will compile
4. exit early with an error if for some reason module is ran from windows

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. windows compile: `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/noobaa-operator-windows.exe .`

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leader-election process handling on Unix platforms.
  * Child processes now shut down gracefully before forced termination when needed.
  * Added reliable exit-status tracking and process cleanup.
  * Added clear unsupported-platform handling for Windows, including cross-compilation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->