### PR TITLE
core HA | always kill supervisord when existing

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -180,11 +180,6 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_CORE_SHUTDOWN_GRACE
-            - name: NOOBAA_CORE_LOST_GRACE
-              valueFrom:
-                configMapKeyRef:
-                  name: noobaa-config
-                  key: NOOBAA_CORE_LOST_GRACE
             - name: NOOBAA_CORE_LEASE_NAME
               value: ""
             - name: POSTGRES_HOST

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5640,7 +5640,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "9fc44f63efc86044491b316f70a18e4087d2f716f2ad4fedafe7cb937597b1df"
+const Sha256_deploy_internal_statefulset_core_yaml = "53d4f049d29a5c368ee267bb94a93ff173f105c238f6f8936baea8ba941222b9"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5824,11 +5824,6 @@ spec:
                 configMapKeyRef:
                   name: noobaa-config
                   key: NOOBAA_CORE_SHUTDOWN_GRACE
-            - name: NOOBAA_CORE_LOST_GRACE
-              valueFrom:
-                configMapKeyRef:
-                  name: noobaa-config
-                  key: NOOBAA_CORE_LOST_GRACE
             - name: NOOBAA_CORE_LEASE_NAME
               value: ""
             - name: POSTGRES_HOST

--- a/pkg/leaderelect/leaderelect.go
+++ b/pkg/leaderelect/leaderelect.go
@@ -9,7 +9,7 @@
 // The command is Hidden so it does not appear in public CLI help. The wrapper
 // acquires a namespaced Lease, spawns the given command in its own process
 // group while holding leadership, reaps orphaned children (PID 1), and on
-// SIGTERM/SIGINT or leadership loss stops the child group before releasing
+// SIGTERM/SIGINT or leadership loss SIGKILLs the child group then releases
 // the Lease (ReleaseOnCancel).
 package leaderelect
 
@@ -43,8 +43,6 @@ const (
 	envLeaseDuration = "NOOBAA_CORE_LEASE_DURATION"
 	envRenewDeadline = "NOOBAA_CORE_RENEW_DEADLINE"
 	envRetryPeriod   = "NOOBAA_CORE_RETRY_PERIOD"
-	envShutdownGrace = "NOOBAA_CORE_SHUTDOWN_GRACE"
-	envLostGrace     = "NOOBAA_CORE_LOST_GRACE"
 	envPodNamespace  = "POD_NAMESPACE"
 	saNamespaceFile  = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
@@ -52,7 +50,6 @@ const (
 	defaultRenewDeadline = 10 * time.Second
 	defaultRetryPeriod   = 3 * time.Second
 	defaultShutdownGrace = 25 * time.Second
-	defaultLostGrace     = 8 * time.Second
 	// childSigkillWait is how long stopChild waits after SIGKILL for the child process group to exit before returning.
 	childSigkillWait = 5 * time.Second
 	// leaseReleaseMargin is extra time after child teardown for ReleaseOnCancel.
@@ -60,7 +57,9 @@ const (
 )
 
 // RecommendedTerminationGracePeriod is the pod terminationGracePeriodSeconds
-// that leaves room for ShutdownGrace + SIGKILL wait + lease release on cancel.
+// that leaves room for a configured shutdown budget + SIGKILL wait + lease release.
+// shutdownGrace comes from NOOBAA_CORE_SHUTDOWN_GRACE (operator / ConfigMap); stopChild
+// itself always SIGKILLs immediately and only waits up to childSigkillWait.
 func RecommendedTerminationGracePeriod(shutdownGrace time.Duration) int64 {
 	if shutdownGrace <= 0 {
 		shutdownGrace = defaultShutdownGrace
@@ -74,8 +73,6 @@ type Config struct {
 	LeaseDuration time.Duration
 	RenewDeadline time.Duration
 	RetryPeriod   time.Duration
-	ShutdownGrace time.Duration
-	LostGrace     time.Duration
 	Command       []string
 }
 
@@ -107,8 +104,6 @@ func defaultConfig() *Config {
 		LeaseDuration: durationFromEnv(envLeaseDuration, defaultLeaseDuration),
 		RenewDeadline: durationFromEnv(envRenewDeadline, defaultRenewDeadline),
 		RetryPeriod:   durationFromEnv(envRetryPeriod, defaultRetryPeriod),
-		ShutdownGrace: durationFromEnv(envShutdownGrace, defaultShutdownGrace),
-		LostGrace:     durationFromEnv(envLostGrace, defaultLostGrace),
 	}
 }
 
@@ -158,14 +153,9 @@ func (c *Config) Validate() error {
 	if len(c.Command) == 0 {
 		return fmt.Errorf("command is required after --")
 	}
-	maxLost := c.LeaseDuration - c.RenewDeadline
-	if maxLost <= 0 {
+	if c.LeaseDuration <= c.RenewDeadline {
 		return fmt.Errorf("%s (%v) must be greater than %s (%v)",
 			envLeaseDuration, c.LeaseDuration, envRenewDeadline, c.RenewDeadline)
-	}
-	if c.LostGrace >= maxLost {
-		return fmt.Errorf("%s (%v) must be < %s - %s (%v)",
-			envLostGrace, c.LostGrace, envLeaseDuration, envRenewDeadline, maxLost)
 	}
 	// Match NewLeaderElector: renewDeadline must be > retryPeriod*JitterFactor (1.2).
 	if c.RetryPeriod <= 0 {
@@ -226,7 +216,7 @@ func Run(cfg *Config) int {
 	go func() {
 		sig := <-sigCh
 		r.log.Infof("leader-elect: received %v, stopping child then releasing lease", sig)
-		r.stopChild(cfg.ShutdownGrace)
+		r.stopChild()
 		r.forceExit(exitOK)
 		cancel()
 	}()
@@ -355,7 +345,7 @@ func (r *runner) onStartedLeading(leadCtx context.Context) {
 	go r.waitAndReap(childPID, childDone)
 
 	if alreadyTerm {
-		r.stopChild(r.cfg.ShutdownGrace)
+		r.stopChild()
 		return
 	}
 
@@ -365,7 +355,7 @@ func (r *runner) onStartedLeading(leadCtx context.Context) {
 		termRequested := r.termRequested
 		r.mu.Unlock()
 		if termRequested {
-			// SIGTERM/lost path owns the wrapper exit code.
+			// Teardown path owns the wrapper exit code.
 			return
 		}
 		code := r.getChildCode()
@@ -377,20 +367,26 @@ func (r *runner) onStartedLeading(leadCtx context.Context) {
 		termRequested := r.termRequested
 		r.mu.Unlock()
 		if termRequested {
-			// SIGTERM path owns teardown; wait for child then return.
-			select {
-			case <-childDone:
-			case <-time.After(r.cfg.ShutdownGrace + childSigkillWait):
-			}
+			// SIGTERM path already called stopChild; just wait for the child.
+			r.waitChildExited()
 			return
 		}
 		r.log.Errorf("leader-elect: leadership lost, stopping child")
-		r.stopChild(r.cfg.LostGrace)
+		r.stopChild()
 		r.forceExit(exitLost)
-		select {
-		case <-childDone:
-		case <-time.After(r.cfg.LostGrace + childSigkillWait):
-		}
+	}
+}
+
+func (r *runner) waitChildExited() {
+	r.mu.Lock()
+	done := r.childExited
+	r.mu.Unlock()
+	if done == nil {
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(childSigkillWait):
 	}
 }
 

--- a/pkg/leaderelect/leaderelect_test.go
+++ b/pkg/leaderelect/leaderelect_test.go
@@ -13,8 +13,6 @@ func clearLeaderElectEnv(t *testing.T) {
 	t.Setenv(envLeaseDuration, "")
 	t.Setenv(envRenewDeadline, "")
 	t.Setenv(envRetryPeriod, "")
-	t.Setenv(envShutdownGrace, "")
-	t.Setenv(envLostGrace, "")
 }
 
 func TestParseArgs(t *testing.T) {
@@ -70,12 +68,6 @@ func TestParseArgs(t *testing.T) {
 			if !reflect.DeepEqual(cfg.Command, tt.wantCmd) {
 				t.Errorf("Command = %#v, want %#v", cfg.Command, tt.wantCmd)
 			}
-			if cfg.LostGrace != defaultLostGrace {
-				t.Errorf("LostGrace = %v, want %v", cfg.LostGrace, defaultLostGrace)
-			}
-			if cfg.ShutdownGrace != defaultShutdownGrace {
-				t.Errorf("ShutdownGrace = %v, want %v", cfg.ShutdownGrace, defaultShutdownGrace)
-			}
 		})
 	}
 }
@@ -93,8 +85,6 @@ func TestParseArgsTimingsFromEnv(t *testing.T) {
 	t.Setenv(envLeaseDuration, "30s")
 	t.Setenv(envRenewDeadline, "12s")
 	t.Setenv(envRetryPeriod, "4s")
-	t.Setenv(envShutdownGrace, "15s")
-	t.Setenv(envLostGrace, "5s")
 
 	cfg, err := ParseArgs([]string{"--", "true"})
 	if err != nil {
@@ -109,24 +99,6 @@ func TestParseArgsTimingsFromEnv(t *testing.T) {
 	if cfg.RetryPeriod != 4*time.Second {
 		t.Errorf("RetryPeriod = %v, want 4s", cfg.RetryPeriod)
 	}
-	if cfg.ShutdownGrace != 15*time.Second {
-		t.Errorf("ShutdownGrace = %v, want 15s", cfg.ShutdownGrace)
-	}
-	if cfg.LostGrace != 5*time.Second {
-		t.Errorf("LostGrace = %v, want 5s", cfg.LostGrace)
-	}
-}
-
-func TestParseArgsLostGraceInvariantFromEnv(t *testing.T) {
-	t.Setenv(envLeaseName, "lease")
-	t.Setenv(envLeaseDuration, "20s")
-	t.Setenv(envRenewDeadline, "10s")
-	t.Setenv(envLostGrace, "10s")
-
-	_, err := ParseArgs([]string{"--", "true"})
-	if err == nil || !strings.Contains(err.Error(), envLostGrace) {
-		t.Fatalf("expected error mentioning %s, got %v", envLostGrace, err)
-	}
 }
 
 func TestDurationFromEnvInvalidFallsBack(t *testing.T) {
@@ -136,7 +108,7 @@ func TestDurationFromEnvInvalidFallsBack(t *testing.T) {
 	}
 }
 
-func TestValidateGraceInvariant(t *testing.T) {
+func TestValidate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -151,44 +123,8 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseDuration: defaultLeaseDuration,
 				RenewDeadline: defaultRenewDeadline,
 				RetryPeriod:   defaultRetryPeriod,
-				LostGrace:     defaultLostGrace,
 				Command:       []string{"sleep"},
 			},
-		},
-		{
-			name: "lost-grace just under max",
-			cfg: Config{
-				LeaseName:     "x",
-				LeaseDuration: 20 * time.Second,
-				RenewDeadline: 10 * time.Second,
-				RetryPeriod:   3 * time.Second,
-				LostGrace:     9 * time.Second,
-				Command:       []string{"sleep"},
-			},
-		},
-		{
-			name: "lost-grace equal rejected",
-			cfg: Config{
-				LeaseName:     "x",
-				LeaseDuration: 20 * time.Second,
-				RenewDeadline: 10 * time.Second,
-				RetryPeriod:   3 * time.Second,
-				LostGrace:     10 * time.Second,
-				Command:       []string{"sleep"},
-			},
-			wantErr: envLostGrace,
-		},
-		{
-			name: "lost-grace above max rejected",
-			cfg: Config{
-				LeaseName:     "x",
-				LeaseDuration: 20 * time.Second,
-				RenewDeadline: 10 * time.Second,
-				RetryPeriod:   3 * time.Second,
-				LostGrace:     11 * time.Second,
-				Command:       []string{"sleep"},
-			},
-			wantErr: envLostGrace,
 		},
 		{
 			name: "lease-duration not greater than renew-deadline",
@@ -197,7 +133,6 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseDuration: 10 * time.Second,
 				RenewDeadline: 10 * time.Second,
 				RetryPeriod:   3 * time.Second,
-				LostGrace:     1 * time.Second,
 				Command:       []string{"sleep"},
 			},
 			wantErr: envLeaseDuration,
@@ -209,7 +144,6 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseDuration: 20 * time.Second,
 				RenewDeadline: 10 * time.Second,
 				RetryPeriod:   10 * time.Second,
-				LostGrace:     1 * time.Second,
 				Command:       []string{"sleep"},
 			},
 			wantErr: envRenewDeadline,
@@ -221,7 +155,6 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseDuration: 30 * time.Second,
 				RenewDeadline: 12 * time.Second,
 				RetryPeriod:   10 * time.Second, // 10s * 1.2 = 12s
-				LostGrace:     1 * time.Second,
 				Command:       []string{"sleep"},
 			},
 			wantErr: envRenewDeadline,
@@ -233,7 +166,6 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseDuration: 30 * time.Second,
 				RenewDeadline: 13 * time.Second,
 				RetryPeriod:   10 * time.Second, // 10s * 1.2 = 12s
-				LostGrace:     1 * time.Second,
 				Command:       []string{"sleep"},
 			},
 		},
@@ -244,7 +176,6 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseDuration: defaultLeaseDuration,
 				RenewDeadline: defaultRenewDeadline,
 				RetryPeriod:   0,
-				LostGrace:     defaultLostGrace,
 				Command:       []string{"sleep"},
 			},
 			wantErr: envRetryPeriod,
@@ -255,7 +186,6 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseDuration: defaultLeaseDuration,
 				RenewDeadline: defaultRenewDeadline,
 				RetryPeriod:   defaultRetryPeriod,
-				LostGrace:     defaultLostGrace,
 				Command:       []string{"sleep"},
 			},
 			wantErr: envLeaseName,
@@ -267,7 +197,6 @@ func TestValidateGraceInvariant(t *testing.T) {
 				LeaseDuration: defaultLeaseDuration,
 				RenewDeadline: defaultRenewDeadline,
 				RetryPeriod:   defaultRetryPeriod,
-				LostGrace:     defaultLostGrace,
 			},
 			wantErr: "command is required after --",
 		},

--- a/pkg/leaderelect/leaderelect_unix.go
+++ b/pkg/leaderelect/leaderelect_unix.go
@@ -54,7 +54,10 @@ func waitStatusExitCode(status syscall.WaitStatus) int {
 	return exitConfig
 }
 
-func (r *runner) stopChild(grace time.Duration) {
+// stopChild SIGKILLs the child process group and waits briefly for it to exit.
+// Used for both pod SIGTERM/SIGINT and leadership loss — there is no separate
+// graceful drain window (supervisord drain delayed lease release / failover).
+func (r *runner) stopChild() {
 	r.mu.Lock()
 	r.termRequested = true
 	pid := r.childPID
@@ -65,28 +68,17 @@ func (r *runner) stopChild(grace time.Duration) {
 		return
 	}
 
-	// Signal the whole process group (Setpgid makes pgid == child pid).
-	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
-		r.log.Errorf("leader-elect: kill pgid %d SIGTERM: %v", pid, err)
+	// Hard-kill the whole process group (Setpgid makes pgid == child pid).
+	r.log.Infof("leader-elect: SIGKILL process group %d", pid)
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		r.log.Errorf("leader-elect: kill pgid %d SIGKILL: %v", pid, err)
 	}
 
 	if done == nil {
 		return
 	}
-
-	timer := time.NewTimer(grace)
-	defer timer.Stop()
 	select {
 	case <-done:
-		return
-	case <-timer.C:
-		r.log.Infof("leader-elect: grace %v elapsed, SIGKILL process group %d", grace, pid)
-		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
-			r.log.Errorf("leader-elect: kill pgid %d SIGKILL: %v", pid, err)
-		}
-		select {
-		case <-done:
-		case <-time.After(childSigkillWait):
-		}
+	case <-time.After(childSigkillWait):
 	}
 }

--- a/pkg/leaderelect/leaderelect_windows.go
+++ b/pkg/leaderelect/leaderelect_windows.go
@@ -5,7 +5,6 @@ package leaderelect
 import (
 	"fmt"
 	"os/exec"
-	"time"
 )
 
 func checkPlatform() error {
@@ -25,7 +24,7 @@ func (r *runner) waitAndReap(childPID int, done chan struct{}) {
 }
 
 // stopChild cannot signal process groups on Windows.
-func (r *runner) stopChild(grace time.Duration) {
+func (r *runner) stopChild() {
 	r.mu.Lock()
 	r.termRequested = true
 	r.mu.Unlock()

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -1697,11 +1697,12 @@ func (r *Reconciler) SetDesiredCoreAppConfig() error {
 		"NOOBAA_VERSION_AUTH_ENABLED":  "true",
 		"ENDPOINT_SYSTEM_STORE_SOURCE": "core", // by default, load the system store in the endpoint from the core instead of the DB
 		"OPERATOR_LOG_LEVEL":           "info",
-		"NOOBAA_CORE_LEASE_DURATION":   "20s",
-		"NOOBAA_CORE_RENEW_DEADLINE":   "10s",
-		"NOOBAA_CORE_RETRY_PERIOD":     "3s",
-		"NOOBAA_CORE_SHUTDOWN_GRACE":   "25s",
-		"NOOBAA_CORE_LOST_GRACE":       "8s",
+		"NOOBAA_CORE_LEASE_DURATION": "20s",
+		"NOOBAA_CORE_RENEW_DEADLINE": "10s",
+		"NOOBAA_CORE_RETRY_PERIOD":   "3s",
+		// Used by the operator to size core pod terminationGracePeriodSeconds.
+		// Leader-elect SIGKILLs the child immediately on stop; this is not a drain window.
+		"NOOBAA_CORE_SHUTDOWN_GRACE": "25s",
 	}
 	for key, value := range DefaultConfigMapData {
 		if _, ok := r.CoreAppConfig.Data[key]; !ok {
@@ -1816,10 +1817,11 @@ func hasEquivalentPreferredAntiAffinity(terms []corev1.WeightedPodAffinityTerm, 
 }
 
 // coreTerminationGracePeriodSeconds returns how many seconds Kubernetes should
-// give the core pod to shut down after it is told to stop. We size this from
-// NOOBAA_CORE_SHUTDOWN_GRACE in noobaa-config, plus a little extra so
-// leader-elect can finish stopping core and releasing the lease. If that
-// config value is missing or invalid, we use the built-in default (40 seconds).
+// give the core pod to shut down after it is told to stop. Sized from
+// NOOBAA_CORE_SHUTDOWN_GRACE in noobaa-config, plus margin for SIGKILL wait and
+// lease release. Leader-elect no longer drains supervisord for that duration;
+// the value mainly controls how long the pod may remain Terminating. If the
+// config value is missing or invalid, the built-in default is used (40 seconds).
 func (r *Reconciler) coreTerminationGracePeriodSeconds() int64 {
 	shutdownGrace := time.Duration(0)
 	if raw := strings.TrimSpace(r.CoreAppConfig.Data["NOOBAA_CORE_SHUTDOWN_GRACE"]); raw != "" {


### PR DESCRIPTION
### Describe the Problem
When a core pod is stopped (delete/drain or losing leadership), leader-elect first sent SIGTERM to supervisord and waited for a long graceful shutdown before releasing the Kubernetes lease (around 25 secodes). That delay slowed failover. since core takes around 30 seconds to start, this effectively doubled the failover time. We also had two separate “grace” settings for planned stop vs leadership loss, which is confusing now that both paths should stop the same way.

### Explain the changes
1. On stop, leader-elect SIGKILLs the core process group immediately instead of SIGTERM + long wait, then releases the lease.
2. One stop path for both pod shutdown and leadership loss (same kill behavior; exit code still differs).
3. Remove NOOBAA_CORE_LOST_GRACE (ConfigMap default + core env). Keep NOOBAA_CORE_SHUTDOWN_GRACE only to size how long Kubernetes may keep the pod in Terminating. it is no longer a supervisord drain window.


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Removed the obsolete lost-leadership grace-period setting from deployment and configuration options.
* Updated shutdown behavior to terminate managed processes promptly when leadership is lost or shutdown is requested.
* Simplified configuration validation to focus on supported lease timing and command settings.

## Documentation
* Clarified pod termination behavior and default handling.

## Chores
* Refreshed deployment metadata to reflect the updated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->