### PR TITLE
Add support for network policy

### DIFF
--- a/deploy/internal/networkpolicy-core.yaml
+++ b/deploy/internal/networkpolicy-core.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: noobaa-core
+  labels:
+    app: noobaa
+spec:
+  podSelector:
+    matchLabels:
+      noobaa-core: noobaa
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 8443
+    - protocol: TCP
+      port: 8444
+    - protocol: TCP
+      port: 8445
+    - protocol: TCP
+      port: 8446
+    - protocol: TCP
+      port: 60100
+    - protocol: UDP
+      port: 5140
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8443

--- a/deploy/internal/networkpolicy-db.yaml
+++ b/deploy/internal/networkpolicy-db.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: noobaa-db-pg-cluster
+  labels:
+    app: noobaa
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: noobaa-db-pg-cluster
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 5432
+    - protocol: TCP
+      port: 8000
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 9187

--- a/deploy/internal/networkpolicy-endpoint.yaml
+++ b/deploy/internal/networkpolicy-endpoint.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: noobaa-endpoint
+  labels:
+    app: noobaa
+spec:
+  podSelector:
+    matchLabels:
+      noobaa-s3: noobaa
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 6001
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 7443
+    - protocol: TCP
+      port: 8444
+    - protocol: TCP
+      port: 9443
+    - protocol: TCP
+      port: 13443
+    - protocol: TCP
+      port: 14443
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 6001
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 7443
+    - protocol: TCP
+      port: 9443
+    - protocol: TCP
+      port: 13443
+    - protocol: TCP
+      port: 14443

--- a/deploy/internal/networkpolicy-pvpool.yaml
+++ b/deploy/internal/networkpolicy-pvpool.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: noobaa-pvpool
+  labels:
+    app: noobaa
+spec:
+  podSelector:
+    matchExpressions:
+    - key: pool
+      operator: Exists
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 60101

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -169,3 +169,14 @@ rules:
   - list
   - watch
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+  - delete

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4914,6 +4914,146 @@ metadata:
     app: noobaa
 `
 
+const Sha256_deploy_internal_networkpolicy_core_yaml = "e03679b5dda3c850d4918bb9f82a08e4c07809b115cf40aa4e490a212aa3a662"
+
+const File_deploy_internal_networkpolicy_core_yaml = `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: noobaa-core
+  labels:
+    app: noobaa
+spec:
+  podSelector:
+    matchLabels:
+      noobaa-core: noobaa
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 8443
+    - protocol: TCP
+      port: 8444
+    - protocol: TCP
+      port: 8445
+    - protocol: TCP
+      port: 8446
+    - protocol: TCP
+      port: 60100
+    - protocol: UDP
+      port: 5140
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8443
+`
+
+const Sha256_deploy_internal_networkpolicy_db_yaml = "12da7394e49f66025bdcbfda849209a827c0eb3b1ab1ffdc1591cb5ac6d58b3b"
+
+const File_deploy_internal_networkpolicy_db_yaml = `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: noobaa-db-pg-cluster
+  labels:
+    app: noobaa
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: noobaa-db-pg-cluster
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 5432
+    - protocol: TCP
+      port: 8000
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 9187
+`
+
+const Sha256_deploy_internal_networkpolicy_endpoint_yaml = "6c55cda146ca6f55d2f2de9332e63e5f57eb897f3b9f180e212f69cd9740a2c5"
+
+const File_deploy_internal_networkpolicy_endpoint_yaml = `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: noobaa-endpoint
+  labels:
+    app: noobaa
+spec:
+  podSelector:
+    matchLabels:
+      noobaa-s3: noobaa
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 6001
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 7443
+    - protocol: TCP
+      port: 8444
+    - protocol: TCP
+      port: 9443
+    - protocol: TCP
+      port: 13443
+    - protocol: TCP
+      port: 14443
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 6001
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 7443
+    - protocol: TCP
+      port: 9443
+    - protocol: TCP
+      port: 13443
+    - protocol: TCP
+      port: 14443
+`
+
+const Sha256_deploy_internal_networkpolicy_pvpool_yaml = "c1db3e37d5f50a40f3176eca696e511c997690033df5f1596fd88831f3bcbc40"
+
+const File_deploy_internal_networkpolicy_pvpool_yaml = `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: noobaa-pvpool
+  labels:
+    app: noobaa
+spec:
+  podSelector:
+    matchExpressions:
+    - key: pool
+      operator: Exists
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 60101
+`
+
 const Sha256_deploy_internal_nsfs_pvc_cr_yaml = "6dd65ca7d324991b813f209ec6a8a6bcf6c2c9a9f45c519ad3fba51e25042f07"
 
 const File_deploy_internal_nsfs_pvc_cr_yaml = `apiVersion: v1
@@ -6948,7 +7088,7 @@ spec:
         #     name: socket
 `
 
-const Sha256_deploy_role_yaml = "1320e5dd53566499e487ad122caef7a0ba9853e8304cb335bab6f90a9ae5daa3"
+const Sha256_deploy_role_yaml = "4739938379286ce9852a155f5faed0425457c7251419b5ac8ac99c7f8575a42a"
 
 const File_deploy_role_yaml = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7118,6 +7258,17 @@ rules:
   - volumesnapshots
   verbs:
   - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - create
+  - update
   - list
   - watch
   - delete

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -120,6 +120,10 @@ func (r *Reconciler) ReconcilePhaseCreating() error {
 		return err
 	}
 
+	if err := r.ReconcileNetworkPolicies(); err != nil {
+		r.Logger.Warnf("ReconcileNetworkPolicies: %v (will retry next cycle)", err)
+	}
+
 	return nil
 }
 

--- a/pkg/system/phase2_network_policies.go
+++ b/pkg/system/phase2_network_policies.go
@@ -1,0 +1,50 @@
+package system
+
+// ReconcileNetworkPolicies reconciles network policies for NooBaa operands.
+// Operator and CNPG controller policies are Phase 2 scope (ODF 5.1).
+func (r *Reconciler) ReconcileNetworkPolicies() error {
+
+	if err := r.ReconcileObject(r.NetworkPolicyCore, r.SetDesiredNetworkPolicyCore); err != nil {
+		return err
+	}
+
+	if err := r.ReconcileObject(r.NetworkPolicyEndpoint, r.SetDesiredNetworkPolicyEndpoint); err != nil {
+		return err
+	}
+
+	if err := r.ReconcileObject(r.NetworkPolicyPVPool, nil); err != nil {
+		return err
+	}
+
+	if r.shouldReconcileCNPGCluster() {
+		if err := r.ReconcileObject(r.NetworkPolicyDb, r.SetDesiredNetworkPolicyDb); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SetDesiredNetworkPolicyCore updates the core network policy pod selector
+// to match the actual NooBaa system name.
+// The cross-namespace rule allows TCP 8443 (mgmt-https) from any namespace because:
+// - Prometheus/monitoring scrapes metrics on this port (namespace varies by platform)
+// - Ingress controllers route external RouteMgmt traffic to this port
+func (r *Reconciler) SetDesiredNetworkPolicyCore() error {
+	r.NetworkPolicyCore.Spec.PodSelector.MatchLabels["noobaa-core"] = r.Request.Name
+	return nil
+}
+
+// SetDesiredNetworkPolicyEndpoint updates the endpoint network policy pod selector
+// to match the actual NooBaa system name
+func (r *Reconciler) SetDesiredNetworkPolicyEndpoint() error {
+	r.NetworkPolicyEndpoint.Spec.PodSelector.MatchLabels["noobaa-s3"] = r.Request.Name
+	return nil
+}
+
+// SetDesiredNetworkPolicyDb updates the DB network policy pod selector
+// to match the actual CNPG cluster name
+func (r *Reconciler) SetDesiredNetworkPolicyDb() error {
+	r.NetworkPolicyDb.Spec.PodSelector.MatchLabels["cnpg.io/cluster"] = r.CNPGCluster.Name
+	return nil
+}

--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -30,6 +30,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,6 +141,12 @@ type Reconciler struct {
 	// CNPG resources
 	CNPGImageCatalog *cnpgv1.ImageCatalog
 	CNPGCluster      *cnpgv1.Cluster
+
+	// Network Policies (Phase 1 - operands only)
+	NetworkPolicyCore     *networkingv1.NetworkPolicy
+	NetworkPolicyDb       *networkingv1.NetworkPolicy
+	NetworkPolicyEndpoint *networkingv1.NetworkPolicy
+	NetworkPolicyPVPool   *networkingv1.NetworkPolicy
 }
 
 // NewReconciler initializes a reconciler to be used for loading or reconciling a noobaa system
@@ -211,6 +218,11 @@ func NewReconciler(
 		CNPGImageCatalog: cnpg.GetCnpgImageCatalogObj(req.Namespace, req.Name+pgImageCatalogSuffix),
 		CNPGCluster:      cnpg.GetCnpgClusterObj(req.Namespace, req.Name+pgClusterSuffix),
 
+		NetworkPolicyCore:     util.KubeObject(bundle.File_deploy_internal_networkpolicy_core_yaml).(*networkingv1.NetworkPolicy),
+		NetworkPolicyDb:       util.KubeObject(bundle.File_deploy_internal_networkpolicy_db_yaml).(*networkingv1.NetworkPolicy),
+		NetworkPolicyEndpoint: util.KubeObject(bundle.File_deploy_internal_networkpolicy_endpoint_yaml).(*networkingv1.NetworkPolicy),
+		NetworkPolicyPVPool:   util.KubeObject(bundle.File_deploy_internal_networkpolicy_pvpool_yaml).(*networkingv1.NetworkPolicy),
+
 		SecretMetricsAuth:        util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 		SecretOIDCKeyCloakConfig: util.KubeObject(bundle.File_deploy_internal_secret_empty_yaml).(*corev1.Secret),
 	}
@@ -269,6 +281,12 @@ func NewReconciler(
 	r.SecretMetricsAuth.Namespace = r.Request.Namespace
 	r.SecretOIDCKeyCloakConfig.Namespace = r.Request.Namespace
 
+	// Network Policy namespaces
+	r.NetworkPolicyCore.Namespace = r.Request.Namespace
+	r.NetworkPolicyDb.Namespace = r.Request.Namespace
+	r.NetworkPolicyEndpoint.Namespace = r.Request.Namespace
+	r.NetworkPolicyPVPool.Namespace = r.Request.Namespace
+
 	// Set Names
 	r.NooBaa.Name = r.Request.Name
 	r.ServiceAccount.Name = r.Request.Name
@@ -320,6 +338,12 @@ func NewReconciler(
 	r.BucketNotificationsPVC.Name = r.Request.Name + "-bucket-notifications-pvc"
 	r.SecretMetricsAuth.Name = r.Request.Name + "-metrics-auth-secret"
 	r.SecretOIDCKeyCloakConfig.Name = r.Request.Name + "-oidc-keycloak-config"
+
+	// Network Policy names
+	r.NetworkPolicyCore.Name = r.Request.Name + "-core"
+	r.NetworkPolicyDb.Name = r.Request.Name + "-db-pg-cluster"
+	r.NetworkPolicyEndpoint.Name = r.Request.Name + "-endpoint"
+	r.NetworkPolicyPVPool.Name = r.Request.Name + "-pvpool"
 
 	// Set the target service for routes.
 	r.RouteMgmt.Spec.To.Name = r.ServiceMgmt.Name


### PR DESCRIPTION
### Describe the Problem

We want to add network policies for all of the noobaa components.

### Explain the changes
This PR adds the required network policies for all of the noobaa components. Currently the network policies DELIBERATELY have only ingress rules. egress rules are out of scope for now.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8134?focusedCommentId=17758637

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added network access policies for NooBaa core, S3 endpoints, operator, database, and storage-pool components.
  * Added network policies for the CloudNative PostgreSQL controller and monitoring endpoints.
  * Policies allow required internal service, API, ingress, and monitoring traffic on designated ports.
  * Policies are automatically applied and reconciled during deployment.
  * Database and PostgreSQL controller policies are configured when applicable.
  * Added permissions required to manage these network policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->