### PR TITLE
core HA | mgmt ServiceMonitor: only scrape Ready core pods (skip standby)

### DIFF
--- a/deploy/internal/servicemonitor-mgmt.yaml
+++ b/deploy/internal/servicemonitor-mgmt.yaml
@@ -9,12 +9,24 @@ spec:
   - port: mgmt-https
     path: /metrics/web_server
     scheme: https
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      action: keep
+      regex: "true"
   - port: mgmt-https
     path: /metrics/bg_workers
     scheme: https
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      action: keep
+      regex: "true"
   - port: mgmt-https
     path: /metrics/hosted_agents
     scheme: https
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      action: keep
+      regex: "true"
   namespaceSelector: {}
   selector:
     matchLabels:

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -5751,7 +5751,7 @@ spec:
     noobaa-operator: deployment
 `
 
-const Sha256_deploy_internal_servicemonitor_mgmt_yaml = "dd92e14c909a2b7605df90ae50647894f7aef63553e86d3a13d7edec6405f9e4"
+const Sha256_deploy_internal_servicemonitor_mgmt_yaml = "3b2820e1088e9cffea1404d1296186af8d478b5c2530a27899104885caa2dcdf"
 
 const File_deploy_internal_servicemonitor_mgmt_yaml = `apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -5764,12 +5764,24 @@ spec:
   - port: mgmt-https
     path: /metrics/web_server
     scheme: https
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      action: keep
+      regex: "true"
   - port: mgmt-https
     path: /metrics/bg_workers
     scheme: https
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      action: keep
+      regex: "true"
   - port: mgmt-https
     path: /metrics/hosted_agents
     scheme: https
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      action: keep
+      regex: "true"
   namespaceSelector: {}
   selector:
     matchLabels:

--- a/pkg/system/phase4_configuring.go
+++ b/pkg/system/phase4_configuring.go
@@ -50,6 +50,9 @@ const (
 	credentialsKey                    = "credentials"
 	metricsAuthKey                    = "metrics_token"
 	serviceMonitorCAFile              = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+	podReadyMetaLabel                 = "__meta_kubernetes_pod_ready"
+	keepReadyRelabelAction            = "keep"
+	keepReadyRelabelRegex             = "true"
 )
 
 // OnAdmissionTLSChanged is called by the reconciler when the NooBaa CR's
@@ -1768,6 +1771,7 @@ func (r *Reconciler) setDesiredServiceMonitorMgmt() error {
 	r.setServiceMonitorEndpointsToHTTPS(r.ServiceMonitorMgmt.Spec.Endpoints, "mgmt-https")
 	r.setServiceMonitorAuthorization(r.ServiceMonitorMgmt.Spec.Endpoints)
 	r.setServiceMonitorTLSConfig(r.ServiceMonitorMgmt.Spec.Endpoints, r.ServiceMgmt.Name)
+	r.setServiceMonitorKeepReadyPodRelabel(r.ServiceMonitorMgmt.Spec.Endpoints)
 	return nil
 }
 
@@ -1800,6 +1804,31 @@ func (r *Reconciler) setServiceMonitorAuthorization(endpoints []monitoringv1.End
 				},
 				Key: metricsAuthKey,
 			},
+		}
+	}
+}
+
+// setServiceMonitorKeepReadyPodRelabel adds a keep-on-pod-ready relabel to each endpoint
+// if missing. Core HA standbys stay Running but never Ready and do not serve /metrics.
+func (r *Reconciler) setServiceMonitorKeepReadyPodRelabel(endpoints []monitoringv1.Endpoint) {
+	keep := monitoringv1.RelabelConfig{
+		SourceLabels: []monitoringv1.LabelName{podReadyMetaLabel},
+		Action:       keepReadyRelabelAction,
+		Regex:        keepReadyRelabelRegex,
+	}
+	for i := range endpoints {
+		found := false
+		for _, c := range endpoints[i].RelabelConfigs {
+			if strings.EqualFold(c.Action, keepReadyRelabelAction) &&
+				c.Regex == keepReadyRelabelRegex &&
+				len(c.SourceLabels) == 1 &&
+				string(c.SourceLabels[0]) == podReadyMetaLabel {
+				found = true
+				break
+			}
+		}
+		if !found {
+			endpoints[i].RelabelConfigs = append([]monitoringv1.RelabelConfig{keep}, endpoints[i].RelabelConfigs...)
 		}
 	}
 }


### PR DESCRIPTION
### Describe the Problem
With core HA on OpenShift, TargetDown fires on noobaa-mgmt because Prometheus scrapes the passive noobaa-core pod. The leader is Ready and serves metrics; the standby is Running but not Ready and does not listen on 8443. Scrapes against the standby fail (connection refused), so half the mgmt targets look down on a healthy system.

### Explain the changes
1. Add a relabel rule on the mgmt ServiceMonitor: only scrape pods where Kubernetes reports Ready (`__meta_kubernetes_pod_ready=true`).
2. Add setServiceMonitorKeepReadyPodRelabel so existing clusters get the rule on upgrade

### Issues: Gaps
1. this will cause us to ignore pods that aren't ready. meaning that if both pods are down we will still not report the TargetDown error. can be on a follow up PR by adding a custom rule that checks if both pods are down for more then 15 minutes
2. even after fix we get the alert:
```
KubeStatefulSetReplicasMismatch
StatefulSet has not matched the expected number of replicas.
```
this is a different problem and will be handled in a follow up PR

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics collection now targets only pods reported as ready.
  * Improved monitoring accuracy by preventing scrapes from unready pods.
  * Applied readiness filtering consistently across all management metrics endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->