### PR TITLE
coreHA | fallback to old core init script if new one is missing

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -77,13 +77,17 @@ spec:
           image: NOOBAA_CORE_IMAGE
           terminationMessagePolicy: FallbackToLogsOnError
           command:
+            # Prefer core_init.js (newer core images); fall back to supervisord (older images).
             - /noobaa-shared/noobaa-operator
             - leader-elect
             - --
             - /bin/bash
             - -ec
             - |
-              exec /usr/local/bin/node /root/node_modules/noobaa-core/src/cmd/core_init.js
+              if [ -f /root/node_modules/noobaa-core/src/cmd/core_init.js ]; then
+                exec /usr/local/bin/node /root/node_modules/noobaa-core/src/cmd/core_init.js
+              fi
+              exec /usr/bin/supervisord start
           volumeMounts:
             - name: logs
               mountPath: /log

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5623,7 +5623,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "1f60f4995b291944111536d9f70b2678ec75dd60f53c0340d2bf6adb5bdd1325"
+const Sha256_deploy_internal_statefulset_core_yaml = "8ff071dc752f7020b32222f46713887a4f9c0d2bd4d0e6d766d470f37ab5d466"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5704,13 +5704,17 @@ spec:
           image: NOOBAA_CORE_IMAGE
           terminationMessagePolicy: FallbackToLogsOnError
           command:
+            # Prefer core_init.js (newer core images); fall back to supervisord (older images).
             - /noobaa-shared/noobaa-operator
             - leader-elect
             - --
             - /bin/bash
             - -ec
             - |
-              exec /usr/local/bin/node /root/node_modules/noobaa-core/src/cmd/core_init.js
+              if [ -f /root/node_modules/noobaa-core/src/cmd/core_init.js ]; then
+                exec /usr/local/bin/node /root/node_modules/noobaa-core/src/cmd/core_init.js
+              fi
+              exec /usr/bin/supervisord start
           volumeMounts:
             - name: logs
               mountPath: /log


### PR DESCRIPTION
### Describe the Problem
During upgrade, the operator can roll before the core image. The new operator always starts core with core_init.js, but older core images (e.g. 5.22) do not have that file, so the core pod CrashLoops with MODULE_NOT_FOUND.

### Explain the changes
1. Update the core container command to try core_init.js first, and fall back to supervisord start if that file is missing.
2. After the core image is upgraded and includes core_init.js, the same command uses the new path automatically.


### Issues: https://redhat.atlassian.net/browse/DFBUGS-9234

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved core service startup compatibility across image versions.
  * Core services now start correctly whether the newer initialization process is available or the legacy startup process is required.
  * Preserved leader election behavior during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->