### PR TITLE
Allow store endpoint change using connection CLI

### DIFF
--- a/pkg/admission/validate_backingstore.go
+++ b/pkg/admission/validate_backingstore.go
@@ -84,6 +84,10 @@ func (bsv *ResourceValidator) ValidateUpdateBS() {
 		bsv.SetValidationResult(false, err.Error())
 		return
 	}
+	if err := validations.ValidateBSEndpointChange(*bs, *oldBS); err != nil && util.IsValidationError(err) {
+		bsv.SetValidationResult(false, err.Error())
+		return
+	}
 
 	switch bs.Spec.Type {
 	case nbv1.StoreTypePVPool:

--- a/pkg/admission/validate_namespacestore.go
+++ b/pkg/admission/validate_namespacestore.go
@@ -81,12 +81,12 @@ func (nsv *ResourceValidator) ValidateUpdateNS() {
 		return
 	}
 
-	if err := validations.ValidateNSEndpointChange(*ns, *oldNS); err != nil && util.IsValidationError(err) {
+	if err := validations.ValidateNamespaceStore(ns); err != nil && util.IsValidationError(err) {
 		nsv.SetValidationResult(false, err.Error())
 		return
 	}
 
-	if err := validations.ValidateNamespaceStore(ns); err != nil && util.IsValidationError(err) {
+	if err := validations.ValidateNSEndpointChange(*ns, *oldNS); err != nil && util.IsValidationError(err) {
 		nsv.SetValidationResult(false, err.Error())
 		return
 	}

--- a/pkg/backingstore/validation_test.go
+++ b/pkg/backingstore/validation_test.go
@@ -1,0 +1,344 @@
+package backingstore
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/constants"
+	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultEndPointURI = "https://127.0.0.1:6443"
+)
+
+func TestBackingStoreS3Compatible(t *testing.T) {
+
+	// Valid backingstore
+	defaultBS := getDefaultS3CompatibleBsStore()
+	err := validations.ValidateBackingStore(defaultBS)
+	AssertNotError(t, err, "Valid s3-compatible backingstore validation failed")
+
+	// Signature version is empty — allowed
+	defaultBS = getDefaultS3CompatibleBsStore()
+	defaultBS.Spec.S3Compatible.SignatureVersion = ""
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertNotError(t, err, "Empty signature version should be allowed")
+
+	// Valid v2 signature version
+	defaultBS = getDefaultS3CompatibleBsStore()
+	defaultBS.Spec.S3Compatible.SignatureVersion = "v2"
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertNotError(t, err, "Valid signature version v2 should be allowed")
+
+	// Invalid signature version
+	defaultBS = getDefaultS3CompatibleBsStore()
+	defaultBS.Spec.S3Compatible.SignatureVersion = "v5"
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertError(t, err, "Invalid signature version v5 should be denied")
+
+	// Empty secret name
+	defaultBS = getDefaultS3CompatibleBsStore()
+	defaultBS.Spec.S3Compatible.Secret.Name = ""
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertError(t, err, "Empty secret name should be denied")
+
+	// Empty target bucket
+	defaultBS = getDefaultS3CompatibleBsStore()
+	defaultBS.Spec.S3Compatible.TargetBucket = ""
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertError(t, err, "Empty target bucket should be denied")
+
+	// Nil S3Compatible spec
+	defaultBS = nbv1.BackingStore{
+		Spec:       nbv1.BackingStoreSpec{Type: nbv1.StoreTypeS3Compatible},
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertError(t, err, "Nil S3Compatible spec should be denied")
+}
+
+func TestBackingStoreIBMCos(t *testing.T) {
+
+	// Valid backingstore
+	defaultBS := getDefaultIBMCosBsStore()
+	err := validations.ValidateBackingStore(defaultBS)
+	AssertNotError(t, err, "Valid ibm-cos backingstore validation failed")
+
+	// Signature version is empty — allowed
+	defaultBS = getDefaultIBMCosBsStore()
+	defaultBS.Spec.IBMCos.SignatureVersion = ""
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertNotError(t, err, "Empty signature version should be allowed")
+
+	// Valid v2 signature version
+	defaultBS = getDefaultIBMCosBsStore()
+	defaultBS.Spec.IBMCos.SignatureVersion = "v2"
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertNotError(t, err, "Valid signature version v2 should be allowed")
+
+	// Invalid signature version
+	defaultBS = getDefaultIBMCosBsStore()
+	defaultBS.Spec.IBMCos.SignatureVersion = "v5"
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertError(t, err, "Invalid signature version v5 should be denied")
+
+	// Empty secret name
+	defaultBS = getDefaultIBMCosBsStore()
+	defaultBS.Spec.IBMCos.Secret.Name = ""
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertError(t, err, "Empty secret name should be denied")
+
+	// Empty target bucket
+	defaultBS = getDefaultIBMCosBsStore()
+	defaultBS.Spec.IBMCos.TargetBucket = ""
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertError(t, err, "Empty target bucket should be denied")
+
+	// Nil IBMCos spec
+	defaultBS = nbv1.BackingStore{
+		Spec:       nbv1.BackingStoreSpec{Type: nbv1.StoreTypeIBMCos},
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+	err = validations.ValidateBackingStore(defaultBS)
+	AssertError(t, err, "Nil IBMCos spec should be denied")
+}
+
+func TestValidateBSEndpointChange(t *testing.T) {
+
+	// S3Compatible: endpoint change should be denied
+	oldBS := getDefaultS3CompatibleBsStore()
+	newBS := getDefaultS3CompatibleBsStore()
+	newBS.Spec.S3Compatible.Endpoint = "https://different-endpoint.example.com"
+	err := validations.ValidateBSEndpointChange(newBS, oldBS)
+	AssertError(t, err, "S3Compatible endpoint change should be denied")
+
+	// S3Compatible: endpoint change allowed when pause annotation is set
+	oldBS = getDefaultS3CompatibleBsStore()
+	newBS = getDefaultS3CompatibleBsStore()
+	newBS.Annotations = map[string]string{
+		constants.PauseReconcile: "true",
+	}
+	newBS.Spec.S3Compatible.Endpoint = "https://different-endpoint.example.com"
+	err = validations.ValidateBSEndpointChange(newBS, oldBS)
+	AssertEqual(t, err, nil, "S3Compatible endpoint change with pause annotation should be allowed")
+
+	// endpoint change not allowed when pause annotation is set any value other than true
+	oldBS = getDefaultS3CompatibleBsStore()
+	newBS = getDefaultS3CompatibleBsStore()
+	newBS.Annotations = map[string]string{
+		constants.PauseReconcile: "false",
+	}
+	newBS.Spec.S3Compatible.Endpoint = "https://different-endpoint.example.com"
+	err = validations.ValidateBSEndpointChange(newBS, oldBS)
+	AssertError(t, err, "Endpoint change with pause annotation 'false' should be not allowed")
+
+	// S3Compatible: secret-only change, same endpoint — should be allowed
+	oldBS = getDefaultS3CompatibleBsStore()
+	newBS = getDefaultS3CompatibleBsStore()
+	newBS.Spec.S3Compatible.Secret.Name = "new-secret"
+	err = validations.ValidateBSEndpointChange(newBS, oldBS)
+	AssertNotError(t, err, "S3Compatible secret-only change should be allowed")
+
+	// S3Compatible: canonical vs non-canonical equivalent endpoint — should be allowed
+	oldBS = getDefaultS3CompatibleBsStore()
+	oldBS.Spec.S3Compatible.Endpoint = "minio.s3-a.svc:9000"
+	newBS = getDefaultS3CompatibleBsStore()
+	newBS.Spec.S3Compatible.Endpoint = "https://minio.s3-a.svc:9000"
+	err = validations.ValidateBSEndpointChange(newBS, oldBS)
+	AssertNotError(t, err, "S3Compatible equivalent endpoints should be allowed")
+
+	// IBMCos: endpoint change should be denied
+	oldIBM := getDefaultIBMCosBsStore()
+	newIBM := getDefaultIBMCosBsStore()
+	newIBM.Spec.IBMCos.Endpoint = "https://different-ibm-endpoint.example.com"
+	err = validations.ValidateBSEndpointChange(newIBM, oldIBM)
+	AssertError(t, err, "IBMCos endpoint change should be denied")
+
+	// IBMCos: endpoint change allowed when pause annotation is set
+	oldIBM = getDefaultIBMCosBsStore()
+	newIBM = getDefaultIBMCosBsStore()
+	newIBM.Annotations = map[string]string{
+		constants.PauseReconcile: "true",
+	}
+	newIBM.Spec.IBMCos.Endpoint = "https://different-ibm-endpoint.example.com"
+	err = validations.ValidateBSEndpointChange(newIBM, oldIBM)
+	AssertEqual(t, err, nil, "IBMCos endpoint change with pause annotation should be allowed")
+
+	// IBMCos: secret-only change, same endpoint — should be allowed
+	oldIBM = getDefaultIBMCosBsStore()
+	newIBM = getDefaultIBMCosBsStore()
+	newIBM.Spec.IBMCos.Secret.Name = "new-secret"
+	err = validations.ValidateBSEndpointChange(newIBM, oldIBM)
+	AssertNotError(t, err, "IBMCos secret-only change should be allowed")
+
+	// S3Compatible: nil old spec should return error
+	oldBS = getDefaultS3CompatibleBsStore()
+	oldBS.Spec.S3Compatible = nil
+	newBS = getDefaultS3CompatibleBsStore()
+	err = validations.ValidateBSEndpointChange(newBS, oldBS)
+	AssertError(t, err, "nil old S3Compatible spec should return error")
+
+	// IBMCos: nil old spec should return error
+	oldIBMNil := getDefaultIBMCosBsStore()
+	oldIBMNil.Spec.IBMCos = nil
+	newIBMNil := getDefaultIBMCosBsStore()
+	err = validations.ValidateBSEndpointChange(newIBMNil, oldIBMNil)
+	AssertError(t, err, "nil old IBMCos spec should return error")
+
+	// aws-s3 type: no endpoint field — should always be allowed
+	oldAWS := getDefaultAWSS3BsStore()
+	newAWS := getDefaultAWSS3BsStore()
+	err = validations.ValidateBSEndpointChange(newAWS, oldAWS)
+	AssertNotError(t, err, "aws-s3 type has no endpoint field, should always be allowed")
+}
+
+func TestValidatePvpoolScaleDown(t *testing.T) {
+
+	// Scale up: allowed
+	oldBS := getDefaultPVPoolBsStore(3)
+	newBS := getDefaultPVPoolBsStore(5)
+	err := validations.ValidatePvpoolScaleDown(newBS, oldBS)
+	AssertNotError(t, err, "Scale up should be allowed")
+
+	// Same count: allowed
+	oldBS = getDefaultPVPoolBsStore(3)
+	newBS = getDefaultPVPoolBsStore(3)
+	err = validations.ValidatePvpoolScaleDown(newBS, oldBS)
+	AssertNotError(t, err, "Same volume count should be allowed")
+
+	// Scale down: denied
+	oldBS = getDefaultPVPoolBsStore(5)
+	newBS = getDefaultPVPoolBsStore(3)
+	err = validations.ValidatePvpoolScaleDown(newBS, oldBS)
+	AssertError(t, err, "Scale down should be denied")
+}
+
+func TestValidateTargetBSBucketChange(t *testing.T) {
+
+	// S3Compatible: bucket change should be denied
+	oldBS := getDefaultS3CompatibleBsStore()
+	newBS := getDefaultS3CompatibleBsStore()
+	newBS.Spec.S3Compatible.TargetBucket = "different-bucket"
+	err := validations.ValidateTargetBSBucketChange(newBS, oldBS)
+	AssertError(t, err, "S3Compatible target bucket change should be denied")
+
+	// S3Compatible: same bucket — allowed
+	oldBS = getDefaultS3CompatibleBsStore()
+	newBS = getDefaultS3CompatibleBsStore()
+	err = validations.ValidateTargetBSBucketChange(newBS, oldBS)
+	AssertNotError(t, err, "S3Compatible same target bucket should be allowed")
+
+	// IBMCos: bucket change should be denied
+	oldIBM := getDefaultIBMCosBsStore()
+	newIBM := getDefaultIBMCosBsStore()
+	newIBM.Spec.IBMCos.TargetBucket = "different-bucket"
+	err = validations.ValidateTargetBSBucketChange(newIBM, oldIBM)
+	AssertError(t, err, "IBMCos target bucket change should be denied")
+
+	// aws-s3: bucket change should be denied
+	oldAWS := getDefaultAWSS3BsStore()
+	newAWS := getDefaultAWSS3BsStore()
+	newAWS.Spec.AWSS3.TargetBucket = "different-bucket"
+	err = validations.ValidateTargetBSBucketChange(newAWS, oldAWS)
+	AssertError(t, err, "aws-s3 target bucket change should be denied")
+}
+
+// --- helpers ---
+
+func AssertNotError(t *testing.T, err error, format string, a ...interface{}) {
+	t.Helper()
+	if err != nil {
+		msg := fmt.Sprintf(format, a...)
+		t.Errorf("%s: %s", msg, err)
+	}
+}
+
+func AssertError(t *testing.T, err error, format string, a ...interface{}) {
+	t.Helper()
+	if err == nil {
+		msg := fmt.Sprintf(format, a...)
+		t.Errorf("%s", msg)
+	}
+}
+
+func AssertEqual(t *testing.T, actual, expected interface{}, format string, a ...interface{}) {
+	t.Helper()
+	msg := fmt.Sprintf(format, a...)
+	if (actual == nil || expected == nil) && actual != expected {
+		t.Errorf("%s", msg)
+		return
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("%s", msg)
+	}
+}
+
+func getDefaultS3CompatibleBsStore() nbv1.BackingStore {
+	return nbv1.BackingStore{
+		Spec: nbv1.BackingStoreSpec{
+			Type: nbv1.StoreTypeS3Compatible,
+			S3Compatible: &nbv1.S3CompatibleSpec{
+				SignatureVersion: nbv1.S3SignatureVersionV4,
+				Endpoint:         defaultEndPointURI,
+				Secret: corev1.SecretReference{
+					Name:      "secret-name",
+					Namespace: "namespace",
+				},
+				TargetBucket: "some-target-bucket",
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-bs"},
+	}
+}
+
+func getDefaultIBMCosBsStore() nbv1.BackingStore {
+	return nbv1.BackingStore{
+		Spec: nbv1.BackingStoreSpec{
+			Type: nbv1.StoreTypeIBMCos,
+			IBMCos: &nbv1.IBMCosSpec{
+				SignatureVersion: nbv1.S3SignatureVersionV4,
+				Endpoint:         defaultEndPointURI,
+				Secret: corev1.SecretReference{
+					Name:      "secret-name",
+					Namespace: "namespace",
+				},
+				TargetBucket: "some-target-bucket",
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-bs"},
+	}
+}
+
+func getDefaultAWSS3BsStore() nbv1.BackingStore {
+	return nbv1.BackingStore{
+		Spec: nbv1.BackingStoreSpec{
+			Type: nbv1.StoreTypeAWSS3,
+			AWSS3: &nbv1.AWSS3Spec{
+				TargetBucket: "some-target-bucket",
+				Secret: corev1.SecretReference{
+					Name:      "secret-name",
+					Namespace: "namespace",
+				},
+				Region: "us-east-1",
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-bs"},
+	}
+}
+
+func getDefaultPVPoolBsStore(numVolumes int) nbv1.BackingStore {
+	return nbv1.BackingStore{
+		Spec: nbv1.BackingStoreSpec{
+			Type: nbv1.StoreTypePVPool,
+			PVPool: &nbv1.PVPoolSpec{
+				NumVolumes: numVolumes,
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pvpool"},
+	}
+}

--- a/pkg/namespacestore/validation_test.go
+++ b/pkg/namespacestore/validation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/constants"
 	"github.com/noobaa/noobaa-operator/v5/pkg/validations"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,6 +193,26 @@ func TestValidateNSEndpointChange(t *testing.T) {
 	err := validations.ValidateNSEndpointChange(newNS, oldNS)
 	AssertError(t, err, "S3Compatible endpoint change should be denied")
 
+	// endpoint change not allowed when pause annotation is set any value other than true
+	oldNS = getDefaultS3CompatibleNsStore()
+	newNS = getDefaultS3CompatibleNsStore()
+	newNS.Annotations = map[string]string{
+		constants.PauseReconcile: "false",
+	}
+	newNS.Spec.S3Compatible.Endpoint = "https://different-endpoint.example.com"
+	err = validations.ValidateNSEndpointChange(newNS, oldNS)
+	AssertError(t, err, "Endpoint change with pause annotation 'false' should be not allowed")
+
+	// S3Compatible: endpoint change should be allowed on pause annotation
+	oldNS = getDefaultS3CompatibleNsStore()
+	newNS = getDefaultS3CompatibleNsStore()
+	newNS.Annotations = map[string]string{
+		constants.PauseReconcile: "true",
+	}
+	newNS.Spec.S3Compatible.Endpoint = "https://different-endpoint.example.com"
+	err = validations.ValidateNSEndpointChange(newNS, oldNS)
+	AssertNotError(t, err, "S3Compatible endpoint change with pause annotation should be allowed")
+
 	// S3Compatible: only secret changed, endpoint same — should be allowed
 	oldNS = getDefaultS3CompatibleNsStore()
 	newNS = getDefaultS3CompatibleNsStore()
@@ -208,12 +229,19 @@ func TestValidateNSEndpointChange(t *testing.T) {
 	err = validations.ValidateNSEndpointChange(newNS, oldNS)
 	AssertNotError(t, err, "S3Compatible secret rotation with equivalent endpoints should be allowed")
 
-	// S3Compatible: nil spec on either side — should not panic and should be allowed
+	// S3Compatible: nil old spec should return error
 	oldNS = getDefaultS3CompatibleNsStore()
 	oldNS.Spec.S3Compatible = nil
 	newNS = getDefaultS3CompatibleNsStore()
 	err = validations.ValidateNSEndpointChange(newNS, oldNS)
-	AssertNotError(t, err, "nil old S3Compatible spec should not cause error or panic")
+	AssertError(t, err, "nil old S3Compatible spec should return error")
+
+	// IBMCos: nil old spec should return error
+	oldIBMNil := getDefaultIBMCosNsStore()
+	oldIBMNil.Spec.IBMCos = nil
+	newIBMNil := getDefaultIBMCosNsStore()
+	err = validations.ValidateNSEndpointChange(newIBMNil, oldIBMNil)
+	AssertError(t, err, "nil old IBMCos spec should return error")
 
 	// IBMCos: endpoint change should be denied
 	oldIBM := getDefaultIBMCosNsStore()
@@ -221,6 +249,16 @@ func TestValidateNSEndpointChange(t *testing.T) {
 	newIBM.Spec.IBMCos.Endpoint = "https://different-ibm-endpoint.example.com"
 	err = validations.ValidateNSEndpointChange(newIBM, oldIBM)
 	AssertError(t, err, "IBMCos endpoint change should be denied")
+
+	// IBMCos: endpoint change should be allowed on pause annotation
+	oldIBM = getDefaultIBMCosNsStore()
+	newIBM = getDefaultIBMCosNsStore()
+	newIBM.Annotations = map[string]string{
+		constants.PauseReconcile: "true",
+	}
+	newIBM.Spec.IBMCos.Endpoint = "https://different-ibm-endpoint.example.com"
+	err = validations.ValidateNSEndpointChange(newIBM, oldIBM)
+	AssertNotError(t, err, "IBMCos endpoint change with pause annotation should be allowed")
 
 	// IBMCos: only secret changed, endpoint same — should be allowed
 	oldIBM = getDefaultIBMCosNsStore()

--- a/pkg/validations/backingstore_validations.go
+++ b/pkg/validations/backingstore_validations.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/constants"
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -57,6 +58,50 @@ func ValidateBackingStore(bs nbv1.BackingStore) error {
 	default:
 		return util.ValidationError{
 			Msg: "Invalid Backingstore type, please provide a valid Backingstore type",
+		}
+	}
+	return nil
+}
+
+// validate changes to endpoint on backingstore
+func ValidateBSEndpointChange(bs, oldBs nbv1.BackingStore) error {
+	// skip validation if connection CLI has added the pause annotation
+	if bs.Annotations != nil && bs.Annotations[constants.PauseReconcile] == "true" {
+		return nil
+	}
+
+	switch bs.Spec.Type {
+	case nbv1.StoreTypeS3Compatible:
+		if oldBs.Spec.S3Compatible == nil {
+			return util.ValidationError{
+				Msg: "Invalid old BackingStore: S3Compatible spec is missing",
+			}
+		}
+		if bs.Spec.S3Compatible != nil {
+			equal, err := EndpointsEquivalent(bs.Spec.S3Compatible.Endpoint, oldBs.Spec.S3Compatible.Endpoint)
+			if err != nil {
+				return err
+			} else if !equal {
+				return util.ValidationError{
+					Msg: "Changing a Backingstore endpoint is supported only using the connection CLI",
+				}
+			}
+		}
+	case nbv1.StoreTypeIBMCos:
+		if oldBs.Spec.IBMCos == nil {
+			return util.ValidationError{
+				Msg: "Invalid old BackingStore: IBMCos spec is missing",
+			}
+		}
+		if bs.Spec.IBMCos != nil {
+			equal, err := EndpointsEquivalent(bs.Spec.IBMCos.Endpoint, oldBs.Spec.IBMCos.Endpoint)
+			if err != nil {
+				return err
+			} else if !equal {
+				return util.ValidationError{
+					Msg: "Changing a Backingstore endpoint is supported only using the connection CLI",
+				}
+			}
 		}
 	}
 	return nil

--- a/pkg/validations/namespacestore_validations.go
+++ b/pkg/validations/namespacestore_validations.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	"github.com/noobaa/noobaa-operator/v5/pkg/constants"
 	"github.com/noobaa/noobaa-operator/v5/pkg/nb"
 	"github.com/noobaa/noobaa-operator/v5/pkg/util"
 )
@@ -446,28 +447,43 @@ func ValidateNSArchiveSpec(nsStore nbv1.NamespaceStore) error {
 
 // ValidateNSEndpointChange validates the user is not trying to update the namespacestore endpoint
 func ValidateNSEndpointChange(ns nbv1.NamespaceStore, oldNs nbv1.NamespaceStore) error {
+	// skip validation if connection CLI has added the pause annotation
+	if ns.Annotations != nil && ns.Annotations[constants.PauseReconcile] == "true" {
+		return nil
+	}
+
 	switch ns.Spec.Type {
 	case nbv1.NSStoreTypeS3Compatible:
-		if oldNs.Spec.S3Compatible != nil && ns.Spec.S3Compatible != nil {
+		if oldNs.Spec.S3Compatible == nil {
+			return util.ValidationError{
+				Msg: "Invalid old NamespaceStore: S3Compatible spec is missing",
+			}
+		}
+		if ns.Spec.S3Compatible != nil {
 			equal, err := EndpointsEquivalent(oldNs.Spec.S3Compatible.Endpoint, ns.Spec.S3Compatible.Endpoint)
 			if err != nil {
 				return err
 			}
 			if !equal {
 				return util.ValidationError{
-					Msg: "Changing a NamespaceStore endpoint is unsupported; delete and re-create the NamespaceStore",
+					Msg: "Changing a NamespaceStore endpoint is supported only using the connection CLI",
 				}
 			}
 		}
 	case nbv1.NSStoreTypeIBMCos:
-		if oldNs.Spec.IBMCos != nil && ns.Spec.IBMCos != nil {
+		if oldNs.Spec.IBMCos == nil {
+			return util.ValidationError{
+				Msg: "Invalid old NamespaceStore: IBMCos spec is missing",
+			}
+		}
+		if ns.Spec.IBMCos != nil {
 			equal, err := EndpointsEquivalent(oldNs.Spec.IBMCos.Endpoint, ns.Spec.IBMCos.Endpoint)
 			if err != nil {
 				return err
 			}
 			if !equal {
 				return util.ValidationError{
-					Msg: "Changing a NamespaceStore endpoint is unsupported; delete and re-create the NamespaceStore",
+					Msg: "Changing a NamespaceStore endpoint is supported only using the connection CLI",
 				}
 			}
 		}


### PR DESCRIPTION
### Describe the Problem
1. Noobaa admission webhook rejects changes to endpoint for namespace stores. Now with the new connection CLI, we should allow these changes.
2. The validations are currently only for namespace stores. Same should be applicable for backing stores.


### Explain the changes
1. Add validations for endpoint change to backingstores and allow changes to endpoint on presence of noobaa `pause` annotation.
2. Allow changes to namespace store endpoint on presence of noobaa `pause` annotation (true).
3. We are returning error if the old spec is empty

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Validation**
  - Backing store endpoint changes are checked before other update validations.
  - Changes to S3-compatible and IBM COS endpoints are restricted to the connection CLI unless reconciliation is paused.
  - Equivalent endpoint formats continue to be accepted; differing endpoints are rejected.
  - Namespace store endpoint changes follow the same pause-reconciliation behavior.
  - AWS S3 endpoint changes remain permitted.
  - Invalid or incomplete endpoint update data is now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->