### PR TITLE
[Backport to 5.17] [azure] updated storage version (#1477)

### DIFF
--- a/pkg/system/azure_utils.go
+++ b/pkg/system/azure_utils.go
@@ -51,7 +51,7 @@ func (r *Reconciler) CreateStorageAccount(accountName, accountGroupName string) 
 		storage.AccountCreateParameters{
 			Sku: &storage.Sku{
 				Name: storage.StandardLRS},
-			Kind:     storage.Storage,
+			Kind:     storage.StorageV2,
 			Location: to.StringPtr(r.AzureContainerCreds.StringData["azure_region"]),
 			AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
 				EnableHTTPSTrafficOnly: &enableHTTPSTrafficOnly,


### PR DESCRIPTION
## Summary
- Backport of https://github.com/noobaa/noobaa-operator/pull/1477 to `5.17`
- Create Azure default backing-store accounts as **GPv2** (`storage.StorageV2`) instead of legacy GPv1 (`storage.Storage`)

Cherry-picked from `6ceb4f8601a0acd18f4a9b3ee9ef28354d6a545d`.

## Test plan
- [ ] Fresh Azure install creates default backing store with GPv2 storage account
- [ ] Upgrade path with existing GPv1 account continues to work (operator does not recreate Kind on existing AccountName)