### PR TITLE
CI | build CNPG test image on the host and load it into minikube

### DIFF
--- a/.github/workflows/run_cnpg_deployment_test.yml
+++ b/.github/workflows/run_cnpg_deployment_test.yml
@@ -27,8 +27,9 @@ jobs:
 
       - name: Start Minikube
         id: minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@v0.0.19
         with:
+            driver: docker
             cpus: 'max'
             memory: 'max'
 
@@ -38,7 +39,9 @@ jobs:
 
       - name: Run Build Image
         id: run-build-image
-        run: eval $(minikube docker-env) && make image || exit 1
+        run: |
+          make image
+          minikube image load noobaa/noobaa-operator:$(go run cmd/version/main.go)
 
       - name: Install noobaa
         run: ./build/_output/bin/noobaa-operator-local -n ${NAMESPACE} --mini install


### PR DESCRIPTION
CI | build CNPG test image on the host and load it into minikube

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the deployment test workflow to use a pinned Minikube action version and the Docker driver.
  - Improved test image handling by building the image directly and loading it into Minikube.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->