### PR TITLE
Update external psql check to allow versions higher than 15

### DIFF
--- a/pkg/system/phase1_verifying.go
+++ b/pkg/system/phase1_verifying.go
@@ -242,17 +242,17 @@ func (r *Reconciler) checkExternalPg(postgresDbURL string) error {
 				dbURL, err))
 	}
 	// Query the PostgreSQL version
-	var version string
+	var version int
 	err = db.QueryRow("SELECT current_setting('server_version_num')::integer / 10000").Scan(&version)
 	if err != nil {
 		return util.NewPersistentError("InvalidExternalPgVersion",
 			fmt.Sprintf("failed getting version of external DB url: %q, error: %s",
 				dbURL, err))
 	}
-	// Check if the version is 15
-	if version != "15" {
+	// Reject PostgreSQL versions older than 15
+	if version < 15 {
 		return util.NewPersistentError("InvalidExternalPgVersion",
-			fmt.Sprintf("version of external DB %q, is not supported: %s",
+			fmt.Sprintf("version of external DB %q, is not supported: %d",
 				dbURL, version))
 	}
 	// Query the database's collation


### PR DESCRIPTION
Update external psql check to allow versions higher than 15

Fixes [DFBUGS-10092](https://redhat.atlassian.net/browse/DFBUGS-10092)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PostgreSQL version validation to support version 15 and newer.
  * Improved handling and reporting of unsupported PostgreSQL versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->