### PR TITLE
[Backport into 5.20] DFBUGS-7108 | Add `ConnectAuto` instead of `Connect` To Use CLI Commands From Operator Pod

### DIFF
--- a/pkg/cosi/cosi_bucket_access.go
+++ b/pkg/cosi/cosi_bucket_access.go
@@ -209,7 +209,7 @@ func RunStatusBucketAccessClaim(cmd *cobra.Command, args []string) {
 		log.Fatalf(`❌ Could not find COSI bucket access claim secret %q in namespace %q`, secret.Name, cosiBucketAccessClaim.Namespace)
 	}
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		util.Logger().Fatalf("❌ %s", err)
 	}

--- a/pkg/cosi/cosi_bucket_claim.go
+++ b/pkg/cosi/cosi_bucket_claim.go
@@ -206,7 +206,7 @@ func RunStatusBucketClaim(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		util.Logger().Fatalf("❌ %s", err)
 	}

--- a/pkg/cosi/cosi_cli_test.go
+++ b/pkg/cosi/cosi_cli_test.go
@@ -34,7 +34,7 @@ var _ = Describe("COSI CLI tests", func() {
 	var nsResource *nbv1.NamespaceStore
 	log := util.Logger()
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Infof("COSI bucket creation tests, can't create sysclient: err= %q", err)
 	}

--- a/pkg/cosi/cosi_test.go
+++ b/pkg/cosi/cosi_test.go
@@ -36,7 +36,7 @@ var _ = Describe("COSI driver/provisioner tests", func() {
 
 	log := util.Logger()
 	nbClient := system.GetNBClient()
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Infof("COSI bucket creation tests, can't create sysclient: err= %q", err)
 	}

--- a/pkg/noobaaaccount/noobaaaccount.go
+++ b/pkg/noobaaaccount/noobaaaccount.go
@@ -262,7 +262,7 @@ func RunUpdate(cmd *cobra.Command, args []string) {
 	noobaaAccount.Name = name
 	noobaaAccount.Namespace = options.Namespace
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Fatalf("❌ failed to run RPC call: %s", err)
 	}
@@ -309,7 +309,7 @@ func RunUpdate(cmd *cobra.Command, args []string) {
 			RunStatus(cmd, args)
 		}
 	} else {
-		sysClient, err := system.Connect(true)
+		sysClient, err := system.ConnectAuto()
 		if err != nil {
 			log.Fatalf(`❌ Unable to create RPC client %s`, err)
 		}
@@ -617,7 +617,7 @@ func GenerateAccountKeys(name string) error {
 
 	var accessKeys nb.S3AccessKeys
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}
@@ -674,7 +674,7 @@ func GenerateNonCrdAccountKeys(name string) error {
 
 	var accessKeys nb.S3AccessKeys
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}
@@ -711,7 +711,7 @@ func GenerateNonCrdAccountKeys(name string) error {
 func UpdateAccountKeys(name string, accessKeys nb.S3AccessKeys) error {
 	log := util.Logger()
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}
@@ -767,7 +767,7 @@ func UpdateAccountKeys(name string, accessKeys nb.S3AccessKeys) error {
 func UpdateNonCrdAccountKeys(name string, accessKeys nb.S3AccessKeys) error {
 	log := util.Logger()
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}

--- a/pkg/obc/obc.go
+++ b/pkg/obc/obc.go
@@ -403,7 +403,7 @@ func RunStatus(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		util.Logger().Fatalf("❌ %s", err)
 	}
@@ -574,7 +574,7 @@ func GenerateAccountKeys(name, accountName, appNamespace string) error {
 
 	var accessKeys nb.S3AccessKeys
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		return err
 	}

--- a/pkg/sts/sts.go
+++ b/pkg/sts/sts.go
@@ -71,7 +71,7 @@ func RunAssign(cmd *cobra.Command, args []string) {
 		log.Fatalf(`❌ The provided role configuration is not valid JSON`)
 	}
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Fatalf(`❌ Failed to create RPC client %s`, err)
 	}
@@ -100,7 +100,7 @@ func RunAssign(cmd *cobra.Command, args []string) {
 func RunRemove(cmd *cobra.Command, args []string) {
 	email, _ := cmd.Flags().GetString("email")
 
-	sysClient, err := system.Connect(true)
+	sysClient, err := system.ConnectAuto()
 	if err != nil {
 		log.Fatalf(`❌ Failed to create RPC client %s`, err)
 	}

--- a/pkg/system/cmd_api_call.go
+++ b/pkg/system/cmd_api_call.go
@@ -35,7 +35,7 @@ func RunAPICall(cmd *cobra.Command, args []string) {
 		apiName += "_api"
 	}
 
-	sysClient, err := Connect(true)
+	sysClient, err := ConnectAuto()
 	if err != nil {
 		log.Fatalf("❌ %s", err)
 	}

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -1103,7 +1104,7 @@ type Client struct {
 
 // GetNBClient returns an api client
 func GetNBClient() nb.Client {
-	c, err := Connect(true)
+	c, err := ConnectAuto()
 	if err != nil {
 		util.Logger().Fatalf("❌ %s", err)
 	}
@@ -1200,6 +1201,22 @@ func Connect(isExternal bool) (*Client, error) {
 		MgmtURL:     mgmtURL,
 		S3URL:       s3URL,
 	}, nil
+}
+
+// IsRunningInCluster returns true when the process runs inside a Kubernetes pod.
+// It uses rest.InClusterConfig(), which checks KUBERNETES_SERVICE_HOST/PORT and
+// the service account token/CA at /var/run/secrets/kubernetes.io/serviceaccount/.
+// KUBECONFIG does not affect this detection.
+func IsRunningInCluster() bool {
+	_, err := rest.InClusterConfig()
+	return err == nil
+}
+
+// ConnectAuto connects to the NooBaa system
+// external to cluster or internal to cluster based on the running environment
+func ConnectAuto() (*Client, error) {
+	isExternal := !IsRunningInCluster()
+	return Connect(isExternal)
 }
 
 // GetDesiredDBImage returns the desired DB image according to spec or env or default (in options)

--- a/pkg/validations/common_bucket_validations.go
+++ b/pkg/validations/common_bucket_validations.go
@@ -82,9 +82,13 @@ func ValidateReplicationPolicy(bucketName string, replicationPolicy string, upda
 	}
 
 	log.Infof("ValidateReplicationPolicy: validating replication: replicationParams: %+v", replicationParams)
-	IsExternalRPCConnection := util.IsTestEnv() || isCLI
 
-	sysClient, err := system.Connect(IsExternalRPCConnection)
+	var sysClient *system.Client
+	if isCLI {
+		sysClient, err = system.ConnectAuto()
+	} else {
+		sysClient, err = system.Connect(util.IsTestEnv())
+	}
 	if err != nil {
 		return fmt.Errorf("Provisioner Failed to validate replication of bucket %q with error: %v", bucketName, err)
 	}


### PR DESCRIPTION
(cherry picked from commit 8e3442faa1591eb02e077b6d1bdcedfde1b2e920) (cherry picked from commit 3fae90f3cbde0ba084d5bb18c7a798d06fa07f50) (cherry picked from commit db37ba0a4ada7448dec4b9bab0f0be9d65339a22)

### Describe the Problem
Currently, CLI commands that use `Connect` (or `GetNBClient`) hardcode the `isExternal` parameter. This leads to a panic error in case someone wants to run the CLI commands from inside the operator pod.

### Explain the changes
1. In file `pkg/system/system.go` added `ConnectAuto` and the helper function `IsRunningInCluster`, which is the decision on whether running from inside the pod. `GetNBClient` changed to use the `ConnectAuto`.

### Issues: Fixed [DFBUGS-7108](https://redhat.atlassian.net/browse/DFBUGS-7108)
1. Backport of https://github.com/noobaa/noobaa-operator/pull/1955
1. Cloned Bug: [DFBUGS-8872](https://redhat.atlassian.net/browse/DFBUGS-8872)

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added
