### PR TITLE
Return reconciler error on endpoint update in CR spec

### DIFF
--- a/pkg/backingstore/reconciler.go
+++ b/pkg/backingstore/reconciler.go
@@ -93,6 +93,8 @@ type Reconciler struct {
 	CreateHostsPoolParams          *nb.CreateHostsPoolParams
 	UpdateHostsPoolParams          *nb.UpdateHostsPoolParams
 	UpdateExternalConnectionParams *nb.UpdateExternalConnectionParams
+	EndpointChanged                bool
+	OldCoreEndpoint                string
 }
 
 // Own sets the object owner references to the backingstore
@@ -636,6 +638,12 @@ func (r *Reconciler) ReadSystemInfo() error {
 			pool.CloudInfo.Endpoint != conn.Endpoint ||
 			pool.CloudInfo.Identity != string(conn.Identity) {
 			r.Logger.Warnf("using existing pool but connection mismatch %+v pool %+v %+v", conn, pool, pool.CloudInfo)
+
+			// endpoint changes are only allowed using CLI
+			if pool.CloudInfo.Endpoint != conn.Endpoint {
+				r.EndpointChanged = true
+				r.OldCoreEndpoint = pool.CloudInfo.Endpoint
+			}
 			r.UpdateExternalConnectionParams = &nb.UpdateExternalConnectionParams{
 				Name:               conn.Name,
 				Identity:           conn.Identity,
@@ -913,6 +921,12 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 	}
 
 	if r.UpdateExternalConnectionParams != nil {
+		if r.EndpointChanged {
+			r.Logger.Errorf("Backingstore endpoint cannot be updated directly on the spec")
+			return util.NewPersistentError("InvalidBackingStore",
+				fmt.Sprintf("Backingstore endpoint cannot be updated directly on the spec. Restore it to old endpoint %+v",
+					r.OldCoreEndpoint))
+		}
 		checkConnectionParams.IgnoreNameAlreadyExist = true
 		err := r.CheckExternalConnection(checkConnectionParams)
 		if err != nil {

--- a/pkg/namespacestore/reconciler.go
+++ b/pkg/namespacestore/reconciler.go
@@ -70,6 +70,8 @@ type Reconciler struct {
 	AddExternalConnectionParams    *nb.AddExternalConnectionParams
 	CreateNamespaceResourceParams  *nb.CreateNamespaceResourceParams
 	UpdateExternalConnectionParams *nb.UpdateExternalConnectionParams
+	EndpointChanged                bool
+	OldCoreEndpoint                string
 }
 
 // Own sets the object owner references to the namespacestore
@@ -508,6 +510,12 @@ func (r *Reconciler) ReadSystemInfo() error {
 			nsr.Endpoint != conn.Endpoint ||
 			nsr.Identity != string(conn.Identity) {
 			r.Logger.Warnf("using existing namespace resource but connection mismatch %+v namespace store %+v", conn, nsr)
+
+			// endpoint changes are only allowed using CLI
+			if nsr.Endpoint != conn.Endpoint {
+				r.EndpointChanged = true
+				r.OldCoreEndpoint = nsr.Endpoint
+			}
 			r.UpdateExternalConnectionParams = &nb.UpdateExternalConnectionParams{
 				Name:               conn.Name,
 				Identity:           conn.Identity,
@@ -803,6 +811,12 @@ func (r *Reconciler) ReconcileExternalConnection() error {
 	}
 
 	if r.UpdateExternalConnectionParams != nil {
+		if r.EndpointChanged {
+			r.Logger.Errorf("NamespaceStore endpoint cannot be updated directly on the spec")
+			return util.NewPersistentError("InvalidNamespaceStore",
+				fmt.Sprintf("NamespaceStore endpoint cannot be updated directly on the spec. Restore it to old endpoint %+v",
+					r.OldCoreEndpoint))
+		}
 		checkConnectionParams.IgnoreNameAlreadyExist = true
 		err := r.CheckExternalConnection(checkConnectionParams)
 		if err != nil {


### PR DESCRIPTION
### Describe the Problem
When the endpoint field on the CR spec for backingstore or namespace store is edited, the store goes into ready phase but the changes are not actually propagated. We need to block this path and ask user to reset the endpoint field back to the original state.

Note: There is already a new CLI added to support the endpoint changes.

### Explain the changes
1. Log and return an error for both namespace store and backingstore when an endpoint mismatch is detected on spec.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reconciliation from automatically changing an existing cloud pool or namespace endpoint.
  * Added clear errors when an endpoint change is detected, prompting restoration of the previously configured endpoint.
  * Continued supporting non-endpoint connection updates, such as connection type or identity changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->