### PR TITLE
Fix DB dump command to accept user preference

### DIFF
--- a/doc/noobaa-cnpg-integration.md
+++ b/doc/noobaa-cnpg-integration.md
@@ -222,6 +222,16 @@ The operator tracks database status through `NooBaaDBStatus`:
 - **Service Discovery**: Uses Kubernetes services for database access
 - **TLS Support**: Optional TLS encryption for database connections. TLS is enabled by default for monitoring endpoints
 
+### DB dump command
+
+Diagnostics collection and database dump commands now feature a new `--dump-from` option. This allows users to target either the primary (`primary`) or replica (`replica`) database, with the primary selected by default.
+When executed, database dumps direct to the specified database pod and generate SQL output accessible locally
+
+
+```
+noobaa diagnostics db-dump --dump-from primary
+```
+
 ### Troubleshooting
 
 #### Common Issues

--- a/pkg/diagnostics/collect.go
+++ b/pkg/diagnostics/collect.go
@@ -25,6 +25,7 @@ func RunCollect(cmd *cobra.Command, args []string) {
 	kubeconfig, _ := cmd.Flags().GetString("kubeconfig")
 	destDir, _ := cmd.Flags().GetString("dir")
 	collectDBDump, _ := cmd.Flags().GetBool("db-dump")
+	dbDumpFrom, _ := cmd.Flags().GetString("dump-from")
 	c := Collector{
 		folderName: fmt.Sprintf("%s_%d", "noobaa_diagnostics", time.Now().Unix()),
 		log:        util.Logger(),
@@ -55,7 +56,7 @@ func RunCollect(cmd *cobra.Command, args []string) {
 	// Collects db dump in addition to diagnostics.
 	// A separate tarball is created for diagnostics and db dump
 	if collectDBDump {
-		CollectDBDump(kubeconfig, destDir)
+		CollectDBDump(kubeconfig, destDir, dbDumpFrom)
 	}
 }
 

--- a/pkg/diagnostics/dbdump.go
+++ b/pkg/diagnostics/dbdump.go
@@ -1,7 +1,10 @@
 package diagnostics
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"time"
@@ -10,7 +13,22 @@ import (
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	"github.com/sirupsen/logrus"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/spf13/cobra"
+)
+
+const (
+
+	// cnpgClusterLabelKey is set (to the cluster name) on every pod managed by a CNPG Cluster.
+	cnpgClusterLabelKey = "cnpg.io/cluster=noobaa-db-pg-cluster"
+	// cnpgInstanceRoleLabelKey and cnpgLegacyRoleLabelKey mark the primary/replica role
+	// of a CNPG managed pod.
+	cnpgInstanceRoleLabelKey = "cnpg.io/instanceRole"
+	cnpgPrimaryRoleValue     = "primary"
+	cnpgReplicaRoleValue     = "replica"
 )
 
 // CollectorDbDump configuration for diagnostics
@@ -20,16 +38,18 @@ type CollectorDbDump struct {
 	remoteTarPath    string // Remote path (at pod) of tar'd db dump
 	kubeconfig       string
 	kubeCommand      string
+	dbDumpFrom       string // DB Preference. Auto-selecct 'replica' when value is empty
 	log              *logrus.Entry
 }
 
-func newCollectorDbDump(kubeconfig string) *CollectorDbDump {
+func newCollectorDbDump(kubeconfig string, dbDumpFrom string) *CollectorDbDump {
 	c := new(CollectorDbDump)
 	c.folderName = fmt.Sprintf("%s_%d", "noobaa_db_dump", time.Now().Unix())
 	c.remoteTarPath = fmt.Sprintf("%s/%s%s", "/tmp", c.folderName, ".tar.gz")
 	c.log = util.Logger()
 	c.kubeconfig = kubeconfig
 	c.kubeCommand = util.GetAvailabeKubeCli()
+	c.dbDumpFrom = dbDumpFrom
 	return c
 }
 
@@ -37,13 +57,14 @@ func newCollectorDbDump(kubeconfig string) *CollectorDbDump {
 func RunDump(cmd *cobra.Command, args []string) {
 	kubeconfig, _ := cmd.Flags().GetString("kubeconfig")
 	destDir, _ := cmd.Flags().GetString("dir")
+	dbDumpFrom, _ := cmd.Flags().GetString("dump-from")
 
-	CollectDBDump(kubeconfig, destDir)
+	CollectDBDump(kubeconfig, destDir, dbDumpFrom)
 }
 
 // CollectDBDump exposes the functionality to the diagnostics collect mechanism
-func CollectDBDump(kubeconfig string, destDir string) {
-	c := newCollectorDbDump(kubeconfig)
+func CollectDBDump(kubeconfig string, destDir string, dbDumpFrom string) {
+	c := newCollectorDbDump(kubeconfig, dbDumpFrom)
 
 	c.log.Println("Collecting db dump")
 
@@ -58,11 +79,81 @@ func CollectDBDump(kubeconfig string, destDir string) {
 	}
 }
 
+// isPodReady returns true when the pod has a Ready condition with status True,
+// meaning all containers have passed their readiness probes and the pod is
+// capable of serving requests.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// getDBPodName resolves the name of the postgres pod to run pg_dumpall against.
+// Ppod is auto-detected by looking for either:
+//  1. The repplica pod of a CNPG managed cluster (e.g. "noobaa-db-pg-cluster-2"), which does not
+//     follow a fixed naming convention and is instead identified via its CNPG labels
+//     a. if the db from is empty or 'replica', fetch the dump from replica db
+//     b. if the db from is primary, fetch the dump from primary db
+func (c *CollectorDbDump) getDBPodName() (string, error) {
+
+	primaryDBPodName := ""
+	replicaDBPodName := ""
+	podList := &corev1.PodList{}
+	// Fall back to looking for the primary pod of a CNPG managed cluster
+	cnpgSelector, err := labels.Parse(cnpgClusterLabelKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse label selector %q: %v", cnpgClusterLabelKey, err)
+	}
+	podList = &corev1.PodList{}
+	foundDBPod := util.KubeList(podList, &client.ListOptions{Namespace: options.Namespace, LabelSelector: cnpgSelector})
+	if !foundDBPod || len(podList.Items) == 0 {
+		return "", fmt.Errorf("Could not find noobaa DB pod in namespace %q, "+
+			"Make sure your DB pods are up and running ", options.Namespace)
+	}
+	if foundDBPod {
+		for _, pod := range podList.Items {
+			role := pod.Labels[cnpgInstanceRoleLabelKey]
+			if role == cnpgPrimaryRoleValue && isPodReady(&pod) {
+				primaryDBPodName = pod.Name
+			} else if role == cnpgReplicaRoleValue && isPodReady(&pod) {
+				replicaDBPodName = pod.Name
+			}
+		}
+	}
+
+	switch c.dbDumpFrom {
+	case "primary":
+		return primaryDBPodName, nil
+	case "replica":
+		return replicaDBPodName, nil
+	default:
+		return "", fmt.Errorf("invalid --dump-from value %q; expected primary or replica", c.dbDumpFrom)
+	}
+}
+
 // Create postgres dump
 func (c *CollectorDbDump) generatePostgresDump(destDir string) error {
-	// In case of a postgres db, the dump is a single file so in this case we can
-	// redirect the output of the dump straight to a local file
-	cmd := exec.Command(c.kubeCommand, "exec", "-n", options.Namespace, "-it", "pod/noobaa-db-pg-0", "--", "pg_dumpall")
+	dbPodName, err := c.getDBPodName()
+	if err != nil {
+		c.log.Printf(`❌ cannot find db pod: %v`, err)
+		return err
+	}
+	if dbPodName == "" {
+		c.log.Printf(`❌ Could not find db pod for %q db, make sure db pods are in Ready state`, c.dbDumpFrom)
+		err = fmt.Errorf("Could not find db pod for %q db", c.dbDumpFrom)
+		return err
+	}
+	c.log.Printf("Using db pod %q for db dump", dbPodName)
+
+	// pg_dumpall's output is piped through gzip inside the pod to reduce the amount of data
+	// transferred over the exec stream (important for large DBs). The gzip stream is
+	// decompressed locally below so the resulting .sql file on disk is plain SQL text, as its
+	// extension implies, rather than leaving it gzip-compressed.
+	dumpScript := "set -o pipefail; pg_dumpall --no-role-passwords | gzip -c"
+	cmd := exec.Command(c.kubeCommand, "exec", "-n", options.Namespace, "-i", fmt.Sprintf("pod/%s", dbPodName), "--", "bash", "-c", dumpScript)
 	// handle custom path for kubeconfig file,
 	// see --kubeconfig cli options
 	if len(c.kubeconfig) > 0 {
@@ -77,7 +168,7 @@ func (c *CollectorDbDump) generatePostgresDump(destDir string) error {
 	}
 
 	// Create the folder containing the dump file
-	err := os.Mkdir(c.dbDumpFolderPath, os.ModePerm)
+	err = os.Mkdir(c.dbDumpFolderPath, os.ModePerm)
 	if err != nil {
 		c.log.Fatalf(`❌ Could not create directory %s, reason: %s`, c.folderName, err)
 		return err
@@ -92,17 +183,50 @@ func (c *CollectorDbDump) generatePostgresDump(destDir string) error {
 		c.log.Printf(`❌ can not create db dump at path %v: %v`, c.dbDumpFolderPath, err)
 		return err
 	}
-
-	// Redirect the command's output to the local dump file
 	defer util.SafeClose(outfile, fmt.Sprintf("Failed to close dump file %s", dumpFilePath))
-	cmd.Stdout = outfile
-
-	// Execute the command, generating the dump file
-	if err := cmd.Run(); err != nil {
-		c.log.Printf(`❌ cannot generate db dump: %v`, err)
+	// Attach to the command's stdout (the gzip-compressed dump) instead of redirecting it
+	// straight to the local file, so it can be decompressed on the fly below
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		c.log.Printf(`❌ cannot attach to db dump command output: %v`, err)
 		return err
 	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Start(); err != nil {
+		c.log.Printf(`❌ cannot start db dump command: %v`, err)
+		return err
+	}
+	copyErr := decompressGzipStream(stdout, outfile)
+	// Always wait for the remote command to finish (reaping the process), regardless of
+	// whether reading/decompressing its output above succeeded
+	waitErr := cmd.Wait()
+	if copyErr != nil {
+		c.log.Printf(`❌ cannot generate db dump: %v`, copyErr)
+		c.log.Printf(`❌ DB dump command failed with error: %v`, stderrBuf.String())
+		return copyErr
+	}
+	if waitErr != nil {
+		c.log.Printf(`❌ cannot generate db dump: %v`, waitErr)
+		c.log.Printf(`❌ DB dump command failed with error: %v`, stderrBuf.String())
+		return waitErr
+	}
 
+	return nil
+}
+
+// decompressGzipStream reads a gzip-compressed stream from src and writes the
+// decompressed content to dst
+func decompressGzipStream(src io.Reader, dst io.Writer) error {
+	gzReader, err := gzip.NewReader(src)
+	if err != nil {
+		return fmt.Errorf("failed reading gzip stream from db pod: %v", err)
+	}
+	defer util.SafeClose(gzReader, "Failed to close gzip reader")
+
+	if _, err := io.Copy(dst, gzReader); err != nil {
+		return fmt.Errorf("failed decompressing db dump: %v", err)
+	}
 	return nil
 }
 

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -39,6 +39,7 @@ func CmdCollect() *cobra.Command {
 	}
 	cmd.Flags().String("dir", "", "collect noobaa diagnostics tar file into destination directory")
 	cmd.Flags().Bool("db-dump", false, "collect db dump in addition to diagnostics")
+	cmd.Flags().String("dump-from", "primary", "specifies the database type from which to collect the dump. Valid options are 'primary' and 'replica' (default: 'primary')")
 	return cmd
 }
 
@@ -51,6 +52,7 @@ func CmdDbDump() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	cmd.Flags().String("dir", "", "collect db dump file into destination directory")
+	cmd.Flags().String("dump-from", "primary", "specifies the database type from which to collect the dump. Valid options are 'primary' and 'replica' (default: 'primary')")
 	return cmd
 }
 
@@ -127,6 +129,7 @@ func CmdDbDumpDeprecated() *cobra.Command {
 		Args:       cobra.NoArgs,
 	}
 	cmd.Flags().String("dir", "", "collect db dump file into destination directory")
+	cmd.Flags().String("dump-from", "primary", "specifies the database type from which to collect the dump. Valid options are 'primary' and 'replica' (default: 'primary')")
 	return cmd
 }
 
@@ -141,5 +144,6 @@ func CmdDiagnoseDeprecated() *cobra.Command {
 	}
 	cmd.Flags().String("dir", "", "collect noobaa diagnose tar file into destination directory")
 	cmd.Flags().Bool("db-dump", false, "collect db dump in addition to diagnostics")
+	cmd.Flags().String("dump-from", "primary", "specifies the database type from which to collect the dump. Valid options are 'primary' and 'replica' (default: 'primary')")
 	return cmd
 }


### PR DESCRIPTION
### Describe the Problem

### Explain the changes
1. If the pod name was explicitly provided (e.g. via the --db-pod CLI flag) it is used as-is.
Otherwise, the pod is auto-detected by looking for either:
    1. The legacy standalone postgres pod (e.g. "noobaa-db-pg-0"), labeled "noobaa-db=postgres"
    2. The primary pod of a CNPG managed cluster (e.g. "noobaa-db-pg-cluster-1"), which does not

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-4113

### Testing Instructions:
1. nb diagnostics db-dump -n noobaa --db-pod noobaa-db-pg-0

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--dump-from` option to diagnostics collection and database dump commands.
  * Choose between the primary or replica database; the primary is used by default.
  * Database dumps now target the selected database and produce locally accessible SQL files.
* **Bug Fixes**
  * Improved handling and reporting of database discovery, command execution, streaming, and dump processing errors.
* **Documentation**
  * Added guidance for using the new database dump option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->