### PR TITLE
Fix NamespaceStore delete skipping external connection cleanup

### DIFF
--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -385,11 +385,7 @@ func (r *Reconciler) ReconcileDeletion(systemFound bool) error {
 		}
 
 		if r.NBClient != nil && r.NamespaceStore.Spec.Type != nbv1.NSStoreTypeNSFS {
-			hasOwned, err := r.hasOwnedExternalConnection()
-			if err != nil {
-				return err
-			}
-			if hasOwned {
+			if r.hasOwnedExternalConnection() {
 				err := r.NBClient.DeleteExternalConnectionAPI(nb.DeleteExternalConnectionParams{Name: r.NamespaceStore.Name})
 				if err != nil {
 					if rpcErr, isRPCErr := err.(*nb.RPCError); isRPCErr {
@@ -409,20 +405,22 @@ func (r *Reconciler) ReconcileDeletion(systemFound bool) error {
 	return r.FinalizeDeletion()
 }
 
-// hasOwnedExternalConnection checks list_accounts for an external connection named like this NamespaceStore
-func (r *Reconciler) hasOwnedExternalConnection() (bool, error) {
-	accountsList, err := r.NBClient.ListAccountsAPI(nb.ListAccountsParams{})
-	if err != nil {
-		return false, err
+// hasOwnedExternalConnection returns true if SystemInfo has an external connection
+// whose name matches this NamespaceStore. That means this store owns the connection
+// and it should be deleted on cleanup. If another store reused a shared connection,
+// the connection keeps that other name, so this returns false and we do not delete it.
+func (r *Reconciler) hasOwnedExternalConnection() bool {
+	if r.SystemInfo == nil {
+		return false
 	}
-	for _, account := range accountsList.Accounts {
-		for i := range account.ExternalConnections.Connections {
-			if account.ExternalConnections.Connections[i].Name == r.NamespaceStore.Name {
-				return true, nil
+	for _, account := range r.SystemInfo.Accounts {
+		for _, conn := range account.ExternalConnections.Connections {
+			if conn.Name == r.NamespaceStore.Name {
+				return true
 			}
 		}
 	}
-	return false, nil
+	return false
 }
 
 // FinalizeDeletion removed the finalizer and updates in order to let the namespace-store get reclaimed by kubernetes


### PR DESCRIPTION
### Describe the Problem
NamespaceStore deletion skipped external connection cleanup. The orphaned connection then blocked recreate with "Connection name already exists".

### Explain the changes
1. Check owned connections from ReadSystemAPI / SystemInfo.Accounts instead of ListAccountsAPI, so delete cleanup finds and removes the connection.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6006 

### Testing Instructions:
1. Create a NamespaceStore pointing to endpoint A, verify it reaches Ready
2. Try to update the endpoint to B — verify it is rejected with "Changing a NamespaceStore endpoint is unsupported"
3. Delete the NamespaceStore — verify the internal connection is removed
4. Re-create the NamespaceStore pointing to endpoint B — verify it reaches Ready with no "Connection name already exists" error

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace-store deletion handling by checking cached system information for associated external connections.
  * Deletions now complete safely when system information is unavailable.
  * Connection matching is more accurate for namespace stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->