### PR TITLE
core HA | set PodManagementPolicy to Parallel

### DIFF
--- a/deploy/internal/statefulset-core.yaml
+++ b/deploy/internal/statefulset-core.yaml
@@ -10,6 +10,7 @@ spec:
     matchLabels:
       noobaa-core: noobaa
   serviceName: noobaa-mgmt
+  podManagementPolicy: Parallel
   # OnDelete: RollingUpdate waits for Ready after each pod; HA standbys never
   # become Ready, so the roll stalls after the standby and never updates the
   # leader. With OnDelete, operator will detect template/hash drift and delete outdated pods itself.

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5807,7 +5807,7 @@ spec:
       noobaa-s3-svc: "true"
 `
 
-const Sha256_deploy_internal_statefulset_core_yaml = "9a446baf09a5995591b96a1990ce256ff5e48a3bf7d839f6a0fc7bf89a9c06e6"
+const Sha256_deploy_internal_statefulset_core_yaml = "987f86f210081559a4842dafa3a77fd5d1da5a598bfde21f2b296a157c1bcf8a"
 
 const File_deploy_internal_statefulset_core_yaml = `apiVersion: apps/v1
 kind: StatefulSet
@@ -5821,6 +5821,7 @@ spec:
     matchLabels:
       noobaa-core: noobaa
   serviceName: noobaa-mgmt
+  podManagementPolicy: Parallel
   # OnDelete: RollingUpdate waits for Ready after each pod; HA standbys never
   # become Ready, so the roll stalls after the standby and never updates the
   # leader. With OnDelete, operator will detect template/hash drift and delete outdated pods itself.

--- a/pkg/system/core_ha_test.go
+++ b/pkg/system/core_ha_test.go
@@ -379,3 +379,76 @@ func assertPreferredCoreTerm(t *testing.T, term corev1.WeightedPodAffinityTerm, 
 		t.Fatalf("labelSelector = %#v, want noobaa-core=%s", term.PodAffinityTerm.LabelSelector, coreName)
 	}
 }
+
+func TestCoreStatefulSetHasOrderedReadyPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		sts    appsv1.StatefulSet
+		want   bool
+	}{
+		{
+			name: "no live object",
+			sts:  appsv1.StatefulSet{},
+			want: false,
+		},
+		{
+			name: "already parallel",
+			sts: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{UID: "uid-1"},
+				Spec:       appsv1.StatefulSetSpec{PodManagementPolicy: appsv1.ParallelPodManagement},
+			},
+			want: false,
+		},
+		{
+			name: "ordered ready",
+			sts: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{UID: "uid-1"},
+				Spec:       appsv1.StatefulSetSpec{PodManagementPolicy: appsv1.OrderedReadyPodManagement},
+			},
+			want: true,
+		},
+		{
+			name: "empty defaults to ordered ready on cluster",
+			sts: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{UID: "uid-1"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := coreStatefulSetHasOrderedReadyPolicy(&tt.sts); got != tt.want {
+				t.Fatalf("coreStatefulSetHasOrderedReadyPolicy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClearStatefulSetServerFieldsForRecreate(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	grace := int64(30)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:                        types.UID("uid-1"),
+			ResourceVersion:            "rv-1",
+			Generation:                 3,
+			CreationTimestamp:          now,
+			DeletionTimestamp:          &now,
+			DeletionGracePeriodSeconds: &grace,
+		},
+	}
+
+	clearStatefulSetServerFieldsForRecreate(sts)
+	if sts.UID != "" || sts.ResourceVersion != "" || sts.Generation != 0 {
+		t.Fatalf("identity not cleared: uid=%q rv=%q gen=%d", sts.UID, sts.ResourceVersion, sts.Generation)
+	}
+	if !sts.CreationTimestamp.IsZero() || sts.DeletionTimestamp != nil || sts.DeletionGracePeriodSeconds != nil {
+		t.Fatal("timestamps/grace not cleared")
+	}
+}

--- a/pkg/system/phase2_creating.go
+++ b/pkg/system/phase2_creating.go
@@ -231,6 +231,10 @@ func (r *Reconciler) ReconcilePhaseCreatingForMainClusters() error {
 		}
 	}
 
+	if err := r.ensureParallelCoreStatefulSet(); err != nil {
+		return err
+	}
+
 	if err := r.ReconcileObject(r.CoreApp, r.SetDesiredCoreApp); err != nil {
 		return err
 	}
@@ -654,6 +658,60 @@ func (r *Reconciler) setDesiredCoreEnv(c *corev1.Container) {
 	util.ApplyTLSEnvVars(&c.Env, r.NooBaa.Spec.Security.APIServerSecurity)
 }
 
+// checks if the statefulset has parallel pod management policy
+func hasParallelPodManagement(sts *appsv1.StatefulSet) bool {
+	if sts.UID == "" {
+		return false
+	}
+	return sts.Spec.PodManagementPolicy == appsv1.ParallelPodManagement
+}
+
+// ensures that the statefulset has parallel pod management policy
+// PodManagementPolicy is immutable, so we need to delete the statefulset and create a new one
+// can happen when upgrading from older operator versions
+func (r *Reconciler) ensureParallelCoreStatefulSet() error {
+	if !util.KubeCheckQuiet(r.CoreApp) {
+		return nil
+	}
+	if hasParallelPodManagement(r.CoreApp) {
+		return nil
+	}
+
+	current := r.CoreApp.Spec.PodManagementPolicy
+	if current == "" {
+		current = appsv1.OrderedReadyPodManagement
+	}
+	r.Logger.Infof(
+		"upgrading %s StatefulSet to parallel pod startup (delete STS, keep pods, recreate) from %q",
+		r.CoreApp.Name, current,
+	)
+
+	// delete the statefulset and keep the pods
+	orphan := metav1.DeletePropagationOrphan
+	if !util.KubeDelete(r.CoreApp, &client.DeleteOptions{PropagationPolicy: &orphan}) {
+		return fmt.Errorf(
+			"failed to delete %s StatefulSet for parallel pod startup upgrade (pods preserved)",
+			r.CoreApp.Name,
+		)
+	}
+
+	clearStatefulSetServerFieldsForRecreate(r.CoreApp)
+	return nil
+}
+
+// clearStatefulSetServerFieldsForRecreate removes server-owned metadata after the
+// StatefulSet object was deleted. Without this, the next Create would reuse stale
+// uid/resourceVersion from the deleted object.
+func clearStatefulSetServerFieldsForRecreate(obj metav1.Object) {
+	obj.SetResourceVersion("")
+	obj.SetUID("")
+	obj.SetGeneration(0)
+	obj.SetCreationTimestamp(metav1.Time{})
+	obj.SetDeletionTimestamp(nil)
+	obj.SetDeletionGracePeriodSeconds(nil)
+	obj.SetManagedFields(nil)
+}
+
 // SetDesiredCoreApp updates the CoreApp as desired for reconciling
 func (r *Reconciler) SetDesiredCoreApp() error {
 	if coreLabels, ok := r.NooBaa.Spec.Labels["core"]; ok {
@@ -666,6 +724,8 @@ func (r *Reconciler) SetDesiredCoreApp() error {
 	r.CoreApp.Spec.Template.Labels["noobaa-mgmt"] = r.Request.Name
 	r.CoreApp.Spec.Selector.MatchLabels["noobaa-core"] = r.Request.Name
 	r.CoreApp.Spec.ServiceName = r.ServiceMgmt.Name
+	// Parallel startup so HA scale-down/recreate does not wait on NotReady standbys.
+	r.CoreApp.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 	// OnDelete avoids RollingUpdate stall on never-Ready HA standbys; see restartStaleCorePods.
 	r.CoreApp.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
 		Type: appsv1.OnDeleteStatefulSetStrategyType,


### PR DESCRIPTION
### Describe the Problem
With HA, the standby core pod is not Ready. Default StatefulSet ordering (OrderedReady) can block scaling or replacing the other core pod until the standby becomes Ready.

### Explain the changes
1. Use podManagementPolicy: Parallel on noobaa-core.
2. since podManagementPolicy is immutable, On upgrade, auto-recreate the StatefulSet (keep pods) 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `go test ./pkg/system/ -run 'CoreStatefulSet|ClearStatefulSet'`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Core service pods are now created and updated concurrently.
  - New installations use parallel pod management.

- **Bug Fixes**
  - Existing deployments using sequential pod management are automatically migrated to the parallel approach while preserving running pods.
  - StatefulSet reconciliation now maintains consistent pod management settings during updates.
  - Management metrics now target only ready pods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->