### PR TITLE
AWS STS | STS Client with `aws.Config`: `Region` and `STSRegionalEndpoint`

### DIFF
--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -1108,6 +1109,10 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 		region = "us-east-1"
 	}
 	r.Logger.Infof("identified aws region %s", region)
+	awsHTTPClient := &http.Client{
+		Transport: util.GlobalCARefreshingTransport,
+		Timeout:   10 * time.Second,
+	}
 	var s3Config *aws.Config
 	if r.IsAWSSTSCluster { // handle STS case first
 		// get credentials
@@ -1123,7 +1128,11 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 		roleARNInput := info["role_arn"]
 		webIdentityTokenPathInput := info["web_identity_token_file"]
 		r.Logger.Info("Initiating a Session with AWS")
-		sess, err := session.NewSession()
+		sess, err := session.NewSession(&aws.Config{
+			Region:              aws.String(region),
+			STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
+			HTTPClient:          awsHTTPClient,
+		})
 		if err != nil {
 			return fmt.Errorf("could not create AWS Session %v", err)
 		}
@@ -1152,11 +1161,8 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 				*result.Credentials.SecretAccessKey,
 				*result.Credentials.SessionToken,
 			),
-			HTTPClient: &http.Client{
-				Transport: util.GlobalCARefreshingTransport,
-				Timeout:   10 * time.Second,
-			},
-			Region: &region,
+			HTTPClient: awsHTTPClient,
+			Region:     &region,
 		}
 	} else { // handle AWS long-lived credentials (not STS)
 		s3Config = &aws.Config{
@@ -1165,11 +1171,8 @@ func (r *Reconciler) prepareAWSBackingStore() error {
 				cloudCredsSecret.StringData["aws_secret_access_key"],
 				"",
 			),
-			HTTPClient: &http.Client{
-				Transport: util.GlobalCARefreshingTransport,
-				Timeout:   10 * time.Second,
-			},
-			Region: &region,
+			HTTPClient: awsHTTPClient,
+			Region:     &region,
 		}
 	}
 


### PR DESCRIPTION
### Describe the Problem
Currently, the STS Client, which is used when the OCP platform is AWS STS to call `AssumeRoleWithWebIdentity`, uses the default session. AWS GovCloud (US) regions should use regional AWS STS endpoints only. Therefore, we added the config to the session to use the region and the regional AWS STS endpoint.

### Explain the changes
1. Change the default session `session.NewSession()` used by the STS Client to contain `Region` and `STSRegionalEndpoint`. I also added the `HTTPClient` to align with the existing `s3Config` used by the S3 client.
Note: it means that now for all the regions (not just AWS GovCloud) we will use regional AWS STS endpoints and not the global endpoint `https://sts.amazonaws.com`.

### Issues: Fixed [DFBUGS-9095](https://redhat.atlassian.net/browse/DFBUGS-9095)
Currently, the STS Client, which is used when the OCP platform is AWS STS to call `AssumeRoleWithWebIdentity`, uses the default session. 
AWS SDK V1 Go `session` is ([AWS docs](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/)):
> session provides configuration for the SDK's service clients

For AWS GovCloud (US) regions should use regional AWS STS endpoints. ([AWS docs](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-iam.html)):
> In the AWS GovCloud (US) Regions, there is no AWS STS global endpoint. AWS provides Regional AWS STS endpoints.

Currently, we use AWS SDK V1 and the default is `Global endpoint` ([AWS docs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html)):

> Global endpoint: `https://sts.amazonaws.com`.
> Regional endpoint: Based on the configured AWS Region used by your application.

SDK | Supports setting | Default setting value | Default service client target STS Endpoint | Service client fallback behavior | 
-- | -- | -- | -- | -- 
SDK for Go 1.x (V1) | Yes | legacy | Global endpoint | Global endpoint |

GAP - Proxy configurations:
In a separate PR, we will add to `http.Transport` `Proxy` for AWS clients to honor `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` envs - a [comment](https://github.com/noobaa/noobaa-operator/pull/2069#discussion_r3709795199) that was raised by CodeRabbit.

### Testing Instructions:
I could not test this with my existing resources; it would be tested as part of [DFBUGS-9095](https://redhat.atlassian.net/browse/DFBUGS-9095).

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS connectivity by using region-aware service endpoints.
  * Enhanced certificate handling so refreshed trusted certificates are recognized automatically.
  * Added a 10-second connection timeout to improve responsiveness when AWS services are unavailable.
  * Improved consistency across AWS authentication and credential operations by reusing a shared connection configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->