### PR TITLE
[Backport to 5.15] [azure] updated storage version (#1477)

### DIFF
--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -3651,7 +3651,7 @@ data:
     pg_stat_statements.track = all
 `
 
-const Sha256_deploy_internal_configmap_postgres_initdb_yaml = "5ef599d78f148d91023d38ef516f73a0d903dfb060eb382fb741b65291955fbe"
+const Sha256_deploy_internal_configmap_postgres_initdb_yaml = "e14a7236a4d1afb7ffd850b931f745a74be1ec889168382744b8d8cbd36366c3"
 
 const File_deploy_internal_configmap_postgres_initdb_yaml = `apiVersion: v1
 kind: ConfigMap
@@ -3700,7 +3700,7 @@ data:
           set -e
           sed -i -e 's/^\(postgres:[^:]\):[0-9]*:[0-9]*:/\1:10001:0:/' /etc/passwd
           su postgres -c "bash -x /usr/bin/run-postgresql" &
-          THRESHOLD=33
+          THRESHOLD=25
           USE=$(df -h --output=pcent "/$HOME/data" | tail -n 1 | tr -d '[:space:]%')
           # Check if the used space is more than the threshold
           if [ "$USE" -gt "$THRESHOLD" ]; then
@@ -3733,7 +3733,7 @@ data:
           set -e
           PGDATA=$HOME/data/userdata
           PGDATA_12=$HOME/data/userdata-12
-          THRESHOLD=33
+          THRESHOLD=25
           USE=$(df -h --output=pcent "/$HOME/data" | tail -n 1 | tr -d '[:space:]%')
           # Check if the used space is more than the threshold
           if [ "$USE" -gt "$THRESHOLD" ]; then

--- a/pkg/system/azure_utils.go
+++ b/pkg/system/azure_utils.go
@@ -51,7 +51,7 @@ func (r *Reconciler) CreateStorageAccount(accountName, accountGroupName string) 
 		storage.AccountCreateParameters{
 			Sku: &storage.Sku{
 				Name: storage.StandardLRS},
-			Kind:     storage.Storage,
+			Kind:     storage.StorageV2,
 			Location: to.StringPtr(r.AzureContainerCreds.StringData["azure_region"]),
 			AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
 				EnableHTTPSTrafficOnly: &enableHTTPSTrafficOnly,


### PR DESCRIPTION
## Summary
- Backport of https://github.com/noobaa/noobaa-operator/pull/1477 to `5.15`
- Create Azure default backing-store accounts as **GPv2** (`storage.StorageV2`) instead of legacy GPv1 (`storage.Storage`)

Cherry-picked from `6ceb4f8601a0acd18f4a9b3ee9ef28354d6a545d`.

## Test plan
- [ ] Fresh Azure install creates default backing store with GPv2 storage account
- [ ] Upgrade path with existing GPv1 account continues to work (operator does not recreate Kind on existing AccountName)