### PR TITLE
core HA | OnDelete STS strategy and stale core pod restarts

### DIFF
--- a/deploy/crds/noobaa.io_noobaas.yaml
+++ b/deploy/crds/noobaa.io_noobaas.yaml
@@ -1658,6 +1658,12 @@ spec:
                 description: DenyHTTP (optional) if given will deny access to the
                   NooBaa S3 service using HTTP (only HTTPS)
                 type: boolean
+              disableCoreHA:
+                description: |-
+                  DisableCoreHA (optional) disables noobaa-core high availability (2 replicas with Kubernetes lease leader election).
+                  When false or omitted, two core pods compete for the Lease; only the leader becomes Ready.
+                  When true, a single core pod still runs leader-elect and holds the Lease.
+                type: boolean
               disableLoadBalancerService:
                 description: DisableLoadBalancerService (optional) sets the service
                   type to ClusterIP instead of LoadBalancer

--- a/deploy/internal/lease-core.yaml
+++ b/deploy/internal/lease-core.yaml
@@ -1,0 +1,6 @@
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: noobaa-core-lease
+  labels:
+    app: noobaa

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -5,13 +5,16 @@ metadata:
   labels:
     app: noobaa
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       noobaa-core: noobaa
   serviceName: noobaa-mgmt
+  # OnDelete: RollingUpdate waits for Ready after each pod; HA standbys never
+  # become Ready, so the roll stalls after the standby and never updates the
+  # leader. With OnDelete, operator will detect template/hash drift and delete outdated pods itself.
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
       labels:
@@ -60,6 +63,13 @@ spec:
           volumeMounts:
             - name: shared-bin
               mountPath: /noobaa-shared
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "10m"
+              memory: "32Mi"
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
@@ -146,6 +156,31 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_VERSION_AUTH_ENABLED
+            - name: NOOBAA_CORE_LEASE_DURATION
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_LEASE_DURATION
+            - name: NOOBAA_CORE_RENEW_DEADLINE
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_RENEW_DEADLINE
+            - name: NOOBAA_CORE_RETRY_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_RETRY_PERIOD
+            - name: NOOBAA_CORE_SHUTDOWN_GRACE
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_SHUTDOWN_GRACE
+            - name: NOOBAA_CORE_LOST_GRACE
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_LOST_GRACE
             - name: NOOBAA_CORE_LEASE_NAME
               value: ""
             - name: POSTGRES_HOST

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -10,10 +10,11 @@ spec:
     matchLabels:
       noobaa-core: noobaa
   serviceName: noobaa-mgmt
-  # RollingUpdate stalls when HA standbys never become Ready; OnDelete + operator
-  # pod deletes are handled in a follow-up change.
+  # OnDelete: RollingUpdate waits for Ready after each pod; HA standbys never
+  # become Ready, so the roll stalls after the standby and never updates the
+  # leader. With OnDelete, operator will detect template/hash drift and delete outdated pods itself.
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
       labels:

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -10,11 +10,10 @@ spec:
     matchLabels:
       noobaa-core: noobaa
   serviceName: noobaa-mgmt
-  # OnDelete: RollingUpdate waits for Ready after each pod; HA standbys never
-  # become Ready, so the roll stalls after the standby and never updates the
-  # leader. With OnDelete, operator will detect template/hash drift and delete outdated pods itself.
+  # RollingUpdate stalls when HA standbys never become Ready; OnDelete + operator
+  # pod deletes are handled in a follow-up change.
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/pkg/apis/noobaa/v1alpha1/noobaa_types.go
+++ b/pkg/apis/noobaa/v1alpha1/noobaa_types.go
@@ -214,6 +214,12 @@ type NooBaaSpec struct {
 	// +optional
 	Annotations AnnotationsSpec `json:"annotations,omitempty"`
 
+	// DisableCoreHA (optional) disables noobaa-core high availability (2 replicas with Kubernetes lease leader election).
+	// When false or omitted, two core pods compete for the Lease; only the leader becomes Ready.
+	// When true, a single core pod still runs leader-elect and holds the Lease.
+	// +optional
+	DisableCoreHA bool `json:"disableCoreHA,omitempty"`
+
 	// DisableLoadBalancerService (optional) sets the service type to ClusterIP instead of LoadBalancer
 	// +nullable
 	// +optional

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5619,7 +5619,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "90a9da6ba592b8648eef9cbfd13f2e430e2a9eb251c2636cb80faee2d04af1af"
+const Sha256_deploy_internal_statefulset_core_yaml = "dee3b3f246428525d3f71a6d67fd99d1d9661be07fbc4fd563da818d60efd167"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5633,11 +5633,10 @@ spec:
     matchLabels:
       noobaa-core: noobaa
   serviceName: noobaa-mgmt
-  # OnDelete: RollingUpdate waits for Ready after each pod; HA standbys never
-  # become Ready, so the roll stalls after the standby and never updates the
-  # leader. With OnDelete, operator will detect template/hash drift and delete outdated pods itself.
+  # RollingUpdate stalls when HA standbys never become Ready; OnDelete + operator
+  # pod deletes are handled in a follow-up change.
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5619,7 +5619,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "dee3b3f246428525d3f71a6d67fd99d1d9661be07fbc4fd563da818d60efd167"
+const Sha256_deploy_internal_statefulset_core_yaml = "46b833ffe357bfd7171502969468b6b7cde10c510ef8af4e330e869c01a5a855"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5633,10 +5633,11 @@ spec:
     matchLabels:
       noobaa-core: noobaa
   serviceName: noobaa-mgmt
-  # RollingUpdate stalls when HA standbys never become Ready; OnDelete + operator
-  # pod deletes are handled in a follow-up change.
+  # OnDelete: RollingUpdate waits for Ready after each pod; HA standbys never
+  # become Ready, so the roll stalls after the standby and never updates the
+  # leader. With OnDelete, operator will detect template/hash drift and delete outdated pods itself.
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
       labels:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -1511,7 +1511,7 @@ spec:
       status: {}
 `
 
-const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "e359dfd8f3c4a8ef7ac5605b1c86ce6d939846435e13c8376cef2252bb9e95f4"
+const Sha256_deploy_crds_noobaa_io_noobaas_yaml = "9215ddeb31fec8d4122946224b4678587b33347145c3d9cf485715d5e0c06cbf"
 
 const File_deploy_crds_noobaa_io_noobaas_yaml = `---
 apiVersion: apiextensions.k8s.io/v1
@@ -3172,6 +3172,12 @@ spec:
               denyHTTP:
                 description: DenyHTTP (optional) if given will deny access to the
                   NooBaa S3 service using HTTP (only HTTPS)
+                type: boolean
+              disableCoreHA:
+                description: |-
+                  DisableCoreHA (optional) disables noobaa-core high availability (2 replicas with Kubernetes lease leader election).
+                  When false or omitted, two core pods compete for the Lease; only the leader becomes Ready.
+                  When true, a single core pod still runs leader-elect and holds the Lease.
                 type: boolean
               disableLoadBalancerService:
                 description: DisableLoadBalancerService (optional) sets the service
@@ -4875,6 +4881,16 @@ metadata:
 data: {}
 `
 
+const Sha256_deploy_internal_lease_core_yaml = "7a53fb9c5a3d886d365104e28cefac9562b02da092d8de5f84751b4e6343f734"
+
+const File_deploy_internal_lease_core_yaml = `apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: noobaa-core-lease
+  labels:
+    app: noobaa
+`
+
 const Sha256_deploy_internal_nsfs_pvc_cr_yaml = "6dd65ca7d324991b813f209ec6a8a6bcf6c2c9a9f45c519ad3fba51e25042f07"
 
 const File_deploy_internal_nsfs_pvc_cr_yaml = `apiVersion: v1
@@ -5603,7 +5619,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "1f60f4995b291944111536d9f70b2678ec75dd60f53c0340d2bf6adb5bdd1325"
+const Sha256_deploy_internal_statefulset_core_yaml = "90a9da6ba592b8648eef9cbfd13f2e430e2a9eb251c2636cb80faee2d04af1af"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5612,13 +5628,16 @@ metadata:
   labels:
     app: noobaa
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       noobaa-core: noobaa
   serviceName: noobaa-mgmt
+  # OnDelete: RollingUpdate waits for Ready after each pod; HA standbys never
+  # become Ready, so the roll stalls after the standby and never updates the
+  # leader. With OnDelete, operator will detect template/hash drift and delete outdated pods itself.
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
       labels:
@@ -5667,6 +5686,13 @@ spec:
           volumeMounts:
             - name: shared-bin
               mountPath: /noobaa-shared
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "10m"
+              memory: "32Mi"
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
@@ -5753,6 +5779,31 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_VERSION_AUTH_ENABLED
+            - name: NOOBAA_CORE_LEASE_DURATION
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_LEASE_DURATION
+            - name: NOOBAA_CORE_RENEW_DEADLINE
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_RENEW_DEADLINE
+            - name: NOOBAA_CORE_RETRY_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_RETRY_PERIOD
+            - name: NOOBAA_CORE_SHUTDOWN_GRACE
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_SHUTDOWN_GRACE
+            - name: NOOBAA_CORE_LOST_GRACE
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config
+                  key: NOOBAA_CORE_LOST_GRACE
             - name: NOOBAA_CORE_LEASE_NAME
               value: ""
             - name: POSTGRES_HOST

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -23,12 +23,17 @@ func CmdInstall() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install the operator and create the noobaa system",
-		Run:   RunInstall,
-		Args:  cobra.NoArgs,
+		Long: `Install the operator and create the NooBaa system.
+
+Core HA is enabled by default (2 noobaa-core pods with Kubernetes lease leader election).
+Use --disable-core-ha to install with a single core pod.`,
+		Run:  RunInstall,
+		Args: cobra.NoArgs,
 	}
 	cmd.Flags().Bool("use-obc-cleanup-policy", false, "Create NooBaa system with obc cleanup policy")
 	cmd.Flags().Bool("use-standalone-db", false, "Create NooBaa system with standalone DB (Legacy)")
 	cmd.Flags().Bool("no-wait", false, "Don't wait for the system to be ready. Exit after applying the changes")
+	system.AddDisableCoreHAFlags(cmd)
 	cmd.AddCommand(
 		CmdYaml(),
 		cnpg.CmdCNPG(),

--- a/pkg/leaderelect/leaderelect.go
+++ b/pkg/leaderelect/leaderelect.go
@@ -3,13 +3,14 @@
 // Exposed as a Hidden cobra subcommand of the noobaa-operator binary and
 // copied into the core pod from the operator image:
 //
-//	noobaa-operator leader-elect [flags] -- <command> [args...]
+//	noobaa-operator leader-elect -- <command> [args...]
 //
+// Timings and lease name come from environment variables (see NOOBAA_CORE_*).
 // The command is Hidden so it does not appear in public CLI help. The wrapper
 // acquires a namespaced Lease, spawns the given command in its own process
 // group while holding leadership, reaps orphaned children (PID 1), and on
-// SIGTERM/SIGINT or leadership loss stops the child group before releasing
-// the Lease (ReleaseOnCancel).
+// SIGTERM/SIGINT or leadership loss stops the child group, cancels the elector
+// (stopping renew), then releases the Lease once le.Run has returned.
 package leaderelect
 
 import (
@@ -27,6 +28,8 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/spf13/cobra"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
@@ -38,9 +41,14 @@ const (
 	exitConfig = 1
 	exitLost   = 2
 
-	envLeaseName    = "NOOBAA_CORE_LEASE_NAME"
-	envPodNamespace = "POD_NAMESPACE"
-	saNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	envLeaseName     = "NOOBAA_CORE_LEASE_NAME"
+	envLeaseDuration = "NOOBAA_CORE_LEASE_DURATION"
+	envRenewDeadline = "NOOBAA_CORE_RENEW_DEADLINE"
+	envRetryPeriod   = "NOOBAA_CORE_RETRY_PERIOD"
+	envShutdownGrace = "NOOBAA_CORE_SHUTDOWN_GRACE"
+	envLostGrace     = "NOOBAA_CORE_LOST_GRACE"
+	envPodNamespace  = "POD_NAMESPACE"
+	saNamespaceFile  = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 	defaultLeaseDuration = 20 * time.Second
 	defaultRenewDeadline = 10 * time.Second
@@ -49,12 +57,12 @@ const (
 	defaultLostGrace     = 8 * time.Second
 	// childSigkillWait is how long stopChild waits after SIGKILL for the child process group to exit before returning.
 	childSigkillWait = 5 * time.Second
-	// leaseReleaseMargin is extra time after child teardown for ReleaseOnCancel.
+	// leaseReleaseMargin is extra time after child teardown for the manual lease release Update.
 	leaseReleaseMargin = 10 * time.Second
 )
 
 // RecommendedTerminationGracePeriod is the pod terminationGracePeriodSeconds
-// that leaves room for ShutdownGrace + SIGKILL wait + lease release on cancel.
+// that leaves room for ShutdownGrace + SIGKILL wait + manual lease release.
 func RecommendedTerminationGracePeriod(shutdownGrace time.Duration) int64 {
 	if shutdownGrace <= 0 {
 		shutdownGrace = defaultShutdownGrace
@@ -74,17 +82,18 @@ type Config struct {
 }
 
 // Cmd returns the leader-elect CLI command (Hidden — for in-pod use).
+// Configuration is read from environment variables; args are only the wrapped command.
 func Cmd() *cobra.Command {
-	cfg := defaultConfig()
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Hidden:                true,
 		Use:                   "leader-elect -- <command> [args...]",
 		Short:                 "Acquire a Lease then exec a command (PID 1 leader-elect wrapper)",
 		DisableFlagsInUseLine: true,
+		DisableFlagParsing:    true,
 		SilenceUsage:          true,
-		Args:                  cobra.ArbitraryArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cfg.Command = args
+		Run: func(_ *cobra.Command, args []string) {
+			cfg := defaultConfig()
+			cfg.Command = commandFromArgs(args)
 			if err := cfg.Validate(); err != nil {
 				fmt.Fprintf(os.Stderr, "leader-elect: %v\n", err)
 				os.Exit(exitConfig)
@@ -92,71 +101,82 @@ func Cmd() *cobra.Command {
 			os.Exit(Run(cfg))
 		},
 	}
-	bindFlags(cmd, cfg)
-	return cmd
 }
 
 func defaultConfig() *Config {
 	return &Config{
 		LeaseName:     os.Getenv(envLeaseName),
-		LeaseDuration: defaultLeaseDuration,
-		RenewDeadline: defaultRenewDeadline,
-		RetryPeriod:   defaultRetryPeriod,
-		ShutdownGrace: defaultShutdownGrace,
-		LostGrace:     defaultLostGrace,
+		LeaseDuration: durationFromEnv(envLeaseDuration, defaultLeaseDuration),
+		RenewDeadline: durationFromEnv(envRenewDeadline, defaultRenewDeadline),
+		RetryPeriod:   durationFromEnv(envRetryPeriod, defaultRetryPeriod),
+		ShutdownGrace: durationFromEnv(envShutdownGrace, defaultShutdownGrace),
+		LostGrace:     durationFromEnv(envLostGrace, defaultLostGrace),
 	}
 }
 
-func bindFlags(cmd *cobra.Command, cfg *Config) {
-	cmd.Flags().StringVar(&cfg.LeaseName, "lease-name", cfg.LeaseName, "Lease object name (default: $NOOBAA_CORE_LEASE_NAME)")
-	cmd.Flags().DurationVar(&cfg.LeaseDuration, "lease-duration", cfg.LeaseDuration, "Lease duration")
-	cmd.Flags().DurationVar(&cfg.RenewDeadline, "renew-deadline", cfg.RenewDeadline, "Leadership renew deadline")
-	cmd.Flags().DurationVar(&cfg.RetryPeriod, "retry-period", cfg.RetryPeriod, "Leadership retry period")
-	cmd.Flags().DurationVar(&cfg.ShutdownGrace, "shutdown-grace", cfg.ShutdownGrace, "Time to wait for child exit after SIGTERM/SIGINT before SIGKILL")
-	cmd.Flags().DurationVar(&cfg.LostGrace, "lost-grace", cfg.LostGrace, "Time to wait for child exit after leadership loss before SIGKILL")
+// durationFromEnv parses a duration env var; returns fallback if unset or invalid.
+func durationFromEnv(key string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
 }
 
-// ParseArgs parses leader-elect flags and the wrapped command (args after flags/--).
+// commandFromArgs returns the wrapped command, stripping a leading "--" if present.
+func commandFromArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	if args[0] == "--" {
+		return append([]string(nil), args[1:]...)
+	}
+	return append([]string(nil), args...)
+}
+
+// ParseArgs builds Config from the environment and the wrapped command args.
 // It does not run the election or spawn processes.
 func ParseArgs(args []string) (*Config, error) {
 	cfg := defaultConfig()
-	cmd := &cobra.Command{
-		Use:           "leader-elect",
-		SilenceErrors: true,
-		SilenceUsage:  true,
-		Args:          cobra.ArbitraryArgs,
-		Run: func(_ *cobra.Command, a []string) {
-			cfg.Command = a
-		},
-	}
-	bindFlags(cmd, cfg)
-	cmd.SetArgs(args)
-	if err := cmd.Execute(); err != nil {
-		return nil, err
-	}
+	cfg.Command = commandFromArgs(args)
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 	return cfg, nil
 }
 
-// Validate checks required fields and the lost-grace invariant.
+// Validate checks required fields and client-go timing invariants.
 func (c *Config) Validate() error {
 	if c == nil {
 		return fmt.Errorf("nil config")
 	}
 	if c.LeaseName == "" {
-		return fmt.Errorf("--lease-name is required (or set $%s)", envLeaseName)
+		return fmt.Errorf("$%s is required", envLeaseName)
 	}
 	if len(c.Command) == 0 {
 		return fmt.Errorf("command is required after --")
 	}
 	maxLost := c.LeaseDuration - c.RenewDeadline
 	if maxLost <= 0 {
-		return fmt.Errorf("lease-duration (%v) must be greater than renew-deadline (%v)", c.LeaseDuration, c.RenewDeadline)
+		return fmt.Errorf("%s (%v) must be greater than %s (%v)",
+			envLeaseDuration, c.LeaseDuration, envRenewDeadline, c.RenewDeadline)
 	}
 	if c.LostGrace >= maxLost {
-		return fmt.Errorf("--lost-grace (%v) must be < lease-duration - renew-deadline (%v)", c.LostGrace, maxLost)
+		return fmt.Errorf("%s (%v) must be < %s - %s (%v)",
+			envLostGrace, c.LostGrace, envLeaseDuration, envRenewDeadline, maxLost)
+	}
+	// Match NewLeaderElector: renewDeadline must be > retryPeriod*JitterFactor (1.2).
+	if c.RetryPeriod <= 0 {
+		return fmt.Errorf("%s (%v) must be greater than zero", envRetryPeriod, c.RetryPeriod)
+	}
+	minRenew := time.Duration(leaderelection.JitterFactor * float64(c.RetryPeriod))
+	if c.RenewDeadline <= minRenew {
+		return fmt.Errorf("%s (%v) must be greater than %s*%g (%v)",
+			envRenewDeadline, c.RenewDeadline, envRetryPeriod, leaderelection.JitterFactor, minRenew)
 	}
 	return nil
 }
@@ -191,9 +211,11 @@ func Run(cfg *Config) int {
 	defer cancel()
 
 	r := &runner{
-		cfg:    cfg,
-		cancel: cancel,
-		log:    log,
+		cfg:      cfg,
+		cancel:   cancel,
+		log:      log,
+		lock:     lock,
+		identity: identity,
 	}
 
 	sigCh := make(chan os.Signal, 2)
@@ -202,25 +224,44 @@ func Run(cfg *Config) int {
 
 	go func() {
 		sig := <-sigCh
-		r.log.Infof("leader-elect: received %v, stopping child then releasing lease", sig)
+		r.log.Infof("leader-elect: received %v, stopping child then cancelling election", sig)
 		r.stopChild(cfg.ShutdownGrace)
 		r.forceExit(exitOK)
 		cancel()
 	}()
 
+	// closed when OnStartedLeading returns, or immediately if we never led.
+	leadingDone := make(chan struct{})
+	closeLeadingDone := sync.OnceFunc(func() { close(leadingDone) })
+	var led bool
+	var ledMu sync.Mutex
+
 	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
-		Lock:            lock,
-		LeaseDuration:   cfg.LeaseDuration,
-		RenewDeadline:   cfg.RenewDeadline,
-		RetryPeriod:     cfg.RetryPeriod,
-		ReleaseOnCancel: true,
+		Lock:          lock,
+		LeaseDuration: cfg.LeaseDuration,
+		RenewDeadline: cfg.RenewDeadline,
+		RetryPeriod:   cfg.RetryPeriod,
+		// Do not release on cancel: renew cancel can race with stopChild and
+		// hand the Lease to a standby while core is still running.
+		// We release manually after le.Run returns and OnStartedLeading finishes.
+		ReleaseOnCancel: false,
 		Name:            cfg.LeaseName,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(leadCtx context.Context) {
+				ledMu.Lock()
+				led = true
+				ledMu.Unlock()
+				defer closeLeadingDone()
 				r.onStartedLeading(leadCtx)
 			},
 			OnStoppedLeading: func() {
 				r.log.Infof("leader-elect: stopped leading (identity %s)", identity)
+				ledMu.Lock()
+				didLead := led
+				ledMu.Unlock()
+				if !didLead {
+					closeLeadingDone()
+				}
 			},
 		},
 	})
@@ -231,6 +272,9 @@ func Run(cfg *Config) int {
 
 	log.Infof("leader-elect: waiting for lease %s/%s as %s", namespace, cfg.LeaseName, identity)
 	le.Run(ctx)
+	// Renew has stopped. Wait for leading teardown (esp. loss-path stopChild) before release.
+	<-leadingDone
+	r.releaseLease()
 
 	return r.getExit()
 }
@@ -262,9 +306,11 @@ type logger interface {
 }
 
 type runner struct {
-	cfg    *Config
-	cancel context.CancelFunc
-	log    logger
+	cfg      *Config
+	cancel   context.CancelFunc
+	log      logger
+	lock     resourcelock.Interface
+	identity string
 
 	mu            sync.Mutex
 	childPID      int
@@ -273,6 +319,7 @@ type runner struct {
 	exitCode      int
 	exitSet       bool
 	termRequested bool
+	releaseOnce   sync.Once
 }
 
 func (r *runner) setExit(code int) {
@@ -342,13 +389,13 @@ func (r *runner) onStartedLeading(leadCtx context.Context) {
 		termRequested := r.termRequested
 		r.mu.Unlock()
 		if termRequested {
-			// SIGTERM/lost path owns the wrapper exit code.
+			// SIGTERM path owns the wrapper exit code; lease release is after le.Run.
 			return
 		}
 		code := r.getChildCode()
 		r.log.Infof("leader-elect: child exited with code %d", code)
 		r.setExit(code)
-		r.cancel() // release lease after child is down
+		r.cancel()
 	case <-leadCtx.Done():
 		r.mu.Lock()
 		termRequested := r.termRequested
@@ -369,6 +416,48 @@ func (r *runner) onStartedLeading(leadCtx context.Context) {
 		case <-time.After(r.cfg.LostGrace + childSigkillWait):
 		}
 	}
+}
+
+// releaseLease clears our HolderIdentity after renew has stopped and the child
+// is down so a standby can acquire immediately. Crashes still rely on Lease TTL.
+// Workaround until client-go waits for OnStartedLeading before ReleaseOnCancel:
+// https://github.com/kubernetes/kubernetes/pull/139991
+func (r *runner) releaseLease() {
+	r.releaseOnce.Do(func() {
+		if r.lock == nil {
+			return
+		}
+		deadline := r.cfg.RenewDeadline
+		if deadline <= 0 {
+			deadline = defaultRenewDeadline
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), deadline)
+		defer cancel()
+
+		old, _, err := r.lock.Get(ctx)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				r.log.Errorf("leader-elect: get lease for release: %v", err)
+			}
+			return
+		}
+		if old.HolderIdentity != r.identity {
+			return
+		}
+
+		now := metav1.NewTime(time.Now())
+		rec := resourcelock.LeaderElectionRecord{
+			LeaderTransitions:    old.LeaderTransitions,
+			LeaseDurationSeconds: 1,
+			RenewTime:            now,
+			AcquireTime:          now,
+		}
+		if err := r.lock.Update(ctx, rec); err != nil {
+			r.log.Errorf("leader-elect: release lease: %v", err)
+			return
+		}
+		r.log.Infof("leader-elect: released lease")
+	})
 }
 
 func (r *runner) getChildCode() int {

--- a/pkg/leaderelect/leaderelect_test.go
+++ b/pkg/leaderelect/leaderelect_test.go
@@ -1,72 +1,56 @@
 package leaderelect
 
 import (
+	"context"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
-func TestParseArgs(t *testing.T) {
-	// Clear env so default lease-name does not leak across cases.
+func clearLeaderElectEnv(t *testing.T) {
+	t.Helper()
 	t.Setenv(envLeaseName, "")
+	t.Setenv(envLeaseDuration, "")
+	t.Setenv(envRenewDeadline, "")
+	t.Setenv(envRetryPeriod, "")
+	t.Setenv(envShutdownGrace, "")
+	t.Setenv(envLostGrace, "")
+}
+
+func TestParseArgs(t *testing.T) {
+	clearLeaderElectEnv(t)
+	t.Setenv(envLeaseName, "foo")
 
 	tests := []struct {
-		name         string
-		args         []string
-		wantLease    string
-		wantCmd      []string
-		wantLost     time.Duration
-		wantShutdown time.Duration
-		wantErr      string
+		name    string
+		args    []string
+		wantCmd []string
+		wantErr string
 	}{
 		{
-			name:         "double-dash splits command",
-			args:         []string{"--lease-name=foo", "--", "/usr/local/bin/node", "core_init.js"},
-			wantLease:    "foo",
-			wantCmd:      []string{"/usr/local/bin/node", "core_init.js"},
-			wantLost:     defaultLostGrace,
-			wantShutdown: defaultShutdownGrace,
+			name:    "double-dash splits command",
+			args:    []string{"--", "/usr/local/bin/node", "core_init.js"},
+			wantCmd: []string{"/usr/local/bin/node", "core_init.js"},
 		},
 		{
-			name:      "command without double-dash",
-			args:      []string{"--lease-name=bar", "sleep", "100"},
-			wantLease: "bar",
-			wantCmd:   []string{"sleep", "100"},
-		},
-		{
-			name:         "custom grace flags",
-			args:         []string{"--lease-name=x", "--lost-grace=5s", "--shutdown-grace=15s", "--", "echo", "hi"},
-			wantLease:    "x",
-			wantCmd:      []string{"echo", "hi"},
-			wantLost:     5 * time.Second,
-			wantShutdown: 15 * time.Second,
-		},
-		{
-			name:      "lease-duration and renew-deadline",
-			args:      []string{"--lease-name=x", "--lease-duration=30s", "--renew-deadline=12s", "--retry-period=4s", "--", "true"},
-			wantLease: "x",
-			wantCmd:   []string{"true"},
-		},
-		{
-			name:    "missing lease-name",
-			args:    []string{"--", "sleep", "1"},
-			wantErr: "--lease-name is required",
+			name:    "command without double-dash",
+			args:    []string{"sleep", "100"},
+			wantCmd: []string{"sleep", "100"},
 		},
 		{
 			name:    "missing command",
-			args:    []string{"--lease-name=foo"},
+			args:    []string{"--"},
 			wantErr: "command is required after --",
 		},
 		{
-			name:    "lost-grace equal to lease-duration minus renew-deadline",
-			args:    []string{"--lease-name=foo", "--lease-duration=20s", "--renew-deadline=10s", "--lost-grace=10s", "--", "sleep", "1"},
-			wantErr: "--lost-grace",
-		},
-		{
-			name:    "lost-grace greater than lease-duration minus renew-deadline",
-			args:    []string{"--lease-name=foo", "--lease-duration=20s", "--renew-deadline=10s", "--lost-grace=15s", "--", "sleep", "1"},
-			wantErr: "--lost-grace",
+			name:    "empty args",
+			args:    nil,
+			wantErr: "command is required after --",
 		},
 	}
 
@@ -85,41 +69,75 @@ func TestParseArgs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cfg.LeaseName != tt.wantLease {
-				t.Errorf("LeaseName = %q, want %q", cfg.LeaseName, tt.wantLease)
+			if cfg.LeaseName != "foo" {
+				t.Errorf("LeaseName = %q, want foo", cfg.LeaseName)
 			}
 			if !reflect.DeepEqual(cfg.Command, tt.wantCmd) {
 				t.Errorf("Command = %#v, want %#v", cfg.Command, tt.wantCmd)
 			}
-			if tt.wantLost != 0 && cfg.LostGrace != tt.wantLost {
-				t.Errorf("LostGrace = %v, want %v", cfg.LostGrace, tt.wantLost)
+			if cfg.LostGrace != defaultLostGrace {
+				t.Errorf("LostGrace = %v, want %v", cfg.LostGrace, defaultLostGrace)
 			}
-			if tt.wantShutdown != 0 && cfg.ShutdownGrace != tt.wantShutdown {
-				t.Errorf("ShutdownGrace = %v, want %v", cfg.ShutdownGrace, tt.wantShutdown)
-			}
-			if tt.name == "lease-duration and renew-deadline" {
-				if cfg.LeaseDuration != 30*time.Second {
-					t.Errorf("LeaseDuration = %v, want 30s", cfg.LeaseDuration)
-				}
-				if cfg.RenewDeadline != 12*time.Second {
-					t.Errorf("RenewDeadline = %v, want 12s", cfg.RenewDeadline)
-				}
-				if cfg.RetryPeriod != 4*time.Second {
-					t.Errorf("RetryPeriod = %v, want 4s", cfg.RetryPeriod)
-				}
+			if cfg.ShutdownGrace != defaultShutdownGrace {
+				t.Errorf("ShutdownGrace = %v, want %v", cfg.ShutdownGrace, defaultShutdownGrace)
 			}
 		})
 	}
 }
 
-func TestParseArgsLeaseNameFromEnv(t *testing.T) {
-	t.Setenv(envLeaseName, "from-env-lease")
+func TestParseArgsMissingLeaseName(t *testing.T) {
+	clearLeaderElectEnv(t)
+	_, err := ParseArgs([]string{"--", "true"})
+	if err == nil || !strings.Contains(err.Error(), envLeaseName) {
+		t.Fatalf("expected error mentioning %s, got %v", envLeaseName, err)
+	}
+}
+
+func TestParseArgsTimingsFromEnv(t *testing.T) {
+	t.Setenv(envLeaseName, "lease")
+	t.Setenv(envLeaseDuration, "30s")
+	t.Setenv(envRenewDeadline, "12s")
+	t.Setenv(envRetryPeriod, "4s")
+	t.Setenv(envShutdownGrace, "15s")
+	t.Setenv(envLostGrace, "5s")
+
 	cfg, err := ParseArgs([]string{"--", "true"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.LeaseName != "from-env-lease" {
-		t.Fatalf("LeaseName = %q, want from-env-lease", cfg.LeaseName)
+	if cfg.LeaseDuration != 30*time.Second {
+		t.Errorf("LeaseDuration = %v, want 30s", cfg.LeaseDuration)
+	}
+	if cfg.RenewDeadline != 12*time.Second {
+		t.Errorf("RenewDeadline = %v, want 12s", cfg.RenewDeadline)
+	}
+	if cfg.RetryPeriod != 4*time.Second {
+		t.Errorf("RetryPeriod = %v, want 4s", cfg.RetryPeriod)
+	}
+	if cfg.ShutdownGrace != 15*time.Second {
+		t.Errorf("ShutdownGrace = %v, want 15s", cfg.ShutdownGrace)
+	}
+	if cfg.LostGrace != 5*time.Second {
+		t.Errorf("LostGrace = %v, want 5s", cfg.LostGrace)
+	}
+}
+
+func TestParseArgsLostGraceInvariantFromEnv(t *testing.T) {
+	t.Setenv(envLeaseName, "lease")
+	t.Setenv(envLeaseDuration, "20s")
+	t.Setenv(envRenewDeadline, "10s")
+	t.Setenv(envLostGrace, "10s")
+
+	_, err := ParseArgs([]string{"--", "true"})
+	if err == nil || !strings.Contains(err.Error(), envLostGrace) {
+		t.Fatalf("expected error mentioning %s, got %v", envLostGrace, err)
+	}
+}
+
+func TestDurationFromEnvInvalidFallsBack(t *testing.T) {
+	t.Setenv(envLeaseDuration, "not-a-duration")
+	if got := durationFromEnv(envLeaseDuration, defaultLeaseDuration); got != defaultLeaseDuration {
+		t.Fatalf("durationFromEnv invalid = %v, want %v", got, defaultLeaseDuration)
 	}
 }
 
@@ -137,6 +155,7 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseName:     "x",
 				LeaseDuration: defaultLeaseDuration,
 				RenewDeadline: defaultRenewDeadline,
+				RetryPeriod:   defaultRetryPeriod,
 				LostGrace:     defaultLostGrace,
 				Command:       []string{"sleep"},
 			},
@@ -147,6 +166,7 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseName:     "x",
 				LeaseDuration: 20 * time.Second,
 				RenewDeadline: 10 * time.Second,
+				RetryPeriod:   3 * time.Second,
 				LostGrace:     9 * time.Second,
 				Command:       []string{"sleep"},
 			},
@@ -157,10 +177,11 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseName:     "x",
 				LeaseDuration: 20 * time.Second,
 				RenewDeadline: 10 * time.Second,
+				RetryPeriod:   3 * time.Second,
 				LostGrace:     10 * time.Second,
 				Command:       []string{"sleep"},
 			},
-			wantErr: "--lost-grace",
+			wantErr: envLostGrace,
 		},
 		{
 			name: "lost-grace above max rejected",
@@ -168,10 +189,11 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseName:     "x",
 				LeaseDuration: 20 * time.Second,
 				RenewDeadline: 10 * time.Second,
+				RetryPeriod:   3 * time.Second,
 				LostGrace:     11 * time.Second,
 				Command:       []string{"sleep"},
 			},
-			wantErr: "--lost-grace",
+			wantErr: envLostGrace,
 		},
 		{
 			name: "lease-duration not greater than renew-deadline",
@@ -179,20 +201,69 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseName:     "x",
 				LeaseDuration: 10 * time.Second,
 				RenewDeadline: 10 * time.Second,
+				RetryPeriod:   3 * time.Second,
 				LostGrace:     1 * time.Second,
 				Command:       []string{"sleep"},
 			},
-			wantErr: "lease-duration",
+			wantErr: envLeaseDuration,
+		},
+		{
+			name: "retry-period equal renew-deadline rejected",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: 20 * time.Second,
+				RenewDeadline: 10 * time.Second,
+				RetryPeriod:   10 * time.Second,
+				LostGrace:     1 * time.Second,
+				Command:       []string{"sleep"},
+			},
+			wantErr: envRenewDeadline,
+		},
+		{
+			name: "renew-deadline equal retry-period*1.2 rejected",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: 30 * time.Second,
+				RenewDeadline: 12 * time.Second,
+				RetryPeriod:   10 * time.Second, // 10s * 1.2 = 12s
+				LostGrace:     1 * time.Second,
+				Command:       []string{"sleep"},
+			},
+			wantErr: envRenewDeadline,
+		},
+		{
+			name: "renew-deadline just above retry-period*1.2 ok",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: 30 * time.Second,
+				RenewDeadline: 13 * time.Second,
+				RetryPeriod:   10 * time.Second, // 10s * 1.2 = 12s
+				LostGrace:     1 * time.Second,
+				Command:       []string{"sleep"},
+			},
+		},
+		{
+			name: "retry-period zero rejected",
+			cfg: Config{
+				LeaseName:     "x",
+				LeaseDuration: defaultLeaseDuration,
+				RenewDeadline: defaultRenewDeadline,
+				RetryPeriod:   0,
+				LostGrace:     defaultLostGrace,
+				Command:       []string{"sleep"},
+			},
+			wantErr: envRetryPeriod,
 		},
 		{
 			name: "missing lease name",
 			cfg: Config{
 				LeaseDuration: defaultLeaseDuration,
 				RenewDeadline: defaultRenewDeadline,
+				RetryPeriod:   defaultRetryPeriod,
 				LostGrace:     defaultLostGrace,
 				Command:       []string{"sleep"},
 			},
-			wantErr: "--lease-name is required",
+			wantErr: envLeaseName,
 		},
 		{
 			name: "missing command",
@@ -200,6 +271,7 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseName:     "x",
 				LeaseDuration: defaultLeaseDuration,
 				RenewDeadline: defaultRenewDeadline,
+				RetryPeriod:   defaultRetryPeriod,
 				LostGrace:     defaultLostGrace,
 			},
 			wantErr: "command is required after --",
@@ -235,5 +307,161 @@ func TestRecommendedTerminationGracePeriod(t *testing.T) {
 	}
 	if got, want := RecommendedTerminationGracePeriod(30*time.Second), int64(45); got != want {
 		t.Fatalf("RecommendedTerminationGracePeriod(30s) = %d, want %d", got, want)
+	}
+}
+
+type fakeLogger struct{}
+
+func (fakeLogger) Infof(string, ...interface{})  {}
+func (fakeLogger) Errorf(string, ...interface{}) {}
+
+// fakeLock is an in-memory resourcelock.Interface for release/renew race tests.
+type fakeLock struct {
+	mu     sync.Mutex
+	rec    resourcelock.LeaderElectionRecord
+	id     string
+	update func(resourcelock.LeaderElectionRecord) // optional hook under lock
+}
+
+func (f *fakeLock) Get(context.Context) (*resourcelock.LeaderElectionRecord, []byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := f.rec
+	return &cp, nil, nil
+}
+
+func (f *fakeLock) Create(context.Context, resourcelock.LeaderElectionRecord) error {
+	return nil
+}
+
+func (f *fakeLock) Update(_ context.Context, rec resourcelock.LeaderElectionRecord) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rec = rec
+	if f.update != nil {
+		f.update(rec)
+	}
+	return nil
+}
+
+func (f *fakeLock) RecordEvent(string) {}
+func (f *fakeLock) Identity() string   { return f.id }
+func (f *fakeLock) Describe() string   { return f.id }
+
+func (f *fakeLock) holder() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.rec.HolderIdentity
+}
+
+func TestReleaseLeaseClearsHolder(t *testing.T) {
+	t.Parallel()
+	const id = "pod-a"
+	lock := &fakeLock{
+		id:  id,
+		rec: resourcelock.LeaderElectionRecord{HolderIdentity: id, LeaseDurationSeconds: 20},
+	}
+	r := &runner{
+		cfg:      &Config{RenewDeadline: time.Second},
+		log:      fakeLogger{},
+		lock:     lock,
+		identity: id,
+	}
+	r.releaseLease()
+	if got := lock.holder(); got != "" {
+		t.Fatalf("after release HolderIdentity = %q, want empty", got)
+	}
+}
+
+func TestReleaseLeaseIdempotent(t *testing.T) {
+	t.Parallel()
+	const id = "pod-a"
+	var updates int
+	lock := &fakeLock{
+		id:  id,
+		rec: resourcelock.LeaderElectionRecord{HolderIdentity: id},
+		update: func(resourcelock.LeaderElectionRecord) {
+			updates++
+		},
+	}
+	r := &runner{
+		cfg:      &Config{RenewDeadline: time.Second},
+		log:      fakeLogger{},
+		lock:     lock,
+		identity: id,
+	}
+	r.releaseLease()
+	r.releaseLease()
+	if updates != 1 {
+		t.Fatalf("releaseLease Update count = %d, want 1", updates)
+	}
+}
+
+// TestRenewRacingWithManualRelease shows why release must run only after renew
+// stops: a concurrent renew Update can rewrite HolderIdentity after a clear.
+func TestRenewRacingWithManualRelease(t *testing.T) {
+	t.Parallel()
+	const id = "pod-a"
+	lock := &fakeLock{
+		id:  id,
+		rec: resourcelock.LeaderElectionRecord{HolderIdentity: id, LeaseDurationSeconds: 20},
+	}
+
+	renewStop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-renewStop:
+				return
+			default:
+			}
+			now := metav1.NewTime(time.Now())
+			_ = lock.Update(context.Background(), resourcelock.LeaderElectionRecord{
+				HolderIdentity:       id,
+				LeaseDurationSeconds: 20,
+				RenewTime:            now,
+				AcquireTime:          now,
+			})
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	r := &runner{
+		cfg:      &Config{RenewDeadline: time.Second},
+		log:      fakeLogger{},
+		lock:     lock,
+		identity: id,
+	}
+
+	// Release while renew still runs — holder can be restored (the race we avoid in Run).
+	sawRestore := false
+	for i := 0; i < 50; i++ {
+		r.releaseOnce = sync.Once{} // allow another clear attempt each iteration
+		r.releaseLease()
+		time.Sleep(2 * time.Millisecond)
+		if lock.holder() == id {
+			sawRestore = true
+			break
+		}
+	}
+	close(renewStop)
+	wg.Wait()
+
+	if !sawRestore {
+		t.Fatal("expected renew to restore HolderIdentity after release while renew still running")
+	}
+
+	// After renew stops, a single release leaves the holder cleared.
+	r.releaseOnce = sync.Once{}
+	r.releaseLease()
+	if got := lock.holder(); got != "" {
+		t.Fatalf("after renew stopped, HolderIdentity = %q, want empty", got)
+	}
+	time.Sleep(5 * time.Millisecond)
+	if got := lock.holder(); got != "" {
+		t.Fatalf("holder changed after renew stopped: %q", got)
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -78,6 +78,13 @@ var PostgresMajorVersion = 16
 // PostgresInstances is the default number of postgres instances in a managed postgres cluster
 var PostgresInstances = 1
 
+// CoreHAReplicaCount is the noobaa-core StatefulSet replica count when core HA is enabled.
+const CoreHAReplicaCount int32 = 2
+
+// DisableCoreHA is the default for spec.disableCoreHA on new systems (install/system create).
+// When false (default), core HA is enabled. Use --disable-core-ha for a single core pod.
+var DisableCoreHA = false
+
 // Psql12Image is the default postgres12 db image url
 // currently it can not be overridden.
 var Psql12Image = "centos/postgresql-12-centos7"

--- a/pkg/system/core_ha_test.go
+++ b/pkg/system/core_ha_test.go
@@ -1,0 +1,65 @@
+package system
+
+import (
+	"testing"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetDesiredCoreReplicas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		disableCoreHA bool
+		want          int32
+	}{
+		{name: "default means on", disableCoreHA: false, want: options.CoreHAReplicaCount},
+		{name: "disabled", disableCoreHA: true, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nb := &nbv1.NooBaa{}
+			nb.Spec.DisableCoreHA = tt.disableCoreHA
+			if got := getDesiredCoreReplicas(nb); got != tt.want {
+				t.Fatalf("getDesiredCoreReplicas() = %d, want %d", got, tt.want)
+			}
+			if got := isCoreHAEnabled(nb); got != (tt.want == options.CoreHAReplicaCount) {
+				t.Fatalf("isCoreHAEnabled() = %v, want %v", got, tt.want == options.CoreHAReplicaCount)
+			}
+		})
+	}
+}
+
+func TestIsCorePodStale(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "noobaa-core-1",
+			Annotations: map[string]string{
+				coreConfigMapHashAnnotation: "oldhash",
+			},
+			Labels: map[string]string{
+				appsv1.ControllerRevisionHashLabelKey: "rev-old",
+			},
+		},
+	}
+
+	if !isCorePodStale(pod, "newhash", "rev-new") {
+		t.Fatal("expected stale on hash mismatch")
+	}
+	pod.Annotations[coreConfigMapHashAnnotation] = "newhash"
+	if !isCorePodStale(pod, "newhash", "rev-new") {
+		t.Fatal("expected stale on revision mismatch")
+	}
+	pod.Labels[appsv1.ControllerRevisionHashLabelKey] = "rev-new"
+	if isCorePodStale(pod, "newhash", "rev-new") {
+		t.Fatal("expected not stale when hash and revision match")
+	}
+}

--- a/pkg/system/core_ha_test.go
+++ b/pkg/system/core_ha_test.go
@@ -5,9 +5,6 @@ import (
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetDesiredCoreReplicas(t *testing.T) {
@@ -33,33 +30,5 @@ func TestGetDesiredCoreReplicas(t *testing.T) {
 				t.Fatalf("isCoreHAEnabled() = %v, want %v", got, tt.want == options.CoreHAReplicaCount)
 			}
 		})
-	}
-}
-
-func TestIsCorePodStale(t *testing.T) {
-	t.Parallel()
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "noobaa-core-1",
-			Annotations: map[string]string{
-				coreConfigMapHashAnnotation: "oldhash",
-			},
-			Labels: map[string]string{
-				appsv1.ControllerRevisionHashLabelKey: "rev-old",
-			},
-		},
-	}
-
-	if !isCorePodStale(pod, "newhash", "rev-new") {
-		t.Fatal("expected stale on hash mismatch")
-	}
-	pod.Annotations[coreConfigMapHashAnnotation] = "newhash"
-	if !isCorePodStale(pod, "newhash", "rev-new") {
-		t.Fatal("expected stale on revision mismatch")
-	}
-	pod.Labels[appsv1.ControllerRevisionHashLabelKey] = "rev-new"
-	if isCorePodStale(pod, "newhash", "rev-new") {
-		t.Fatal("expected not stale when hash and revision match")
 	}
 }

--- a/pkg/system/core_ha_test.go
+++ b/pkg/system/core_ha_test.go
@@ -5,6 +5,9 @@ import (
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	"github.com/noobaa/noobaa-operator/v5/pkg/options"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetDesiredCoreReplicas(t *testing.T) {
@@ -30,5 +33,33 @@ func TestGetDesiredCoreReplicas(t *testing.T) {
 				t.Fatalf("isCoreHAEnabled() = %v, want %v", got, tt.want == options.CoreHAReplicaCount)
 			}
 		})
+	}
+}
+
+func TestIsCorePodStale(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "noobaa-core-1",
+			Annotations: map[string]string{
+				coreConfigMapHashAnnotation: "oldhash",
+			},
+			Labels: map[string]string{
+				appsv1.ControllerRevisionHashLabelKey: "rev-old",
+			},
+		},
+	}
+
+	if !isCorePodStale(pod, "newhash", "rev-new") {
+		t.Fatal("expected stale on hash mismatch")
+	}
+	pod.Annotations[coreConfigMapHashAnnotation] = "newhash"
+	if !isCorePodStale(pod, "newhash", "rev-new") {
+		t.Fatal("expected stale on revision mismatch")
+	}
+	pod.Labels[appsv1.ControllerRevisionHashLabelKey] = "rev-new"
+	if isCorePodStale(pod, "newhash", "rev-new") {
+		t.Fatal("expected not stale when hash and revision match")
 	}
 }

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -53,7 +53,7 @@ const (
 	gcpServiceAccountEmailEnvVar string = "SERVICE_ACCOUNT_EMAIL"
 
 	// coreConfigMapHashAnnotation is set on the core configmap and STS/endpoint pod
-	// templates so config drift can be detected (e.g. for pod restarts).
+	// templates so OnDelete can detect config drift.
 	coreConfigMapHashAnnotation = "noobaa.io/configmap-hash"
 )
 
@@ -227,6 +227,10 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 	}
 
 	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
+		return err
+	}
+	// OnDelete: operator must delete outdated pods (see restartStaleCorePods).
+	if err := r.restartStaleCorePods(); err != nil {
 		return err
 	}
 
@@ -656,6 +660,10 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	r.CoreApp.Spec.Template.Labels["noobaa-mgmt"] = r.Request.Name
 	r.CoreApp.Spec.Selector.MatchLabels["noobaa-core"] = r.Request.Name
 	r.CoreApp.Spec.ServiceName = r.ServiceMgmt.Name
+	// OnDelete avoids RollingUpdate stall on never-Ready HA standbys; see restartStaleCorePods.
+	r.CoreApp.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.OnDeleteStatefulSetStrategyType,
+	}
 
 	podSpec := &r.CoreApp.Spec.Template.Spec
 	terminationGracePeriodSeconds := r.coreTerminationGracePeriodSeconds()
@@ -1736,6 +1744,64 @@ func (r *Reconciler) coreTerminationGracePeriodSeconds() int64 {
 		}
 	}
 	return leaderelect.RecommendedTerminationGracePeriod(shutdownGrace)
+}
+
+// restartStaleCorePods deletes one outdated core pod per reconcile under OnDelete.
+func (r *Reconciler) restartStaleCorePods() error {
+	if r.CoreApp.UID == "" {
+		return nil
+	}
+	// Refresh status (UpdateRevision) after the STS reconcile.
+	if !util.KubeCheckQuiet(r.CoreApp) {
+		return nil
+	}
+
+	desiredHash := ""
+	if r.CoreApp.Spec.Template.Annotations != nil {
+		desiredHash = r.CoreApp.Spec.Template.Annotations[coreConfigMapHashAnnotation]
+	}
+	updateRevision := r.CoreApp.Status.UpdateRevision
+
+	podList := &corev1.PodList{}
+	if !util.KubeList(podList, client.InNamespace(r.Request.Namespace), client.MatchingLabels{"noobaa-core": r.Request.Name}) {
+		return fmt.Errorf("failed listing core pods to restart stale revisions")
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.DeletionTimestamp != nil {
+			// Wait for in-flight deletes before starting another.
+			return nil
+		}
+		if !isCorePodStale(pod, desiredHash, updateRevision) {
+			continue
+		}
+		r.Logger.Warnf("deleting outdated core pod %q (OnDelete) desiredHash=%q updateRevision=%q",
+			pod.Name, desiredHash, updateRevision)
+		util.KubeDeleteNoPolling(pod)
+		return nil
+	}
+	return nil
+}
+
+func isCorePodStale(pod *corev1.Pod, desiredHash, updateRevision string) bool {
+	if pod == nil {
+		return false
+	}
+	if desiredHash != "" {
+		podHash := ""
+		if pod.Annotations != nil {
+			podHash = pod.Annotations[coreConfigMapHashAnnotation]
+		}
+		if podHash != "" && podHash != desiredHash {
+			return true
+		}
+	}
+	if updateRevision == "" || pod.Labels == nil {
+		return false
+	}
+	podRevision := pod.Labels[appsv1.ControllerRevisionHashLabelKey]
+	return podRevision != "" && podRevision != updateRevision
 }
 
 // SetDesiredCoreLease updates the core Lease as desired for reconciling

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -51,6 +51,10 @@ const (
 	gcpPoolIdEnvVar              string = "POOL_ID"
 	gcpProviderIdEnvVar          string = "PROVIDER_ID"
 	gcpServiceAccountEmailEnvVar string = "SERVICE_ACCOUNT_EMAIL"
+
+	// coreConfigMapHashAnnotation is set on the core configmap and STS/endpoint pod
+	// templates so OnDelete can detect config drift.
+	coreConfigMapHashAnnotation = "noobaa.io/configmap-hash"
 )
 
 // ReconcilePhaseCreating runs the reconcile phase
@@ -203,6 +207,10 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 		return err
 	}
 
+	if err := r.ReconcileObject(r.CoreLease, r.SetDesiredCoreLease); err != nil {
+		return err
+	}
+
 	// before reconciling the core, check if the image was changed so an upgrade is needed.
 	// if upgrade is needed, stop the core and endpoints pods to allow the upgrade_manager in noobaa-core to run without interruptions
 	if util.KubeCheckQuiet(r.CoreApp) {
@@ -219,6 +227,10 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 	}
 
 	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
+		return err
+	}
+	// OnDelete: operator must delete outdated pods (see restartStaleCorePods).
+	if err := r.restartStaleCorePods(); err != nil {
 		return err
 	}
 
@@ -621,7 +633,7 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 			}
 
 		case "NOOBAA_CORE_LEASE_NAME":
-			c.Env[j].Value = r.Request.Name + "-core-leader"
+			c.Env[j].Value = r.CoreLease.Name
 		}
 	}
 
@@ -648,21 +660,19 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	r.CoreApp.Spec.Template.Labels["noobaa-mgmt"] = r.Request.Name
 	r.CoreApp.Spec.Selector.MatchLabels["noobaa-core"] = r.Request.Name
 	r.CoreApp.Spec.ServiceName = r.ServiceMgmt.Name
+	// OnDelete avoids RollingUpdate stall on never-Ready HA standbys; see restartStaleCorePods.
+	r.CoreApp.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.OnDeleteStatefulSetStrategyType,
+	}
 
 	podSpec := &r.CoreApp.Spec.Template.Spec
-	// ShutdownGrace (25s) + SIGKILL wait (5s) + lease-release margin (10s).
-	// Keep in sync with leaderelect.RecommendedTerminationGracePeriod.
-	terminationGracePeriodSeconds := leaderelect.RecommendedTerminationGracePeriod(0)
+	terminationGracePeriodSeconds := r.coreTerminationGracePeriodSeconds()
 	podSpec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 	podSpec.ServiceAccountName = "noobaa-core"
 	coreImageChanged := false
 
-	if r.CoreApp.Spec.Replicas != nil && *r.CoreApp.Spec.Replicas == 0 {
-		// replicas can be set to 0 if the cluster went through data import to DB cluster
-		// restore back to 1 replica
-		oneReplica := int32(1)
-		r.CoreApp.Spec.Replicas = &oneReplica
-	}
+	desiredCoreReplicas := getDesiredCoreReplicas(r.NooBaa)
+	r.CoreApp.Spec.Replicas = &desiredCoreReplicas
 
 	// adding the missing Volumes from default podSpec
 	podSpec.Volumes = r.DefaultCoreApp.Volumes
@@ -857,7 +867,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 		r.CoreApp.Spec.Template.Annotations = make(map[string]string)
 	}
 
-	r.CoreApp.Spec.Template.Annotations["noobaa.io/configmap-hash"] = r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"]
+	r.CoreApp.Spec.Template.Annotations[coreConfigMapHashAnnotation] = r.CoreAppConfig.Annotations[coreConfigMapHashAnnotation]
 	r.CoreApp.Spec.Template.Annotations[secv1.RequiredSCCAnnotation] = "noobaa-core"
 
 	// we want to check that the cm exists and also that it has data in it
@@ -1683,6 +1693,11 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 		"NOOBAA_VERSION_AUTH_ENABLED":  "true",
 		"ENDPOINT_SYSTEM_STORE_SOURCE": "core", // by default, load the system store in the endpoint from the core instead of the DB
 		"OPERATOR_LOG_LEVEL":           "info",
+		"NOOBAA_CORE_LEASE_DURATION":   "20s",
+		"NOOBAA_CORE_RENEW_DEADLINE":   "10s",
+		"NOOBAA_CORE_RETRY_PERIOD":     "3s",
+		"NOOBAA_CORE_SHUTDOWN_GRACE":   "25s",
+		"NOOBAA_CORE_LOST_GRACE":       "8s",
 	}
 	for key, value := range DefaultConfigMapData {
 		if _, ok := r.CoreAppConfig.Data[key]; !ok {
@@ -1702,8 +1717,100 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 			coreData[k] = v
 		}
 	}
-	r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"] = util.GetCmDataHash(coreData)
+	r.CoreAppConfig.Annotations[coreConfigMapHashAnnotation] = util.GetCmDataHash(coreData)
 
+	return nil
+}
+
+func isCoreHAEnabled(nooBaa *nbv1.NooBaa) bool {
+	// Omitted/false keeps HA enabled; only an explicit disableCoreHA=true uses 1 replica.
+	return !nooBaa.Spec.DisableCoreHA
+}
+
+func getDesiredCoreReplicas(nooBaa *nbv1.NooBaa) int32 {
+	if isCoreHAEnabled(nooBaa) {
+		return options.CoreHAReplicaCount
+	}
+	return 1
+}
+
+// coreTerminationGracePeriodSeconds derives pod terminationGracePeriodSeconds from
+// noobaa-config NOOBAA_CORE_SHUTDOWN_GRACE (invalid/missing → leaderelect default).
+func (r *Reconciler) coreTerminationGracePeriodSeconds() int64 {
+	shutdownGrace := time.Duration(0)
+	if raw := strings.TrimSpace(r.CoreAppConfig.Data["NOOBAA_CORE_SHUTDOWN_GRACE"]); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			shutdownGrace = d
+		}
+	}
+	return leaderelect.RecommendedTerminationGracePeriod(shutdownGrace)
+}
+
+// restartStaleCorePods deletes one outdated core pod per reconcile under OnDelete.
+func (r *Reconciler) restartStaleCorePods() error {
+	if r.CoreApp.UID == "" {
+		return nil
+	}
+	// Refresh status (UpdateRevision) after the STS reconcile.
+	if !util.KubeCheckQuiet(r.CoreApp) {
+		return nil
+	}
+
+	desiredHash := ""
+	if r.CoreApp.Spec.Template.Annotations != nil {
+		desiredHash = r.CoreApp.Spec.Template.Annotations[coreConfigMapHashAnnotation]
+	}
+	updateRevision := r.CoreApp.Status.UpdateRevision
+
+	podList := &corev1.PodList{}
+	if !util.KubeList(podList, client.InNamespace(r.Request.Namespace), client.MatchingLabels{"noobaa-core": r.Request.Name}) {
+		return fmt.Errorf("failed listing core pods to restart stale revisions")
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.DeletionTimestamp != nil {
+			// Wait for in-flight deletes before starting another.
+			return nil
+		}
+		if !isCorePodStale(pod, desiredHash, updateRevision) {
+			continue
+		}
+		r.Logger.Warnf("deleting outdated core pod %q (OnDelete) desiredHash=%q updateRevision=%q",
+			pod.Name, desiredHash, updateRevision)
+		util.KubeDeleteNoPolling(pod)
+		return nil
+	}
+	return nil
+}
+
+func isCorePodStale(pod *corev1.Pod, desiredHash, updateRevision string) bool {
+	if pod == nil {
+		return false
+	}
+	if desiredHash != "" {
+		podHash := ""
+		if pod.Annotations != nil {
+			podHash = pod.Annotations[coreConfigMapHashAnnotation]
+		}
+		if podHash != "" && podHash != desiredHash {
+			return true
+		}
+	}
+	if updateRevision == "" || pod.Labels == nil {
+		return false
+	}
+	podRevision := pod.Labels[appsv1.ControllerRevisionHashLabelKey]
+	return podRevision != "" && podRevision != updateRevision
+}
+
+// SetDesiredCoreLease updates the core Lease as desired for reconciling
+func (r *Reconciler) SetDesiredCoreLease() error {
+	if r.CoreLease.Labels == nil {
+		r.CoreLease.Labels = map[string]string{}
+	}
+	r.CoreLease.Labels["app"] = "noobaa"
+	r.CoreLease.Labels["noobaa-core-lease"] = r.Request.Name
 	return nil
 }
 

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -53,7 +53,7 @@ const (
 	gcpServiceAccountEmailEnvVar string = "SERVICE_ACCOUNT_EMAIL"
 
 	// coreConfigMapHashAnnotation is set on the core configmap and STS/endpoint pod
-	// templates so OnDelete can detect config drift.
+	// templates so config drift can be detected (e.g. for pod restarts).
 	coreConfigMapHashAnnotation = "noobaa.io/configmap-hash"
 )
 
@@ -227,10 +227,6 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 	}
 
 	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
-		return err
-	}
-	// OnDelete: operator must delete outdated pods (see restartStaleCorePods).
-	if err := r.restartStaleCorePods(); err != nil {
 		return err
 	}
 
@@ -660,10 +656,6 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	r.CoreApp.Spec.Template.Labels["noobaa-mgmt"] = r.Request.Name
 	r.CoreApp.Spec.Selector.MatchLabels["noobaa-core"] = r.Request.Name
 	r.CoreApp.Spec.ServiceName = r.ServiceMgmt.Name
-	// OnDelete avoids RollingUpdate stall on never-Ready HA standbys; see restartStaleCorePods.
-	r.CoreApp.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
-		Type: appsv1.OnDeleteStatefulSetStrategyType,
-	}
 
 	podSpec := &r.CoreApp.Spec.Template.Spec
 	terminationGracePeriodSeconds := r.coreTerminationGracePeriodSeconds()
@@ -1744,64 +1736,6 @@ func (r *Reconciler) coreTerminationGracePeriodSeconds() int64 {
 		}
 	}
 	return leaderelect.RecommendedTerminationGracePeriod(shutdownGrace)
-}
-
-// restartStaleCorePods deletes one outdated core pod per reconcile under OnDelete.
-func (r *Reconciler) restartStaleCorePods() error {
-	if r.CoreApp.UID == "" {
-		return nil
-	}
-	// Refresh status (UpdateRevision) after the STS reconcile.
-	if !util.KubeCheckQuiet(r.CoreApp) {
-		return nil
-	}
-
-	desiredHash := ""
-	if r.CoreApp.Spec.Template.Annotations != nil {
-		desiredHash = r.CoreApp.Spec.Template.Annotations[coreConfigMapHashAnnotation]
-	}
-	updateRevision := r.CoreApp.Status.UpdateRevision
-
-	podList := &corev1.PodList{}
-	if !util.KubeList(podList, client.InNamespace(r.Request.Namespace), client.MatchingLabels{"noobaa-core": r.Request.Name}) {
-		return fmt.Errorf("failed listing core pods to restart stale revisions")
-	}
-
-	for i := range podList.Items {
-		pod := &podList.Items[i]
-		if pod.DeletionTimestamp != nil {
-			// Wait for in-flight deletes before starting another.
-			return nil
-		}
-		if !isCorePodStale(pod, desiredHash, updateRevision) {
-			continue
-		}
-		r.Logger.Warnf("deleting outdated core pod %q (OnDelete) desiredHash=%q updateRevision=%q",
-			pod.Name, desiredHash, updateRevision)
-		util.KubeDeleteNoPolling(pod)
-		return nil
-	}
-	return nil
-}
-
-func isCorePodStale(pod *corev1.Pod, desiredHash, updateRevision string) bool {
-	if pod == nil {
-		return false
-	}
-	if desiredHash != "" {
-		podHash := ""
-		if pod.Annotations != nil {
-			podHash = pod.Annotations[coreConfigMapHashAnnotation]
-		}
-		if podHash != "" && podHash != desiredHash {
-			return true
-		}
-	}
-	if updateRevision == "" || pod.Labels == nil {
-		return false
-	}
-	podRevision := pod.Labels[appsv1.ControllerRevisionHashLabelKey]
-	return podRevision != "" && podRevision != updateRevision
 }
 
 // SetDesiredCoreLease updates the core Lease as desired for reconciling

--- a/pkg/system/phase3_connecting.go
+++ b/pkg/system/phase3_connecting.go
@@ -29,11 +29,11 @@ func (r *Reconciler) ReconcilePhaseConnecting() error {
 		r.CheckServiceStatus(r.ServiceMgmt, r.RouteMgmt, &r.NooBaa.Status.Services.ServiceMgmt, "mgmt-https")
 	}
 
-	// wait for noobaa core statefulset to be ready before proceeding
+	// wait for at least one ready core pod (HA: only the leader becomes Ready; standbys stay not Ready)
 	if r.CoreApp.Spec.Replicas == nil {
 		return fmt.Errorf("noobaa core statefulset replicas is nil, cannot proceed")
-	} else if r.CoreApp.Status.ReadyReplicas < *r.CoreApp.Spec.Replicas {
-		return fmt.Errorf("waiting for noobaa core pod to be ready, currently ready replicas: %d, expected: %d",
+	} else if r.CoreApp.Status.ReadyReplicas < 1 {
+		return fmt.Errorf("waiting for noobaa core pod to be ready, currently ready replicas: %d, expected: at least 1 (%d configured)",
 			r.CoreApp.Status.ReadyReplicas, *r.CoreApp.Spec.Replicas)
 	}
 

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -480,7 +480,7 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 				r.DeploymentEndpoint.Spec.Template.Annotations = make(map[string]string)
 			}
 
-			r.DeploymentEndpoint.Spec.Template.Annotations["noobaa.io/configmap-hash"] = r.CoreAppConfig.Annotations["noobaa.io/configmap-hash"]
+			r.DeploymentEndpoint.Spec.Template.Annotations[coreConfigMapHashAnnotation] = r.CoreAppConfig.Annotations[coreConfigMapHashAnnotation]
 			r.DeploymentEndpoint.Spec.Template.Annotations[secv1.RequiredSCCAnnotation] = "noobaa-endpoint"
 
 			r.addContainerPortsIfNotExist(c, []corev1.ContainerPort{

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -73,6 +74,7 @@ type Reconciler struct {
 	NooBaa                    *nbv1.NooBaa
 	ServiceAccount            *corev1.ServiceAccount
 	CoreApp                   *appsv1.StatefulSet
+	CoreLease                 *coordinationv1.Lease
 	CoreAppConfig             *corev1.ConfigMap
 	DefaultCoreApp            *corev1.PodSpec
 	PostgresDBConf            *corev1.ConfigMap
@@ -160,6 +162,7 @@ func NewReconciler(
 		NooBaa:                    util.KubeObject(bundle.File_deploy_crds_noobaa_io_v1alpha1_noobaa_cr_yaml).(*nbv1.NooBaa),
 		ServiceAccount:            util.KubeObject(bundle.File_deploy_service_account_yaml).(*corev1.ServiceAccount),
 		CoreApp:                   util.KubeObject(bundle.File_deploy_internal_statefulset_core_yaml).(*appsv1.StatefulSet),
+		CoreLease:                 util.KubeObject(bundle.File_deploy_internal_lease_core_yaml).(*coordinationv1.Lease),
 		CoreAppConfig:             util.KubeObject(bundle.File_deploy_internal_configmap_empty_yaml).(*corev1.ConfigMap),
 		PostgresDBConf:            util.KubeObject(bundle.File_deploy_internal_configmap_postgres_db_yaml).(*corev1.ConfigMap),
 		NooBaaPostgresDB:          util.KubeObject(bundle.File_deploy_internal_statefulset_postgres_db_yaml).(*appsv1.StatefulSet),
@@ -216,6 +219,7 @@ func NewReconciler(
 	r.NooBaa.Namespace = r.Request.Namespace
 	r.ServiceAccount.Namespace = r.Request.Namespace
 	r.CoreApp.Namespace = r.Request.Namespace
+	r.CoreLease.Namespace = r.Request.Namespace
 	r.CoreAppConfig.Namespace = r.Request.Namespace
 	r.PostgresDBConf.Namespace = r.Request.Namespace
 	r.NooBaaPostgresDB.Namespace = r.Request.Namespace
@@ -269,6 +273,7 @@ func NewReconciler(
 	r.NooBaa.Name = r.Request.Name
 	r.ServiceAccount.Name = r.Request.Name
 	r.CoreApp.Name = r.Request.Name + "-core"
+	r.CoreLease.Name = r.Request.Name + "-core-lease"
 	r.CoreAppConfig.Name = "noobaa-config"
 	r.NooBaaPostgresDB.Name = r.Request.Name + "-db-pg"
 	r.ServiceMgmt.Name = r.Request.Name + "-mgmt"
@@ -360,6 +365,7 @@ func (r *Reconciler) CheckAll() {
 	CheckSystem(r.NooBaa)
 	r.reportKMSConditionStatus()
 	util.KubeCheck(r.CoreApp)
+	util.KubeCheckQuiet(r.CoreLease)
 	util.KubeCheck(r.CoreAppConfig)
 	util.KubeCheck(r.ServiceMgmt)
 	util.KubeCheck(r.ServiceS3)

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -67,14 +68,19 @@ func CmdCreate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a noobaa system",
-		Run:   RunCreate,
-		Args:  cobra.NoArgs,
+		Long: `Create a noobaa system.
+
+Core HA is enabled by default (2 noobaa-core pods with Kubernetes lease leader election).
+Use --disable-core-ha to install with a single core pod.`,
+		Run:  RunCreate,
+		Args: cobra.NoArgs,
 	}
 	cmd.Flags().String("core-resources", "", "Core resources JSON")
 	cmd.Flags().String("db-resources", "", "DB resources JSON")
 	cmd.Flags().String("endpoint-resources", "", "Endpoint resources JSON")
 	cmd.Flags().Bool("use-standalone-db", false, "Create NooBaa system with standalone DB (Legacy)")
 	cmd.Flags().Bool("use-obc-cleanup-policy", false, "Create NooBaa system with obc cleanup policy")
+	AddDisableCoreHAFlags(cmd)
 	return cmd
 }
 
@@ -195,6 +201,15 @@ func CmdOidc() *cobra.Command {
 	return cmd
 }
 
+// AddDisableCoreHAFlags registers the disable-core-ha flag on install/create (local to those commands, like use-standalone-db).
+func AddDisableCoreHAFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(
+		&options.DisableCoreHA, "disable-core-ha",
+		options.DisableCoreHA,
+		"Disable noobaa-core HA (single core pod). Default is HA enabled (2 pods with lease leader election)",
+	)
+}
+
 // LoadSystemDefaults loads a noobaa system CR from bundled yamls
 // and apply's changes from CLI flags to the defaults.
 func LoadSystemDefaults() *nbv1.NooBaa {
@@ -210,6 +225,7 @@ func LoadSystemDefaults() *nbv1.NooBaa {
 	sys.Spec.LoadBalancerSourceSubnets.S3 = options.S3LoadBalancerSourceSubnets
 	sys.Spec.LoadBalancerSourceSubnets.STS = options.STSLoadBalancerSourceSubnets
 	sys.Spec.LoadBalancerSourceSubnets.Vectors = options.VectorsLoadBalancerSourceSubnets
+	sys.Spec.DisableCoreHA = options.DisableCoreHA
 
 	LoadConfigMapFromFlags()
 
@@ -1207,9 +1223,10 @@ func CheckWaitingFor(sys *nbv1.NooBaa) error {
 	if coreApp.Spec.Replicas != nil {
 		desiredReplicas = *coreApp.Spec.Replicas
 	}
-	if coreApp.Status.Replicas != desiredReplicas {
+	// HA: only the leader becomes Ready; standbys stay not Ready — require at least one.
+	if coreApp.Status.ReadyReplicas < 1 {
 		log.Printf(`⏳ System Phase is %q. StatefulSet %q is not yet ready:`+
-			` ReadyReplicas %d/%d`,
+			` ReadyReplicas %d, need at least 1 (%d configured)`,
 			sys.Status.Phase,
 			coreAppName,
 			coreApp.Status.ReadyReplicas,
@@ -1226,22 +1243,15 @@ func CheckWaitingFor(sys *nbv1.NooBaa) error {
 	if corePodErr != nil {
 		return corePodErr
 	}
-	if len(corePodList.Items) != int(desiredReplicas) {
-		return fmt.Errorf("Can't find the core pods")
-	}
-	corePod := &corePodList.Items[0]
-	if corePod.Status.Phase != corev1.PodRunning {
-		log.Printf(`⏳ System Phase is %q. Pod %q is not yet ready: %s`,
-			sys.Status.Phase, corePod.Name, util.GetPodStatusLine(corePod))
+	if len(corePodList.Items) == 0 {
+		log.Printf(`⏳ System Phase is %q. No core pods found yet (want %d)`,
+			sys.Status.Phase, desiredReplicas)
 		return nil
 	}
-	for i := range corePod.Status.ContainerStatuses {
-		c := &corePod.Status.ContainerStatuses[i]
-		if !c.Ready {
-			log.Printf(`⏳ System Phase is %q. Container %q is not yet ready: %s`,
-				sys.Status.Phase, c.Name, util.GetContainerStatusLine(c))
-			return nil
-		}
+	if len(corePodList.Items) != int(desiredReplicas) {
+		log.Printf(`⏳ System Phase is %q. Found %d core pods, want %d`,
+			sys.Status.Phase, len(corePodList.Items), desiredReplicas)
+		return nil
 	}
 
 	log.Printf(`⏳ System Phase is %q. Waiting for phase ready ...`, sys.Status.Phase)
@@ -1381,13 +1391,17 @@ func Connect(isExternal bool) (*Client, error) {
 
 	if isExternal {
 
-		// setup port forwarding
+		// Port-forward to a Ready mgmt/core pod (HA: standbys are not Ready).
+		podName, err := findReadyMgmtPod(r.ServiceMgmt)
+		if err != nil {
+			return nil, fmt.Errorf("Connect(): %w", err)
+		}
 		router := &nb.APIRouterPortForward{
 			ServiceMgmt:  r.ServiceMgmt,
 			PodNamespace: r.NooBaa.Namespace,
-			PodName:      r.NooBaa.Name + "-core-0",
+			PodName:      podName,
 		}
-		err := router.Start()
+		err = router.Start()
 		if err != nil {
 			return nil, err
 		}
@@ -1438,6 +1452,54 @@ func Connect(isExternal bool) (*Client, error) {
 		S3URL:       s3URL,
 		VectorsURL:  vectorsURL,
 	}, nil
+}
+
+// findReadyMgmtPod returns the name of a Ready pod matching the mgmt Service selector.
+// Matches kube Endpoints policy: only Ready backends are eligible for mgmt traffic.
+func findReadyMgmtPod(svc *corev1.Service) (string, error) {
+	if svc == nil {
+		return "", fmt.Errorf("mgmt service is nil")
+	}
+	if len(svc.Spec.Selector) == 0 {
+		return "", fmt.Errorf("mgmt service %q has empty selector", svc.Name)
+	}
+	podList := &corev1.PodList{}
+	if !util.KubeList(podList, client.InNamespace(svc.Namespace), client.MatchingLabels(svc.Spec.Selector)) {
+		return "", fmt.Errorf("failed listing pods for mgmt service %q", svc.Name)
+	}
+	return pickReadyPodName(podList.Items)
+}
+
+// pickReadyPodName returns the lexicographically first Running+Ready pod name.
+func pickReadyPodName(pods []corev1.Pod) (string, error) {
+	var ready []string
+	for i := range pods {
+		pod := &pods[i]
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		if !isPodReady(pod) {
+			continue
+		}
+		ready = append(ready, pod.Name)
+	}
+	if len(ready) == 0 {
+		return "", fmt.Errorf("no Ready mgmt/core pod found for port-forward")
+	}
+	sort.Strings(ready)
+	return ready[0], nil
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // IsRunningInCluster returns true when the process runs inside a Kubernetes pod.


### PR DESCRIPTION
## Summary
- Switch `noobaa-core` StatefulSet to `updateStrategy: OnDelete` so RollingUpdate does not stall on never-Ready HA standbys.
- Operator deletes one outdated core pod per reconcile when configmap-hash or controller-revision drifts (`restartStaleCorePods`).
- Unit coverage for `isCorePodStale`.

## Context
**Depends on / stacked on #2060.** Please review this PR for the OnDelete + operator pod-delete approach only.

`podManagementPolicy: Parallel` does **not** replace this: it only affects scale ordering, not RollingUpdate's Ready wait between ordinals.

If GitHub shows a large diff vs `master`, focus on the top commit (`core HA | use OnDelete and restart stale core pods`) or compare against the `#2060` branch:
https://github.com/noobaa/noobaa-operator/compare/nadavMiz:replicas-increase...nadavMiz:core-ha-ondelete

## Test plan
- [ ] With #2060 applied + this PR: change core config / image and confirm both core pods eventually pick up the new revision
- [ ] Confirm only one stale pod is deleted per reconcile while a delete is in flight
- [ ] Confirm Ready leader remains Ready until deliberately deleted / fails over
- [ ] `go test ./pkg/system/ -run TestIsCorePodStale`