### PR TITLE
Core HA | add anti-affinity to core pods so they will run on different nodes

### DIFF
--- a/pkg/system/core_ha_test.go
+++ b/pkg/system/core_ha_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestGetDesiredCoreReplicas(t *testing.T) {
@@ -184,5 +185,197 @@ func TestPickStaleCorePodToDelete(t *testing.T) {
 				t.Fatalf("pickStaleCorePodToDelete() = %q, want %q", got.Name, tt.want)
 			}
 		})
+	}
+}
+
+func TestDesiredCoreAffinity(t *testing.T) {
+	t.Parallel()
+
+	const coreName = "noobaa"
+	zoneKey := "topology.kubernetes.io/zone"
+
+	reconcilerFor := func(nb *nbv1.NooBaa) *Reconciler {
+		return &Reconciler{
+			NooBaa:  nb,
+			Request: types.NamespacedName{Name: nb.Name},
+		}
+	}
+
+	t.Run("HA off no affinity", func(t *testing.T) {
+		t.Parallel()
+		nb := &nbv1.NooBaa{}
+		nb.Name = coreName
+		nb.Spec.DisableCoreHA = true
+		if got := reconcilerFor(nb).desiredCoreAffinity(); got != nil {
+			t.Fatalf("expected nil affinity, got %#v", got)
+		}
+	})
+
+	t.Run("HA on no affinity hostname only", func(t *testing.T) {
+		t.Parallel()
+		nb := &nbv1.NooBaa{}
+		nb.Name = coreName
+		got := reconcilerFor(nb).desiredCoreAffinity()
+		if got == nil || got.PodAntiAffinity == nil {
+			t.Fatal("expected pod anti-affinity")
+		}
+		prefs := got.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		if len(prefs) != 1 {
+			t.Fatalf("preferred terms = %d, want 1", len(prefs))
+		}
+		assertPreferredCoreTerm(t, prefs[0], coreName, corev1.LabelHostname)
+	})
+
+	t.Run("HA on with topologyKey zone", func(t *testing.T) {
+		t.Parallel()
+		nb := &nbv1.NooBaa{}
+		nb.Name = coreName
+		nb.Spec.Affinity = &nbv1.AffinitySpec{TopologyKey: zoneKey}
+		got := reconcilerFor(nb).desiredCoreAffinity()
+		prefs := got.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		if len(prefs) != 2 {
+			t.Fatalf("preferred terms = %d, want 2", len(prefs))
+		}
+		assertPreferredCoreTerm(t, prefs[0], coreName, corev1.LabelHostname)
+		assertPreferredCoreTerm(t, prefs[1], coreName, zoneKey)
+	})
+
+	t.Run("HA on topologyKey hostname no duplicate", func(t *testing.T) {
+		t.Parallel()
+		nb := &nbv1.NooBaa{}
+		nb.Name = coreName
+		nb.Spec.Affinity = &nbv1.AffinitySpec{TopologyKey: corev1.LabelHostname}
+		got := reconcilerFor(nb).desiredCoreAffinity()
+		prefs := got.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		if len(prefs) != 1 {
+			t.Fatalf("preferred terms = %d, want 1", len(prefs))
+		}
+		assertPreferredCoreTerm(t, prefs[0], coreName, corev1.LabelHostname)
+	})
+
+	t.Run("HA on preserves nodeAffinity", func(t *testing.T) {
+		t.Parallel()
+		nb := &nbv1.NooBaa{}
+		nb.Name = coreName
+		nb.Spec.Affinity = &nbv1.AffinitySpec{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+						MatchExpressions: []corev1.NodeSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/worker",
+							Operator: corev1.NodeSelectorOpExists,
+						}},
+					}},
+				},
+			},
+		}
+		got := reconcilerFor(nb).desiredCoreAffinity()
+		if got.NodeAffinity == nil {
+			t.Fatal("expected nodeAffinity preserved")
+		}
+		if got.PodAntiAffinity == nil || len(got.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
+			t.Fatal("expected injected hostname preferred term")
+		}
+		// Must not mutate the CR affinity object.
+		if nb.Spec.Affinity.PodAntiAffinity != nil {
+			t.Fatal("expected CR PodAntiAffinity to remain nil (deep copy)")
+		}
+	})
+
+	t.Run("HA on existing preferred term no duplicate", func(t *testing.T) {
+		t.Parallel()
+		existing := corev1.WeightedPodAffinityTerm{
+			Weight: 100,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				TopologyKey: corev1.LabelHostname,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"noobaa-core": coreName},
+				},
+			},
+		}
+		nb := &nbv1.NooBaa{}
+		nb.Name = coreName
+		nb.Spec.Affinity = &nbv1.AffinitySpec{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{existing},
+			},
+		}
+		got := reconcilerFor(nb).desiredCoreAffinity()
+		prefs := got.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		if len(prefs) != 1 {
+			t.Fatalf("preferred terms = %d, want 1 (no duplicate)", len(prefs))
+		}
+	})
+
+	t.Run("HA on stricter user selector still injects term", func(t *testing.T) {
+		t.Parallel()
+		// User term includes noobaa-core but also an extra label — must not suppress ours.
+		userTerm := corev1.WeightedPodAffinityTerm{
+			Weight: 50,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				TopologyKey: corev1.LabelHostname,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"noobaa-core": coreName,
+						"app":         "special",
+					},
+				},
+			},
+		}
+		nb := &nbv1.NooBaa{}
+		nb.Name = coreName
+		nb.Spec.Affinity = &nbv1.AffinitySpec{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{userTerm},
+			},
+		}
+		got := reconcilerFor(nb).desiredCoreAffinity()
+		prefs := got.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		if len(prefs) != 2 {
+			t.Fatalf("preferred terms = %d, want 2 (user + generated)", len(prefs))
+		}
+		assertPreferredCoreTerm(t, prefs[1], coreName, corev1.LabelHostname)
+	})
+
+	t.Run("HA off preserves user podAntiAffinity", func(t *testing.T) {
+		t.Parallel()
+		userTerm := corev1.WeightedPodAffinityTerm{
+			Weight: 50,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				TopologyKey: "topology.kubernetes.io/region",
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "custom"},
+				},
+			},
+		}
+		nb := &nbv1.NooBaa{}
+		nb.Name = coreName
+		nb.Spec.DisableCoreHA = true
+		nb.Spec.Affinity = &nbv1.AffinitySpec{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{userTerm},
+			},
+		}
+		got := reconcilerFor(nb).desiredCoreAffinity()
+		if got == nil || got.PodAntiAffinity == nil {
+			t.Fatal("expected user podAntiAffinity")
+		}
+		prefs := got.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		if len(prefs) != 1 || prefs[0].Weight != 50 || prefs[0].PodAffinityTerm.TopologyKey != "topology.kubernetes.io/region" {
+			t.Fatalf("user anti-affinity changed: %#v", prefs)
+		}
+	})
+}
+
+func assertPreferredCoreTerm(t *testing.T, term corev1.WeightedPodAffinityTerm, coreName, topologyKey string) {
+	t.Helper()
+	if term.Weight != 100 {
+		t.Fatalf("weight = %d, want 100", term.Weight)
+	}
+	if term.PodAffinityTerm.TopologyKey != topologyKey {
+		t.Fatalf("topologyKey = %q, want %q", term.PodAffinityTerm.TopologyKey, topologyKey)
+	}
+	if term.PodAffinityTerm.LabelSelector == nil || term.PodAffinityTerm.LabelSelector.MatchLabels["noobaa-core"] != coreName {
+		t.Fatalf("labelSelector = %#v, want noobaa-core=%s", term.PodAffinityTerm.LabelSelector, coreName)
 	}
 }

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -3,6 +3,7 @@ package system
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"strings"
@@ -843,7 +844,7 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 			[]corev1.LocalObjectReference{*r.NooBaa.Spec.ImagePullSecret}
 	}
 	podSpec.Tolerations = r.NooBaa.Spec.Tolerations
-	podSpec.Affinity = r.GetAffinity()
+	podSpec.Affinity = r.desiredCoreAffinity()
 	podSpec.PriorityClassName = r.NooBaa.Spec.CorePriorityClassName
 
 	if r.CoreApp.UID == "" {
@@ -1732,6 +1733,83 @@ func getDesiredCoreReplicas(nooBaa *nbv1.NooBaa) int32 {
 		return options.CoreHAReplicaCount
 	}
 	return 1
+}
+
+// desiredCoreAffinity returns pod affinity for noobaa-core.
+// When Core HA is on, adds preferred anti-affinity for hostname so replicas prefer
+// different nodes. if spec.affinity.topologyKey is set, adds preferred anti-affinity for that
+// topology domain too.
+func (r *Reconciler) desiredCoreAffinity() *corev1.Affinity {
+
+	if r.NooBaa == nil {
+		return nil
+	}
+
+	base := r.GetAffinity()
+	if base != nil {
+		base = base.DeepCopy()
+	}
+
+	if !isCoreHAEnabled(r.NooBaa) {
+		return base
+	}
+
+	if base == nil {
+		base = &corev1.Affinity{}
+	}
+
+	topologyKey := ""
+	if r.NooBaa.Spec.Affinity != nil {
+		topologyKey = r.NooBaa.Spec.Affinity.TopologyKey
+	}
+
+	peerLabels := map[string]string{"noobaa-core": r.Request.Name}
+	//when core HA is enabled, always add preferred anti-affinity for hostname
+	ensurePreferredAntiAffinity(base, peerLabels, corev1.LabelHostname)
+	// if added by the user, also add the topology key to the preferred anti-affinity
+	if topologyKey != "" && topologyKey != corev1.LabelHostname {
+		ensurePreferredAntiAffinity(base, peerLabels, topologyKey)
+	}
+	return base
+}
+
+func ensurePreferredAntiAffinity(aff *corev1.Affinity, matchLabels map[string]string, topologyKey string) {
+	term := corev1.WeightedPodAffinityTerm{
+		Weight: 100,
+		PodAffinityTerm: corev1.PodAffinityTerm{
+			TopologyKey: topologyKey,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: maps.Clone(matchLabels),
+			},
+		},
+	}
+	if aff.PodAntiAffinity == nil {
+		aff.PodAntiAffinity = &corev1.PodAntiAffinity{}
+	}
+	//don't add the same preferred anti-affinity again
+	if hasEquivalentPreferredAntiAffinity(aff.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, matchLabels, topologyKey) {
+		return
+	}
+	//add the preferred anti-affinity to the affinity
+	aff.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		aff.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, term)
+}
+
+func hasEquivalentPreferredAntiAffinity(terms []corev1.WeightedPodAffinityTerm, matchLabels map[string]string, topologyKey string) bool {
+	for i := range terms {
+		t := &terms[i]
+		if t.PodAffinityTerm.TopologyKey != topologyKey {
+			continue
+		}
+		if t.PodAffinityTerm.LabelSelector == nil {
+			continue
+		}
+		selector := t.PodAffinityTerm.LabelSelector
+		if len(selector.MatchExpressions) == 0 && maps.Equal(selector.MatchLabels, matchLabels) {
+			return true
+		}
+	}
+	return false
 }
 
 // coreTerminationGracePeriodSeconds returns how many seconds Kubernetes should


### PR DESCRIPTION
### Describe the Problem
Core HA runs two core pods for failover, but both can be scheduled on the same node. If that node dies, both go down and failover doesn’t help.


### Explain the changes
1. When Core HA is on, ask the scheduler to prefer putting the two core pods on different nodes.
2. If the user sets a topology key (e.g. zone), also prefer spreading across that topology.
3. Keep any affinity the user already configured; don’t change behavior when HA is off.


### Issues: https://redhat.atlassian.net/browse/RHSTOR-9431

### Testing Instructions:
1. `go test ./pkg/system/ -count=1 -run 'TestDesiredCoreAffinity|TestGetDesiredCoreReplicas'`

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved high-availability scheduling by preferring placement across different hostnames and custom topology zones.
* Preserved existing node, pod, and anti-affinity settings, including user-defined preferences.
* Prevented duplicate scheduling rules while retaining configurations safely without unintended changes.
* Ensured high-availability settings remain unchanged when the feature is disabled.
* Improved scheduling behavior when custom topology rules overlap with automatically generated preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->