### PR TITLE
External postgres is failing with connection refused error

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -148,6 +148,7 @@ spec:
             - name: POSTGRES_PASSWORD_PATH
             - name: POSTGRES_DBNAME_PATH
             - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
             - name: VIRTUAL_HOSTS
             - name: REGION
             - name: ENDPOINT_GROUP_ID

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -202,6 +202,7 @@ spec:
             - name: POSTGRES_PASSWORD_PATH
             - name: POSTGRES_DBNAME_PATH
             - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
             - name: GUARANTEED_LOGS_PATH
             - name: DB_TYPE
               value: postgres

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4364,7 +4364,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "e028fd7874ebec9b0b63f84ed2f9b3648a8785c7f0cd99b49d8de4a28b7d1910"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "16b4b00ed2e3f87a4862754ada95512dfa5731a80f22ee15800602bd4c8b4cae"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4516,6 +4516,7 @@ spec:
             - name: POSTGRES_PASSWORD_PATH
             - name: POSTGRES_DBNAME_PATH
             - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
             - name: VIRTUAL_HOSTS
             - name: REGION
             - name: ENDPOINT_GROUP_ID
@@ -5639,7 +5640,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "6d6c6f11ff0ec75ff25a1da47f32ce22af1104d7ee64d564ef1839e26954b78c"
+const Sha256_deploy_internal_statefulset_core_yaml = "9fc44f63efc86044491b316f70a18e4087d2f716f2ad4fedafe7cb937597b1df"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5845,6 +5846,7 @@ spec:
             - name: POSTGRES_PASSWORD_PATH
             - name: POSTGRES_DBNAME_PATH
             - name: POSTGRES_PORT_PATH
+            - name: POSTGRES_CONNECTION_STRING_PATH
             - name: GUARANTEED_LOGS_PATH
             - name: DB_TYPE
               value: postgres

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -610,7 +610,11 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 		case "POSTGRES_HOST_PATH":
 			c.Env[j].Value = postgresSecretMountPath + "/host"
 		case "POSTGRES_CONNECTION_STRING_PATH":
-			c.Env[j].Value = postgresSecretMountPath + "/db_url"
+			c.Env[j].Value = ""
+			c.Env[j].ValueFrom = nil
+			if r.ExternalPgSecret != nil {
+				c.Env[j].Value = postgresSecretMountPath + "/db_url"
+			}
 
 		case "NODE_EXTRA_CA_CERTS":
 			c.Env[j].Value = r.ApplyCAsToPods


### PR DESCRIPTION
### Describe the Problem

External postgres is failing with connection refused error

### Explain the changes
1. Noobaa core and endpoint was missing the `POSTGRES_CONNECTION_STRING_PATH` in its env list
and its added to env list noobaa CNPG was able to connect to external pg using connection URI

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-9179

### Testing Instructions:
Install noobaa with external postgress, please find steps
1. create PersistentVolumeClaim for DB
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: postgres-external-pvc
  namespace: noobaa
spec:
  accessModes: ["ReadWriteOnce"]
  resources:
    requests:
      storage: 2Gi
```
2. Create postgres deployment version postgres:15
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: postgres-external
  namespace: noobaa
spec:
  replicas: 1
  selector:
    matchLabels:
      app: postgres-external
  template:
    metadata:
      labels:
        app: postgres-external
    spec:
      containers:
        - name: postgres
          image: postgres:15
          env:
            - name: POSTGRES_PASSWORD
              value: noobaa
            - name: POSTGRES_DB
              value: nbcore
            - name: POSTGRES_INITDB_ARGS
              value: "--locale=C"
          ports:
            - containerPort: 5432
          volumeMounts:
            - name: pgdata
              mountPath: /var/lib/postgresql/data
      volumes:
        - name: pgdata
          persistentVolumeClaim:
            claimName: postgres-external-pvc
```
3. create PG service 
```
apiVersion: v1
kind: Service
metadata:
  name: postgres-external
  namespace: noobaa
spec:
  selector:
    app: postgres-external
  ports:
    - port: 5432
      targetPort: 5432
```
4. After creating external pg deployemnts and database and service, we can access it using uri
`--postgres-url="postgres://postgres:noobaa@postgres-external.noobaa.svc.cluster.local:5432/nbcore"`
5. Install noobaa with external pg
```
nb install --dev --noobaa-image='<noobaa-core-image>' --operator-image='<noobaa-operator-image>' -n noobaa --postgres-url="postgres://postgres:noobaa@postgres-external.noobaa.svc.cluster.local:5432/nbcore"
```
6. Verify noobaa core and complete installation is success.
- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the PostgreSQL connection string through a file path in endpoint and core workloads.
  * The connection string path is now configured when an external PostgreSQL secret is enabled.
* **Bug Fixes**
  * Corrected deployment behavior so the connection string path is not set when no external PostgreSQL secret is configured.
* **Chores**
  * Updated deployment configuration metadata to reflect the latest settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->