### PR TITLE
allow cluster CR updates while the DB cluster is not ready

### DIFF
--- a/pkg/system/db_reconciler.go
+++ b/pkg/system/db_reconciler.go
@@ -228,21 +228,16 @@ func (r *Reconciler) reconcileDBCluster() error {
 			diff := deep.Equal(*existingClusterSpec, r.CNPGCluster.Spec)
 			r.cnpgLog("cluster spec is changed, updating cluster. diff: %v", diff)
 
-			currentDBClusterStatus := r.NooBaa.Status.DBStatus.DBClusterStatus
-			// avoid updating a cluster that is being created.
-			// We might want to consider allowing this somehow for supportability (through annotation or something)
-			if currentDBClusterStatus == nbv1.DBClusterStatusCreating || currentDBClusterStatus == nbv1.DBClusterStatusRecovering {
-				r.cnpgLog("the cluster spec was changed but the cluster creation is still in progress, skipping update")
-				return fmt.Errorf("cluster creation is still in progress, skipping update")
-			}
-
-			r.cnpgLog("cluster spec is changed, updating cluster")
+			// Apply the change regardless of the current cluster status and let CNPG arbitrate.
+			// CNPG holds back all pod and PVC changes while its bootstrap job is running, so an
+			// update applied mid-creation only takes effect once the cluster is up.
 			if err := r.Client.Update(r.Ctx, r.CNPGCluster); err != nil {
 				r.cnpgLogError("got error updating cluster. error: %v", err)
 				return err
 			}
+
 			// update the DB status
-			r.NooBaa.Status.DBStatus.DBClusterStatus = nbv1.DBClusterStatusUpdating
+			r.NooBaa.Status.DBStatus.DBClusterStatus = dbClusterStatusAfterSpecUpdate(r.NooBaa.Status.DBStatus.DBClusterStatus)
 		}
 
 		// The cluster spec is unchanged, no need to update
@@ -250,6 +245,17 @@ func (r *Reconciler) reconcileDBCluster() error {
 	}
 
 	return nil
+}
+
+// dbClusterStatusAfterSpecUpdate returns the DB cluster status to report after a cluster
+// spec update was applied. Only a Ready cluster moves to Updating. Any other status means
+// the initial deployment is still in flight, and ReconcileCNPGCluster advances it to Ready
+// once the cluster reports ready. Overwriting it here would mask the real phase.
+func dbClusterStatusAfterSpecUpdate(current nbv1.DBClusterStatus) nbv1.DBClusterStatus {
+	if current == nbv1.DBClusterStatusReady {
+		return nbv1.DBClusterStatusUpdating
+	}
+	return current
 }
 
 func (r *Reconciler) reconcileClusterSpec(dbSpec *nbv1.NooBaaDBSpec) error {

--- a/pkg/system/db_reconciler_test.go
+++ b/pkg/system/db_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestFormatBytesKB(t *testing.T) {
@@ -334,4 +335,153 @@ func TestSetDesiredStorageConfAccessMode(t *testing.T) {
 			t.Fatalf("got storage class %v, want %q", storageConfiguration.StorageClass, storageClass)
 		}
 	})
+}
+
+// TestDBClusterStatusAfterSpecUpdate covers the regression behind DFBUGS-8895: a cluster
+// spec update must never overwrite a status that reports an in-flight initial deployment,
+// otherwise the reported phase no longer reflects what the cluster is actually doing.
+func TestDBClusterStatusAfterSpecUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		current nbv1.DBClusterStatus
+		want    nbv1.DBClusterStatus
+	}{
+		{"ready moves to updating", nbv1.DBClusterStatusReady, nbv1.DBClusterStatusUpdating},
+		{"creating is preserved", nbv1.DBClusterStatusCreating, nbv1.DBClusterStatusCreating},
+		{"recovering is preserved", nbv1.DBClusterStatusRecovering, nbv1.DBClusterStatusRecovering},
+		{"importing is preserved", nbv1.DBClusterStatusImporting, nbv1.DBClusterStatusImporting},
+		{"updating is preserved", nbv1.DBClusterStatusUpdating, nbv1.DBClusterStatusUpdating},
+		{"none is preserved", nbv1.DBClusterStatusNone, nbv1.DBClusterStatusNone},
+		{"failed is preserved", nbv1.DBClusterStatusFailed, nbv1.DBClusterStatusFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := dbClusterStatusAfterSpecUpdate(tt.current); got != tt.want {
+				t.Fatalf("dbClusterStatusAfterSpecUpdate(%q) = %q, want %q", tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
+// baseClusterSpec returns a cluster spec populated on every field that
+// wasClusterSpecChanged compares, so each case can mutate exactly one of them.
+func baseClusterSpec() cnpgv1.ClusterSpec {
+	storageClass := "test-storage-class"
+	apiGroup := "postgresql.cnpg.io"
+	offlineBackup := false
+	defaultQueriesEnabled := false
+
+	return cnpgv1.ClusterSpec{
+		InheritedMetadata: &cnpgv1.EmbeddedObjectMetadata{
+			Labels: map[string]string{"app": "noobaa"},
+		},
+		ImageCatalogRef: &cnpgv1.ImageCatalogRef{
+			TypedLocalObjectReference: corev1.TypedLocalObjectReference{
+				Kind:     "ImageCatalog",
+				APIGroup: &apiGroup,
+				Name:     "noobaa-db-pg-image-catalog",
+			},
+			Major: 17,
+		},
+		Instances: 2,
+		Affinity: cnpgv1.AffinityConfiguration{
+			TopologyKey: "kubernetes.io/hostname",
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+		},
+		StorageConfiguration: cnpgv1.StorageConfiguration{
+			StorageClass: &storageClass,
+			Size:         "50Gi",
+			PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
+			},
+		},
+		Monitoring: &cnpgv1.MonitoringConfiguration{
+			DisableDefaultQueries: &defaultQueriesEnabled,
+		},
+		PostgresConfiguration: cnpgv1.PostgresConfiguration{
+			Parameters: map[string]string{"wal_level": "replica", "jit": "off"},
+		},
+		Backup: &cnpgv1.BackupConfiguration{
+			VolumeSnapshot: &cnpgv1.VolumeSnapshotConfiguration{
+				ClassName: "test-snapshot-class",
+				Online:    &offlineBackup,
+			},
+		},
+		Certificates: &cnpgv1.CertificatesConfiguration{
+			ServerAltDNSNames: []string{"noobaa-db-pg"},
+		},
+		PriorityClassName: "test-priority-class",
+		FailoverDelay:     defaultFailoverDelaySec,
+	}
+}
+
+// TestWasClusterSpecChanged covers the gate that decides whether the operator issues an
+// update at all. The "unchanged" cases matter as much as the rest: a spurious diff would
+// make the operator rewrite the cluster CR on every reconcile.
+func TestWasClusterSpecChanged(t *testing.T) {
+	t.Parallel()
+
+	otherStorageClass := "other-storage-class"
+	disableDefaultQueries := true
+
+	tests := []struct {
+		name    string
+		mutate  func(spec *cnpgv1.ClusterSpec)
+		changed bool
+	}{
+		{"identical spec", func(*cnpgv1.ClusterSpec) {}, false},
+		{"untracked field", func(s *cnpgv1.ClusterSpec) { s.LogLevel = "debug" }, false},
+		{"inherited metadata", func(s *cnpgv1.ClusterSpec) { s.InheritedMetadata.Labels["app"] = "other" }, true},
+		{"image catalog major version", func(s *cnpgv1.ClusterSpec) { s.ImageCatalogRef.Major = 18 }, true},
+		{"instances", func(s *cnpgv1.ClusterSpec) { s.Instances = 3 }, true},
+		{"affinity", func(s *cnpgv1.ClusterSpec) { s.Affinity.TopologyKey = "topology.kubernetes.io/zone" }, true},
+		{"resources", func(s *cnpgv1.ClusterSpec) {
+			s.Resources.Requests[corev1.ResourceCPU] = resource.MustParse("4")
+		}, true},
+		{"storage class", func(s *cnpgv1.ClusterSpec) {
+			s.StorageConfiguration.StorageClass = &otherStorageClass
+		}, true},
+		{"storage size", func(s *cnpgv1.ClusterSpec) { s.StorageConfiguration.Size = "100Gi" }, true},
+		{"pvc template", func(s *cnpgv1.ClusterSpec) {
+			s.StorageConfiguration.PersistentVolumeClaimTemplate.AccessModes =
+				[]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+		}, true},
+		{"monitoring", func(s *cnpgv1.ClusterSpec) { s.Monitoring.DisableDefaultQueries = &disableDefaultQueries }, true},
+		{"postgres parameter value", func(s *cnpgv1.ClusterSpec) {
+			s.PostgresConfiguration.Parameters["jit"] = "on"
+		}, true},
+		{"postgres parameter added", func(s *cnpgv1.ClusterSpec) {
+			s.PostgresConfiguration.Parameters["work_mem"] = "8MB"
+		}, true},
+		{"backup snapshot class", func(s *cnpgv1.ClusterSpec) { s.Backup.VolumeSnapshot.ClassName = "other" }, true},
+		{"backup removed", func(s *cnpgv1.ClusterSpec) { s.Backup = nil }, true},
+		{"certificates", func(s *cnpgv1.ClusterSpec) {
+			s.Certificates.ServerAltDNSNames = append(s.Certificates.ServerAltDNSNames, "noobaa-db-pg.test.svc")
+		}, true},
+		{"priority class", func(s *cnpgv1.ClusterSpec) { s.PriorityClassName = "other-priority-class" }, true},
+		{"failover delay", func(s *cnpgv1.ClusterSpec) { s.FailoverDelay = defaultFailoverDelaySec + 30 }, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			existing := baseClusterSpec()
+			desired := existing.DeepCopy()
+			tt.mutate(desired)
+
+			r := &Reconciler{CNPGCluster: &cnpgv1.Cluster{Spec: *desired}}
+			if got := r.wasClusterSpecChanged(&existing); got != tt.changed {
+				t.Fatalf("wasClusterSpecChanged() = %v, want %v", got, tt.changed)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Describe the Problem

During an ODF 4.18 -> 4.19 upgrade with a large NooBaa DB (423GB), the CNPG import completed and the CNPG Cluster reported `Ready`, but the operator stayed stuck in `Creating` forever and never brought up `noobaa-core` or `noobaa-endpoint`. S3 was down indefinitely until the NooBaa CR status was manually patched.

`reconcileDBCluster()` refused to apply a cluster spec diff whenever `DBClusterStatus` was `Creating`/`Recovering` (`Importing` on 5.19), and returned an error:

```
level=info msg="cnpg:: the cluster spec was changed but the cluster creation is still in progress, skipping update"
level=warning msg="⏳ Temporary Error: cluster creation is still in progress, skipping update"
```

The only code that clears those statuses lives in `ReconcileCNPGCluster()` and runs *after* `reconcileDBCluster()` returns, so the error prevented the very status transition that would disarm the guard — a self-sustaining deadlock. The error propagates out of `ReconcilePhaseCreatingForMainClusters()`, so core and endpoints are never created.

The large DB is what exposed it: the import took ~5 hours, so the 4.19 CSVs were installed while it ran. The new operator computes a different desired spec than the one the 4.18 operator applied, so `wasClusterSpecChanged()` always returns true and the guard always fires. With a small DB the import finishes before the upgrade and the status reaches `Ready` cleanly, which is why regression runs never caught it.

The same deadlock is reachable outside upgrades: any edit to the NooBaa CR while the cluster is bootstrapping or recovering from a snapshot — exactly when a user is most likely to be editing the CR to fix a stuck deployment.

### Explain the Changes
1. Removed the guard in `reconcileDBCluster()` that skipped cluster CR updates while `DBClusterStatus` was `Creating`/`Recovering`, and the error it returned. The update is now always applied and CNPG arbitrates it. Verified against CNPG v1.29.1 that this is safe for the fields we mutate: `Spec.Bootstrap` (the one bootstrap-sensitive field) is only set in the CR creation branch and is not compared by `wasClusterSpecChanged()`; CNPG's validating webhook runs the same checks regardless of phase and none fire for our diffs; and CNPG's `reconcileResources()` defers all pod/PVC changes while a bootstrap job is running, so a mid-creation update only lands once the cluster is up.
2. Added `dbClusterStatusAfterSpecUpdate()` so an update only steps the status down to `Updating` from a `Ready` cluster. Previously the status was set to `Updating` unconditionally, which would have masked a genuine in-progress `Recovering`/`Creating` phase once the guard was gone. Any non-Ready status is left alone and resolved to `Ready` by `ReconcileCNPGCluster()` when the cluster reports ready.
3. Added `TestDBClusterStatusAfterSpecUpdate` — table over all seven statuses, including `Importing`, so the test transfers to 5.19 unchanged.
4. Added `TestWasClusterSpecChanged` — 18 cases over a fully populated baseline spec, one field mutated per case. This gate had no coverage at all. The two negative cases (identical spec, untracked field) guard against a spurious diff, which post-fix would mean rewriting the cluster CR on every reconcile.

### Issues: Fixed DFBUGS-8895
1. https://redhat.atlassian.net/browse/DFBUGS-8895

### Testing Instructions:
1. Deploy NooBaa with a `dbSpec` (CNPG cluster) and wait for `status.dbStatus.dbClusterStatus: Ready` and running core/endpoint pods.
2. Simulate the wedged status without needing a multi-hour import: `oc patch noobaa noobaa -n openshift-storage --type merge --subresource status -p '{"status":{"dbStatus":{"dbClusterStatus":"Creating"}}}'`
3. Produce a cluster spec diff, e.g. add a param under `spec.dbSpec.dbConf` or change `spec.dbSpec.dbResources`.
4. Before the fix the operator loops on `cluster creation is still in progress, skipping update` and the NooBaa CR stays in `Creating`. After the fix the update is applied, the status returns to `Ready`, and core/endpoints stay up.
5. Verify the normal paths are unaffected: a fresh install reaches `Ready`, and a snapshot recovery (`spec.dbSpec.dbRecovery`) reports `Recovering` — not `Updating` — for the whole recovery, then `Ready` with `recoveryStatus.status: Completed`.
6. Full upgrade check: 4.18 -> 4.19 with a DB large enough that the import outlasts the operator upgrade (~400GB via `md_blow.js`); core and endpoints should come up once the import finishes, with no manual status patch.
7. `go test ./pkg/system/`

- [ ] Doc added/updated
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database configuration updates are now applied consistently while clusters are being created, recovered, or updated.
  * In-progress creation and recovery statuses are preserved during configuration changes.
  * Ready databases transition to an Updating status when changes are detected.

* **Tests**
  * Expanded coverage for changes to storage, compute, monitoring, PostgreSQL, backup, certificate, and failover settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->