### PR TITLE
Clear stale postgresUpdatePhase from NooBaa status

### DIFF
--- a/pkg/system/reconciler.go
+++ b/pkg/system/reconciler.go
@@ -721,6 +721,9 @@ func (r *Reconciler) SetReadme(t *template.Template) {
 // UpdateStatus updates the system status in kubernetes from the memory
 func (r *Reconciler) UpdateStatus() error {
 	r.NooBaa.Status.ObservedGeneration = r.NooBaa.Generation
+	// Drop leftover postgresUpdatePhase from the ODF 4.15 dump/restore state
+	// machine so omitempty omits it from the status PUT.
+	r.NooBaa.Status.PostgresUpdatePhase = ""
 	err := r.Client.Status().Update(r.Ctx, r.NooBaa)
 	if err != nil {
 		r.Logger.Errorf("UpdateStatus: %s", err)


### PR DESCRIPTION
### Describe the Problem
After ODF upgrade, NooBaa status can still show postgresUpdatePhase: Failed even when the DB is healthy.
### Explain the changes
1. On reconcile, UpdateStatus() sets unused postgresUpdatePhase to empty so omitempty drops it from the status PUT.  That field is leftover from the old PG 12→15 dump/restore flow; the operator no longer writes it, but every status PUT echoes the stale value forever.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-9566

### Testing Instructions:
1. Install NooBaa.
2. Patch status postgresUpdatePhase: Failed.
3. Restart the operator.
4. Confirm `oc get noobaa -o yaml` no longer lists the field and phase stays `Ready`.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared stale PostgreSQL update phase information before status updates, preventing outdated dump/restore state from appearing in persisted status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->