### PR TITLE
Util | Add to `http.Transport` Proxy for AWS clients to honor `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` envs

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -178,11 +178,13 @@ var (
 
 	// InsecureHTTPTransport is a global insecure http transport
 	InsecureHTTPTransport = &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
 	// GlobalCARefreshingTransport is a global secure http transport
 	GlobalCARefreshingTransport = &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
 	}
 


### PR DESCRIPTION
### Describe the Problem
Our current implementation added `http.Transport` but without honoring envs related to proxies.
 This was raised as a [comment](https://github.com/noobaa/noobaa-operator/pull/2069#discussion_r3709795199) by CodeRabbit in PR #2069.

### Explain the changes
1. Add to `http.Transport` `Proxy` for AWS clients to honor `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` envs.

### Issues: Fixed [DFBUGS-9567](https://redhat.atlassian.net/browse/DFBUGS-9567)
1. (The issue reported by me)

### Testing Instructions:
1. It would be tested as part of [DFBUGS-9567](https://redhat.atlassian.net/browse/DFBUGS-9567)

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically detecting and using proxy settings from the environment for HTTP connections.
  * Existing TLS behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->