### PR TITLE
Fix NetworkPolicies to allow N2N ICE port range 60101-60600

### DIFF
--- a/deploy/internal/networkpolicy-endpoint.yaml
+++ b/deploy/internal/networkpolicy-endpoint.yaml
@@ -28,6 +28,10 @@ spec:
       port: 13443
     - protocol: TCP
       port: 14443
+    # N2N ICE listens on a random port in this range (see noobaa-core rpc_n2n_agent)
+    - protocol: TCP
+      port: 60101
+      endPort: 60600
   - from:
     - namespaceSelector: {}
     ports:

--- a/deploy/internal/networkpolicy-pvpool.yaml
+++ b/deploy/internal/networkpolicy-pvpool.yaml
@@ -15,5 +15,7 @@ spec:
   - from:
     - podSelector: {}
     ports:
+    # N2N ICE listens on a random port in this range (see noobaa-core rpc_n2n_agent)
     - protocol: TCP
       port: 60101
+      endPort: 60600

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -4989,7 +4989,7 @@ spec:
       port: 9187
 `
 
-const Sha256_deploy_internal_networkpolicy_endpoint_yaml = "6c55cda146ca6f55d2f2de9332e63e5f57eb897f3b9f180e212f69cd9740a2c5"
+const Sha256_deploy_internal_networkpolicy_endpoint_yaml = "37b72fc7a57df738460390ef88f02d7ea47ab0cb44dd4df0f8c61257e9fd74d2"
 
 const File_deploy_internal_networkpolicy_endpoint_yaml = `apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -5021,6 +5021,10 @@ spec:
       port: 13443
     - protocol: TCP
       port: 14443
+    # N2N ICE listens on a random port in this range (see noobaa-core rpc_n2n_agent)
+    - protocol: TCP
+      port: 60101
+      endPort: 60600
   - from:
     - namespaceSelector: {}
     ports:
@@ -5038,7 +5042,7 @@ spec:
       port: 14443
 `
 
-const Sha256_deploy_internal_networkpolicy_pvpool_yaml = "c1db3e37d5f50a40f3176eca696e511c997690033df5f1596fd88831f3bcbc40"
+const Sha256_deploy_internal_networkpolicy_pvpool_yaml = "bf0a2f786bc4e0e1f199abbd0ca2f24f186b58e21d5c95ed9b1ca8380eaed9de"
 
 const File_deploy_internal_networkpolicy_pvpool_yaml = `apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -5057,8 +5061,10 @@ spec:
   - from:
     - podSelector: {}
     ports:
+    # N2N ICE listens on a random port in this range (see noobaa-core rpc_n2n_agent)
     - protocol: TCP
       port: 60101
+      endPort: 60600
 `
 
 const Sha256_deploy_internal_nsfs_pvc_cr_yaml = "6dd65ca7d324991b813f209ec6a8a6bcf6c2c9a9f45c519ad3fba51e25042f07"


### PR DESCRIPTION
### Describe the Problem
PV-pool and endpoint policies only allowed a single port (or none) while N2N listens on a random port in 60101-60600, causing RPC CONNECT TIMEOUT on uploads. 

### Explain the changes
1. Allow the full range so endpoint↔agent block IO can connect.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. s3 cp obj.txt s3://first.bucket/obj.txt -> fails on write_block timeout 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules to allow the full TCP port range required for N2N ICE connections.
  * Improved connectivity for endpoint and persistent volume pool traffic across ports 60101–60600.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->