### PR TITLE
coreHA | disable ha when installed with dev or mini flags

### DIFF
--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -371,7 +371,7 @@ func RunCreate(cmd *cobra.Command, args []string) {
 	if useOBCCleanupPolicy {
 		sys.Spec.CleanupPolicy.Confirmation = nbv1.DeleteOBCConfirmation
 	}
-	if disableCoreHA {
+	if disableCoreHA || options.DevEnv || options.MiniEnv {
 		sys.Spec.DisableCoreHA = true
 	}
 	if coreResourcesJSON != "" {


### PR DESCRIPTION
### Describe the Problem
on dev and mini environments the resources are limited. so we don't want to create two core pods for those installs 

### Explain the changes
1. in case `dev` or `mini` flags were set in install disable core HA

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Core high availability is now automatically disabled when creating deployments in development or mini-environment modes.
  * Added support for explicitly disabling core high availability with the `--disable-core-ha` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->