### PR TITLE
notifications - fix NOTIFICATION_LOG_DIR df 8857

### DIFF
--- a/deploy/internal/deployment-endpoint.yaml
+++ b/deploy/internal/deployment-endpoint.yaml
@@ -175,6 +175,8 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: NOTIFICATION_LOG_DIR
+              value: ""
           volumeMounts:
             # curently ssl_utils expects both secrets to be configured in order to use
             # certificates. TODO: Allow each secret to be configured by intself.

--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -238,6 +238,8 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: NOTIFICATION_LOG_DIR
+              value: ""
           envFrom:
             - configMapRef:
                 name: noobaa-config

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4364,7 +4364,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 `
 
-const Sha256_deploy_internal_deployment_endpoint_yaml = "16b4b00ed2e3f87a4862754ada95512dfa5731a80f22ee15800602bd4c8b4cae"
+const Sha256_deploy_internal_deployment_endpoint_yaml = "e55babcc37ae8d7b038ec9394184c1ec8458309cc2511cd5d514bb58bc763993"
 
 const File_deploy_internal_deployment_endpoint_yaml = `apiVersion: apps/v1
 kind: Deployment
@@ -4543,6 +4543,8 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: NOTIFICATION_LOG_DIR
+              value: ""
           volumeMounts:
             # curently ssl_utils expects both secrets to be configured in order to use
             # certificates. TODO: Allow each secret to be configured by intself.
@@ -5640,7 +5642,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "9fc44f63efc86044491b316f70a18e4087d2f716f2ad4fedafe7cb937597b1df"
+const Sha256_deploy_internal_statefulset_core_yaml = "9a446baf09a5995591b96a1990ce256ff5e48a3bf7d839f6a0fc7bf89a9c06e6"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5882,6 +5884,8 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: NOTIFICATION_LOG_DIR
+              value: ""
           envFrom:
             - configMapRef:
                 name: noobaa-config

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -638,15 +638,13 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 
 		case "NOOBAA_CORE_LEASE_NAME":
 			c.Env[j].Value = r.CoreLease.Name
+		case "NOTIFICATION_LOG_DIR":
+			notification_log_dir_value := "";
+			if (r.NooBaa.Spec.BucketNotifications.Enabled) {
+				notification_log_dir_value = "/var/logs/notifications";
+			}
+			c.Env[j].Value = notification_log_dir_value
 		}
-	}
-
-	if r.NooBaa.Spec.BucketNotifications.Enabled {
-		envVar := corev1.EnvVar{
-			Name:  "NOTIFICATION_LOG_DIR",
-			Value: "/var/logs/notifications",
-		}
-		util.MergeEnvArrays(&c.Env, &[]corev1.EnvVar{envVar})
 	}
 
 	util.ApplyTLSEnvVars(&c.Env, r.NooBaa.Spec.Security.APIServerSecurity)

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -453,19 +453,16 @@ func (r *Reconciler) SetDesiredDeploymentEndpoint() error {
 					} else {
 						c.Env[j].Value = ""
 					}
+				case "NOTIFICATION_LOG_DIR":
+					notification_log_dir_value := "";
+					if (r.NooBaa.Spec.BucketNotifications.Enabled) {
+						notification_log_dir_value = "/var/logs/notifications";
+					}
+					c.Env[j].Value = notification_log_dir_value
 				}
 			}
 
 			util.ApplyTLSEnvVars(&c.Env, r.NooBaa.Spec.Security.APIServerSecurity)
-
-			if r.NooBaa.Spec.BucketNotifications.Enabled {
-				envVar := corev1.EnvVar{
-					Name:  "NOTIFICATION_LOG_DIR",
-					Value: "/var/logs/notifications",
-				}
-
-				util.MergeEnvArrays(&c.Env, &[]corev1.EnvVar{envVar})
-			}
 
 			c.SecurityContext = &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
### Describe the Problem
NOTIFICATION_LOG_DIR could not be updated (if a param already appear in a list, the merge doesn't update it).

### Explain the changes
1. Instead use same patterns as other core env params.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-8857

### Testing Instructions:
1. see https://redhat.atlassian.net/browse/DFBUGS-8857 description.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification log directory configuration across core and endpoint services.
  * Ensured the notification log path is consistently set when bucket notifications are enabled and cleared when disabled.
  * Added a default empty notification log directory setting to deployment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->